### PR TITLE
Fix PowerShell detection + execution policy for sandboxed Windows 11

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -98,6 +98,14 @@ function tryRun(cmd, args, opts = {}) {
   const r = spawnSync(cmd, args, { stdio: 'inherit', shell: IS_WIN, ...opts });
   return !r.error && r.status === 0;
 }
+// have(cmd) probes with `--version`, which Windows PowerShell 5.1's powershell.exe does NOT
+// understand as a flag — it parses `--version` as a PowerShell expression (`--` looks like a unary
+// operator to it) and exits 1. Only pwsh (7+, often absent in a locked-down sandbox) supports
+// `--version`. Use `-Command exit 0` instead, which both powershell.exe and pwsh.exe understand.
+function havePowerShell(exe) {
+  const probe = spawnSync(exe, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
 
 // ── download with redirect-following + progress ──────────────────────────────────────────────────
 function download(url, dest, redirects = 0) {
@@ -292,7 +300,7 @@ function unzipInto(zipPath, cacheDir) {
 
   const hasUnzip = have('unzip');
   // Windows fallback: PowerShell's Expand-Archive is available on all modern Windows systems.
-  const psExe = !hasUnzip ? (['pwsh', 'powershell'].find(have) || null) : null;
+  const psExe = !hasUnzip ? (['pwsh', 'powershell'].find(havePowerShell) || null) : null;
 
   if (!hasUnzip && !psExe) {
     die(
@@ -316,8 +324,12 @@ function unzipInto(zipPath, cacheDir) {
       // Windows: PowerShell's Expand-Archive handles .zip natively with -Force for overwrite.
       // shell:false here (pwsh/powershell are real .exe files, not .cmd shims) — routing this
       // through cmd.exe would re-tokenize the already-quoted -Command string and break it.
+      // -ExecutionPolicy Bypass: Expand-Archive ships as a script module (.psm1); on a locked-down
+      // machine (Restricted/AllSigned policy — common in sandboxes) importing it fails with
+      // "running scripts is disabled on this system" even though the exe itself runs fine. Bypass
+      // only affects this one child process, not any persistent machine setting.
       run(psExe, [
-        '-NoProfile', '-NonInteractive', '-Command',
+        '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command',
         `Expand-Archive -LiteralPath "${zipPath}" -DestinationPath "${cacheDir}" -Force`,
       ], { shell: false });
     }
@@ -478,7 +490,7 @@ function doctor() {
   have('node') ? ok('node present') : warn('node missing');
   have('npm') ? ok('npm present') : warn('npm missing');
   have('claude') ? ok('claude CLI present') : warn('claude CLI missing (plugin wiring needs it)');
-  have('unzip') || have('pwsh') || have('powershell')
+  have('unzip') || havePowerShell('pwsh') || havePowerShell('powershell')
     ? ok('zip extraction available (unzip or PowerShell Expand-Archive)')
     : warn('no zip tool found — unzip or PowerShell needed for re-install');
   const env = detectEnvironment();


### PR DESCRIPTION
## Summary
Reported: on a sandbox with only Windows PowerShell 5.1 (no pwsh 7 installed), the installer still reported "unzip not available" even after #1 added the `Expand-Archive` fallback.

**Root cause:** `have(cmd)` probes with `<cmd> --version`. Windows PowerShell 5.1's `powershell.exe` does not understand `--version` as a flag — it parses `--version` as a PowerShell expression (`--` reads as a unary operator) and exits 1. Only `pwsh` (7+, frequently absent in a locked-down sandbox) actually supports `--version`. So `have('powershell')` always returned `false` on a 5.1-only machine, `psExe` stayed `null`, and the installer died claiming no zip tool existed at all — even though `powershell.exe` was right there and perfectly capable of running `Expand-Archive`.

**Fix:** added `havePowerShell(exe)`, which probes with `-NoProfile -NonInteractive -Command "exit 0"` instead — understood identically by both `powershell.exe` and `pwsh.exe`. Used in `unzipInto()` and the `--doctor` check.

**Bonus fix found while verifying:** while testing the *actual* `Expand-Archive` call (not just detection), also hit a second, related sandbox failure mode: `"running scripts is disabled on this system"`. `Expand-Archive` ships as a script module (`.psm1`), so a `Restricted`/`AllSigned` execution policy (common in locked-down/sandboxed environments) blocks importing it even once the exe is found and detected correctly. Added `-ExecutionPolicy Bypass` to that one child-process invocation — this only affects the single spawned process, it does not touch any persistent machine policy.

## Test plan
- [x] Confirmed the exact failure: `powershell --version` exits 1 with a PowerShell parser error on this machine's Windows PowerShell 5.1, while `pwsh --version` (7.6.3) exits 0 and prints the version.
- [x] Confirmed `havePowerShell('powershell')` correctly returns `true` where the old `have('powershell')` returned `false`, and still correctly returns `false` for a nonexistent command.
- [x] Confirmed `Expand-Archive` fails with "running scripts is disabled on this system" without `-ExecutionPolicy Bypass` on this machine (PSModulePath picks up a script-module copy blocked by policy), and succeeds with it.
- [x] Ran a full `--force` reinstall through the real `unzipInto()` code path end-to-end — extraction succeeds.
- [x] `--doctor` reports zip extraction available using the corrected detection.