### PR TITLE
Fix installer: Windows unzip/npm fallback + RuVector auto-install scope bug

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -80,17 +80,22 @@ function die(msg, hint) {
 }
 
 // ── shell helpers ────────────────────────────────────────────────────────────────────────────────
+// On Windows, npm/claude/claude-flow/ruflo etc. are `.cmd` shims, not `.exe` binaries. Node's
+// spawnSync uses CreateProcess directly (no shell:true) which CANNOT launch .cmd/.bat files — it
+// fails with ENOENT even when the command works fine in any real terminal. shell:true routes the
+// call through cmd.exe, which resolves .cmd shims the same way an interactive shell would.
+const IS_WIN = process.platform === 'win32';
 function have(cmd) {
-  const probe = spawnSync(cmd, ['--version'], { stdio: 'ignore' });
-  return !probe.error;
+  const probe = spawnSync(cmd, ['--version'], { stdio: 'ignore', shell: IS_WIN });
+  return !probe.error && probe.status === 0;
 }
 function run(cmd, args, opts = {}) {
-  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  const r = spawnSync(cmd, args, { stdio: 'inherit', shell: IS_WIN, ...opts });
   if (r.error) throw r.error;
   if (r.status !== 0) throw new Error(`\`${cmd} ${args.join(' ')}\` exited with code ${r.status}`);
 }
 function tryRun(cmd, args, opts = {}) {
-  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  const r = spawnSync(cmd, args, { stdio: 'inherit', shell: IS_WIN, ...opts });
   return !r.error && r.status === 0;
 }
 
@@ -309,10 +314,12 @@ function unzipInto(zipPath, cacheDir) {
       run('unzip', ['-q', '-o', zipPath, '-d', cacheDir]);
     } else {
       // Windows: PowerShell's Expand-Archive handles .zip natively with -Force for overwrite.
+      // shell:false here (pwsh/powershell are real .exe files, not .cmd shims) — routing this
+      // through cmd.exe would re-tokenize the already-quoted -Command string and break it.
       run(psExe, [
         '-NoProfile', '-NonInteractive', '-Command',
         `Expand-Archive -LiteralPath "${zipPath}" -DestinationPath "${cacheDir}" -Force`,
-      ]);
+      ], { shell: false });
     }
   } catch (e) {
     die(`extraction failed (${e.message}).`, `The archive may be incomplete — re-run to download a fresh copy.`);

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -284,19 +284,38 @@ function unzipInto(zipPath, cacheDir) {
     'Unpacking the brain into place',
     'so the plugin finds forge-mcp-all.mjs and the vector stores right where it looks',
   );
-  if (!have('unzip')) {
+
+  const hasUnzip = have('unzip');
+  // Windows fallback: PowerShell's Expand-Archive is available on all modern Windows systems.
+  const psExe = !hasUnzip ? (['pwsh', 'powershell'].find(have) || null) : null;
+
+  if (!hasUnzip && !psExe) {
     die(
-      `the \`unzip\` command isn't available on this machine.`,
-      `Install it and re-run:\n  • macOS:  already built in (this is unusual — check your PATH)\n  • Debian/Ubuntu:  ${c.bold('sudo apt-get install -y unzip')}\n  • Fedora/RHEL:  ${c.bold('sudo dnf install -y unzip')}`,
+      `no zip extraction tool is available on this machine.`,
+      [
+        `Install one and re-run:`,
+        `  • macOS:  \`unzip\` is already built in — check your PATH`,
+        `  • Debian/Ubuntu:  ${c.bold('sudo apt-get install -y unzip')}`,
+        `  • Fedora/RHEL:  ${c.bold('sudo dnf install -y unzip')}`,
+        `  • Windows:  open a PowerShell window and re-run (Expand-Archive is built in)`,
+      ].join('\n'),
     );
   }
 
   // The zip extracts to a top-level `ruvnet-brain/` folder. Extract into the cache dir, then lift
   // its CONTENTS up one level so that cacheDir/forge-mcp-all.mjs exists (idempotent: -o overwrites).
   try {
-    run('unzip', ['-q', '-o', zipPath, '-d', cacheDir]);
+    if (hasUnzip) {
+      run('unzip', ['-q', '-o', zipPath, '-d', cacheDir]);
+    } else {
+      // Windows: PowerShell's Expand-Archive handles .zip natively with -Force for overwrite.
+      run(psExe, [
+        '-NoProfile', '-NonInteractive', '-Command',
+        `Expand-Archive -LiteralPath "${zipPath}" -DestinationPath "${cacheDir}" -Force`,
+      ]);
+    }
   } catch (e) {
-    die(`unzip failed (${e.message}).`, `The archive may be incomplete — re-run to download a fresh copy.`);
+    die(`extraction failed (${e.message}).`, `The archive may be incomplete — re-run to download a fresh copy.`);
   }
 
   const nested = path.join(cacheDir, 'ruvnet-brain');
@@ -452,7 +471,9 @@ function doctor() {
   have('node') ? ok('node present') : warn('node missing');
   have('npm') ? ok('npm present') : warn('npm missing');
   have('claude') ? ok('claude CLI present') : warn('claude CLI missing (plugin wiring needs it)');
-  have('unzip') ? ok('unzip present') : warn('unzip missing (needed for re-install)');
+  have('unzip') || have('pwsh') || have('powershell')
+    ? ok('zip extraction available (unzip or PowerShell Expand-Archive)')
+    : warn('no zip tool found — unzip or PowerShell needed for re-install');
   const env = detectEnvironment();
   env.ruflo
     ? ok('Ruflo present — orchestration / swarms / SPARC available')


### PR DESCRIPTION
## Summary
Three bugs found and fixed while testing the installer end-to-end on Windows 11 (the third affects every platform, not just Windows).

**1. `unzip` not found (Windows)**
Windows has no `unzip` on PATH by default, and `unzipInto()` only ever shelled out to it. Now falls back to `pwsh`/`powershell`'s built-in `Expand-Archive -Force` when `unzip` isn't found.

**2. `npm isn't available` even when npm is installed and working (Windows)**
On Windows, `npm`/`claude`/`claude-flow`/`ruflo` ship as `.cmd` shims, not `.exe` binaries. Node's `spawnSync` without `shell: true` calls `CreateProcess` directly, which **cannot execute `.bat`/`.cmd` files** — a documented Node/libuv limitation (nodejs/node#3675). It fails with `ENOENT` regardless of PATH or shell aliases. Fixed `have()`/`run()`/`tryRun()` to pass `shell: true` on `win32`, with the PowerShell `Expand-Archive` call from fix (1) pinned to `shell: false` explicitly since routing its already-quoted `-Command` string through `cmd.exe` would break it. Non-Windows behavior unchanged.

**3. RuVector auto-install "succeeds" but never sticks (any platform)**
- `offerStack()` ran `claude mcp add ruvector` with no `--scope`, defaulting to **local** scope — tying the server to whatever directory happened to be the cwd at install time. This contradicts the installer's own "one toolkit, every project" model (the plugin itself installs with `--scope user`). Now passes `--scope user`.
- `detectEnvironment()` checked `~/.claude/settings.json` for the string `"ruvector"`, but `claude mcp add` actually writes user-scope servers to the top-level `mcpServers` object in `~/.claude.json` (local-scope entries live under `projects[cwd].mcpServers` instead — neither is in `settings.json`). So even a correctly-scoped install was never detected on a later run. Added `hasUserScopeMcpServer()` to read the right file/field.
- `claude mcp add` exits non-zero when the server already exists, which was being treated as a hard failure even though the server is actually present. The install loop now falls back to a `verify()` check of real state before warning.

## Test plan
- [x] Windows 11 without `unzip` on PATH: `node bin/install.mjs` extracts via PowerShell instead of dying.
- [x] Windows 11: `node bin/install.mjs --doctor` reports `npm present` / `claude CLI present` green (previously false-negative).
- [x] Windows 11: full install (`node bin/install.mjs --no-verify --no-stack --no-enhance`) completes, including the `npm i` reader-install step.
- [x] Windows 11: reproduced the RuVector bug against a real `~/.claude.json` (had a stale local-scope `ruvector` entry from a prior run, invisible to detection). After the fix, `--with-stack` adds it at `--scope user`, `hasUserScopeMcpServer('ruvector')` correctly detects it, and `--doctor` / subsequent runs stop re-offering the install.
- [ ] macOS/Linux with `unzip` present: confirm shell/unzip behavior is unchanged.