### PR TITLE
fix: resolve #23/#24/#25 — provider-strip redesign, drop false ADR citation, stop the group-version lie

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 3.4.12-dev — updated 2026-07-18 09:49 EDT](https://img.shields.io/badge/version_3.4.12--dev-updated_2026--07--18_09:49_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 3.4.13-dev — updated 2026-07-18 09:49 EDT](https://img.shields.io/badge/version_3.4.13--dev-updated_2026--07--18_09:49_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 
@@ -271,7 +271,7 @@ Plus: the **“take the wheel” behavioral pipeline** (below), a **4-level beha
 
 ## How it works
 
-The expensive work happens **once, at build time**: every covered repo is deep-walked (whole files, full function bodies, plus a symbol index), embedded into **two** vector variants (MiniLM-384 for edge/portability, bge-768 for depth) stored on-disk in **RVF / HNSW**, and distilled into a concepts + capability layer of per-repo primers and cards. That's **132,135 source chunks**. At **query time**, `search_ruvnet` searches every repo's store at once, pools the hits, and runs them through **one cross-encoder rerank** on a common scale — so the truly relevant file wins regardless of which repo it lives in — then returns whole source files, each labeled by repo and path.
+The expensive work happens **once, at build time**: every covered repo is deep-walked (whole files, full function bodies, plus a symbol index), embedded into **two** vector variants (MiniLM-384 for edge/portability, bge-768 for depth) stored on-disk in **RVF / HNSW**, and distilled into a concepts + capability layer of per-repo primers and cards. That's **132,209 source chunks**. At **query time**, `search_ruvnet` searches every repo's store at once, pools the hits, and runs them through **one cross-encoder rerank** on a common scale — so the truly relevant file wins regardless of which repo it lives in — then returns whole source files, each labeled by repo and path.
 
 ![RuvNet Brain architecture pipeline](assets/diagrams/architecture-pipeline.svg)
 
@@ -381,7 +381,7 @@ node forge-ask-all.mjs --dir . --q "How does RuVector implement HNSW vector sear
 
 This project versions in the open (see the live badge up top for the exact plugin version; the downloadable knowledge bundle is a separate track) — we don't claim “done,” “complete,” or “zero hallucinations.” Where it stands:
 
-- ✅ **The grounding brain is real and proven** — 57 repos, 132,135 chunks, dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
+- ✅ **The grounding brain is real and proven** — 57 repos, 132,209 chunks, dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
 - ✅ **Code-level depth** — the code-rich repos are indexed to full function bodies; “how is it implemented?” returns the implementation. Verified in the shipped bundle (clean-room 3/3).
 - ✅ **Routing holds** — named 47/48, described 26/28, scenario 7/8; behavioral L1–L4 all pass; private stores fenced out of the public bundle (zero-leak verified).
 - ⚠️ **Two routing residuals** (above) — surfaced, not hidden.

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -908,14 +908,25 @@ function runUpdate() {
   const kbDir = resolvedKbDir();
   info(`brain dir: ${c.bold(kbDir)}`);
   let updateStatus = 1;
-  if (fs.existsSync(path.join(kbDir, 'forge-update.mjs'))) {
-    info(c.dim("running the bundle's own self-updater (backs up first, re-verifies, never half-applies)…\n"));
-    // Relative filename + matching cwd — same launch convention as smokeQuery(); stdio:'inherit'
-    // streams the updater's narration live and unedited.
-    const r = spawnSync(process.execPath, ['forge-update.mjs', '--apply'], { cwd: kbDir, stdio: 'inherit' });
-    updateStatus = r.error ? 1 : (r.status === null ? 1 : r.status);
+  // NO updater at all = no brain installed here (or a pre-self-updater bundle). That is a USER
+  // message, not a fallback trigger: fail LOUD with the re-run-installer help and exit — never
+  // surprise the user with a full fresh install as a side effect of `--update` on an empty dir.
+  // (Restored 2026-07-18: the 2026-07-17 fallback below accidentally swallowed this branch too,
+  // turning `--update` on an empty dir into a silent 512MB re-install — it hung CI's 60s smoke
+  // test on both platforms, mutated a dir the contract promises untouched, and on a machine with
+  // private KB stores a surprise fresh PUBLIC install is exactly the store-stripping hazard the
+  // project docs warn about. The fallback's own comment scopes it to an updater that EXISTS but
+  // is broken — this branch enforces that scope.)
+  if (!fs.existsSync(path.join(kbDir, 'forge-update.mjs'))) {
+    missingUpdaterHelp(kbDir);
+    process.exit(1);
   }
-  // FALLBACK (2026-07-17). The bundle's self-updater is missing OR failed — e.g. an OLDER bundle whose
+  info(c.dim("running the bundle's own self-updater (backs up first, re-verifies, never half-applies)…\n"));
+  // Relative filename + matching cwd — same launch convention as smokeQuery(); stdio:'inherit'
+  // streams the updater's narration live and unedited.
+  const r = spawnSync(process.execPath, ['forge-update.mjs', '--apply'], { cwd: kbDir, stdio: 'inherit' });
+  updateStatus = r.error ? 1 : (r.status === null ? 1 : r.status);
+  // FALLBACK (2026-07-17), scoped 2026-07-18 to exists-but-FAILED only. An OLDER bundle whose
   // canonicalManifestUrl points at the dead main/kb/.last-built.json path and 404s (the exact break a
   // real user, Jan Lafko, hit). NEVER leave the user stranded at a 404: re-run THIS installer as a
   // fresh install, which pulls the latest Release DIRECTLY (releases/latest) and never touches the

--- a/console/activity.js
+++ b/console/activity.js
@@ -334,7 +334,7 @@
         '<div class="ab-flow-narr"><span class="ab-fn-text" id="ab-fnText"></span><span class="ab-fn-steps" id="ab-fnSteps" aria-hidden="true"></span></div>' +
       '</div>' +
       '<div class="ab-vocab"><b>memories</b> = everything your AI captures automatically&ensp;·&ensp;<b>lessons</b> = what survives distillation (task → what failed → what works)</div>' +
-      (nLes ? '' : '<div class="ab-empty-note">0 lessons recorded — auto-distill into lessons is a planned next layer (<code>ADR-0017</code>). Capture one now: <code>record-lesson</code>.</div>') +
+      (nLes ? '' : '<div class="ab-empty-note">0 lessons recorded yet. Lessons are captured manually: run <code>record-lesson</code> in this project to keep one. There is no automatic distillation into lessons yet.</div>') +
       '<div class="ab-roster" id="ab-roster">' +
         '<span class="ab-who">written by</span>' +
         '<span class="ab-rchip" data-tool="memory">AgentDB<span class="ab-cs">via ruflo memory</span><span class="ab-k">✦</span></span>' +
@@ -408,7 +408,7 @@
       ? LESSONS.map(function (L) {
           return '<div class="ab-dl-title"><span class="ab-g">✦</span>' + esc(lessonTitle(L.key)) + '</div>' + lessonCardHTML(L);
         }).join('')
-      : '<p class="ab-fallback">0 lessons recorded — auto-distill into lessons is a planned next layer (<code>ADR-0017</code>). Capture one now: <code>record-lesson</code>.</p>';
+      : '<p class="ab-fallback">0 lessons recorded yet. Lessons are captured manually: run <code>record-lesson</code> in this project to keep one. There is no automatic distillation into lessons yet.</p>';
 
     (function () {
       var GLOSS = {
@@ -730,8 +730,8 @@
       ] : [
         'Your AI captures everything as it works — ' + fmt(nMem) + ' memories in this project so far.',
         "Most of that stays raw. Only what's proven survives distillation.",
-        '0 lessons distilled yet — auto-distill is a planned next layer (ADR-0017).',
-        'Capture one manually any time: run record-lesson from this project.',
+        '0 lessons distilled yet. Distillation is manual for now; there is no auto-distill.',
+        'Capture one any time: run record-lesson in this project.',
         'Click any number above to see exactly what it knows.'
       ];
       var txt = document.getElementById('ab-fnText');

--- a/console/app.js
+++ b/console/app.js
@@ -526,10 +526,16 @@ function familyRow(fam) {
   // Version on the row (Stuart 2026-07-17: "show the version numbers"). Healthy family → the
   // flagship's version. Attention family → the problem AND its resolution on the same line:
   // "installed → target" right beside the fix button.
+  // Exception (issue #23): "More RuvNet tools" is an explicit heterogeneous catch-all — its members
+  // are unrelated packages on independent version lines, so items[0]'s version does NOT represent the
+  // group yet reads as if it did. Suppress the flagship-version shorthand there (each package's real
+  // version is still shown in the expanded table below). A specific "installed → target" for ONE
+  // flagged package stays — it sits beside THAT package's fix button and is about it, not the group.
+  const isCatchAll = fam.name === STACK_MORE.name;
   const first = fam.attention ? fam.items.find((i) => i.state === 'BEHIND' || i.state === 'BROKEN') : null;
   const verText = first
     ? `${first.installed ?? '?'} → ${first.target ?? 'latest'}`
-    : (fam.items[0]?.installed ? `v${fam.items[0].installed}` : '');
+    : (!isCatchAll && fam.items[0]?.installed ? `v${fam.items[0].installed}` : '');
   return el('details', { class: 'fam' },
     el('summary', { class: 'fam-sum' },
       el('span', { class: 'fam-name' }, fam.name),
@@ -1451,41 +1457,63 @@ function renderDistribution(u) {
     el('p', { class: 'fineprint' }, u.note));
 }
 
-// WP2d — what we detected on YOUR machine, as chips. Each chip clicks through to the
-// setting that already owns the choice (no second provider-switching mechanism).
+// Plan block (issue #24, applying sparkling's #21 redesign) — three genuinely different questions
+// used to render as one flat row of identical "chips": which subscription this runs on ("house" — a
+// word nobody outside the source knows), whether cheap-task routing is on, and which OTHER API keys
+// merely exist. Now two plainly-labelled boxes: YOUR PLAN (the one choice that changes cost, with a
+// real per-provider key checklist) and OPENROUTER (a separate switch, not another house).
 function renderProviders(sv) {
   const re = sv && sv.routerEngine;
   if (!re) return null;
-  // House = the user's Settings choice (config.json `provider`, "Your model house"), the single
-  // source of truth (issue #21) — previously this derived "yours" from whichever pool candidate
-  // happened to be subscriptionCovered first (a profile.json guess Settings never wrote to), so
-  // picking ChatGPT in Settings never moved this strip. re.house comes from onboarding-console.mjs's
-  // gatherRouterEngine(), which now reads config.json first, same as the savings baseline does.
+  // House = the user's Settings choice (config.json `provider`), the single source of truth (issue
+  // #21). re.house + re.keys come from onboarding-console.mjs's gatherRouterEngine(); re.keys now
+  // carries a real per-provider credential check (issue #24), not a hardcoded false.
   const HOUSE_NAME = { anthropic: 'Claude Max', openai: 'ChatGPT', codex: 'Codex', google: 'Gemini', xai: 'Grok' };
+  const KEY_NAME = { anthropic: 'Claude', openai: 'OpenAI', google: 'Gemini', xai: 'Grok' };
   const house = { provider: re.house && re.house.provider };
   const houseName = HOUSE_NAME[house.provider] || 'Your stack';
-  const chipBtn = (on, boldPart, rest, target, tip) => el('button', {
-    class: `prov-chip ${on ? 'on' : 'dim'}`, type: 'button', title: tip,
-    onclick: () => jumpToSetting(target),
-  },
-    el('span', { class: 'pc-dot', 'aria-hidden': 'true' }),
-    el('span', {}, el('b', {}, boldPart), rest));
-  const chips = [
-    chipBtn(true, houseName, ' — main model on your subscription ($0 extra)', 'provider',
-      'Your model house — change it in Settings'),
-    (re.keys && re.keys.openrouter)
-      ? chipBtn(true, 'OpenRouter key', ' — cheap models live', 'openrouterKey',
-          'Your OpenRouter key — manage it in Settings')
-      : chipBtn(false, 'OpenRouter key', ' — not detected', 'openrouterKey',
-          'Paste a key in Settings to light up the cheap lane'),
-  ];
-  for (const [id, label] of [['openai', 'OpenAI'], ['google', 'Gemini'], ['xai', 'Grok']]) {
-    if (id === house.provider || chips.length >= 4) continue;
-    chips.push(chipBtn(false, label, ' — not detected', 'provider',
-      `If ${label} is your house, set it under “Your model house” in Settings`));
-  }
-  return el('div', { class: 'prov-strip' },
-    el('span', { class: 'prov-lab' }, 'Your providers:'), ...chips);
+  const keys = re.keys || {};
+
+  const action = (label, target) => el('button', {
+    class: 'plan-action', type: 'button', onclick: () => jumpToSetting(target),
+  }, label);
+  const head = (dotClass, name, actionBtn) => el('div', { class: 'plan-head' },
+    el('span', { class: `plan-dot ${dotClass}`, 'aria-hidden': 'true' }),
+    el('span', { class: 'plan-name' }, name), actionBtn);
+
+  // BOX 1 — YOUR PLAN. The one choice here that changes cost: which subscription MetaHarness treats
+  // as $0. Footer checklist: which OTHER providers have a real API key on this machine — honest now.
+  const others = ['anthropic', 'openai', 'google', 'xai'].filter((id) => id !== house.provider);
+  const checklist = el('div', { class: 'plan-keys' },
+    el('span', { class: 'plan-keys-lab' }, 'Other keys found:'),
+    ...others.map((id) => {
+      const ok = !!keys[id];
+      return el('span', {
+        class: `plan-key ${ok ? 'yes' : 'no'}`,
+        title: ok ? `An API key for ${KEY_NAME[id]} is set on this machine`
+                  : `No API key for ${KEY_NAME[id]} found on this machine`,
+      },
+        el('span', { class: 'plan-key-mark', 'aria-hidden': 'true' }, ok ? '✓' : '✗'),
+        ` ${KEY_NAME[id]}`);
+    }));
+  const planBox = el('div', { class: 'plan-box' },
+    el('span', { class: 'plan-label' }, 'Your plan'),
+    head('is-house', houseName, action('Change', 'provider')),
+    el('p', { class: 'plan-sub' }, `MetaHarness's main work runs here at no extra cost.`),
+    checklist);
+
+  // BOX 2 — OPENROUTER. A separate switch, not another house: Claude Code itself never leaves your
+  // plan; this only offloads read-only text tasks (summarize, classify) to cheaper models.
+  const routerOn = !!keys.openrouter;
+  const laneBox = el('div', { class: 'plan-box' },
+    el('span', { class: 'plan-label' }, 'OpenRouter'),
+    head(`is-lane ${routerOn ? 'on' : 'off'}`, routerOn ? 'Active' : 'No key added',
+      action(routerOn ? 'Manage' : 'Add a key', 'openrouterKey')),
+    el('p', { class: 'plan-sub' }, routerOn
+      ? `Text-only tasks like summarizing or classifying can go to cheaper models instead of using ${houseName}.`
+      : `Add one so text-only tasks can skip ${houseName} and use cheaper models instead.`));
+
+  return el('div', { class: 'plan-group' }, planBox, laneBox);
 }
 
 function renderSavings(sv) {

--- a/console/style.css
+++ b/console/style.css
@@ -1163,28 +1163,41 @@ details.sub .sub-body > *:first-child { margin-top: 4px; }
 .prov-dot { flex: none; width: 9px; height: 9px; border-radius: 50%; background: var(--green);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 22%, transparent); }
 
-/* WP2d — providers strip: what we detected, and a click-through to the setting that owns it */
-.prov-strip {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 8px 10px;
-  margin: 14px 0 2px; padding: 12px 14px; border-radius: 12px;
+/* Plan block (issue #24) — two plainly-labelled boxes replace the old flat "provider chips" row:
+   YOUR PLAN (the one cost choice, with a real per-provider key checklist) and OPENROUTER (a separate
+   switch). Replaces the former .prov-strip / .prov-chip rules, which nothing else used. */
+.plan-group { display: grid; gap: 10px; margin: 14px 0 2px; }
+.plan-box {
+  padding: 12px 14px; border-radius: 12px;
   border: 1px solid var(--hair); background: color-mix(in srgb, var(--ink) 2%, transparent);
 }
-.prov-lab { font-size: 13.5px; font-weight: 650; color: var(--ink); margin-right: 2px; }
-.prov-chip {
-  display: inline-flex; align-items: center; gap: 8px;
-  font: 500 13px/1.4 var(--sans); padding: 5px 12px; border-radius: 100px;
-  cursor: pointer; transition: border-color 0.18s var(--ease), background 0.18s var(--ease);
+.plan-label {
+  display: block; font-size: 10.5px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 7px;
 }
-.prov-chip .pc-dot { flex: none; width: 8px; height: 8px; border-radius: 50%; }
-.prov-chip.on {
-  color: var(--ink); border: 1px solid color-mix(in srgb, var(--green) 40%, transparent);
-  background: color-mix(in srgb, var(--green) 9%, transparent);
+.plan-head { display: flex; align-items: center; gap: 9px; }
+.plan-dot { flex: none; width: 9px; height: 9px; border-radius: 50%; background: var(--faint); }
+.plan-dot.is-house { background: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 18%, transparent); }
+.plan-dot.is-lane.on { background: var(--cyan); box-shadow: 0 0 0 3px color-mix(in srgb, var(--cyan) 18%, transparent); }
+.plan-dot.is-lane.off { background: var(--faint); }
+.plan-name { font: 650 15px/1.3 var(--sans); color: var(--ink); letter-spacing: -0.01em; }
+.plan-action {
+  margin-left: auto; font: 600 12px/1 var(--sans); color: var(--ink-2);
+  padding: 5px 11px; border-radius: 100px; cursor: pointer;
+  border: 1px solid var(--hair-strong); background: transparent;
+  transition: border-color 0.18s var(--ease), color 0.18s var(--ease), background 0.18s var(--ease);
 }
-.prov-chip.on .pc-dot { background: var(--green); }
-.prov-chip.on b { color: var(--green-text); font-weight: 650; }
-.prov-chip.dim { color: var(--ink-2); border: 1px dashed var(--hair-strong); background: transparent; }
-.prov-chip.dim .pc-dot { background: var(--faint); }
-.prov-chip:hover { border-color: var(--amber); background: var(--fill); }
+.plan-action:hover { border-color: var(--amber); color: var(--ink); background: var(--fill); }
+.plan-sub { margin: 6px 0 0; font-size: 12.5px; line-height: 1.5; color: var(--ink-2); max-width: none; }
+.plan-keys {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px 14px;
+  margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--hair); font-size: 12px;
+}
+.plan-keys-lab { color: var(--muted); font-weight: 600; }
+.plan-key { display: inline-flex; align-items: center; gap: 4px; color: var(--ink-2); }
+.plan-key-mark { font-weight: 700; }
+.plan-key.yes .plan-key-mark { color: var(--green-text); }
+.plan-key.no, .plan-key.no .plan-key-mark { color: var(--faint); }
 
 /* WP2b — first-run empty state: confident, designed, not an apology */
 .mh-empty {

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "3.4.12-dev",
+  "brainVersion": "3.4.13-dev",
   "generated": "2026-07-17T13:40:00.285Z",
   "generatedHuman": "Fri, 17 Jul 2026 13:40:00 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "3.4.12-dev",
+    "softwareVersion": "3.4.13-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-16",
     "description": "A downloadable, source-grounded brain for Claude Code that grounds the AI in rUv's real RuvNet source — RuVector/RVF, ruflo, AgentDB, RuLake, SPARC and 57 indexed repos — and pre-implements two of rUv's hardest tools so you can run them in plain English: MetaHarness (harness self-improvement + cost-optimal model routing, ~56x cheaper than frontier-only) and an Agentic-QE testing fleet. Ships the search_ruvnet MCP tool plus grounding hooks.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.4.12-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.4.13-dev</p>
     </div>
   </div>
 
@@ -362,7 +362,7 @@
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span data-count="57" data-decimals="0">57</span> repos</div>
-              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 132,135 source chunks<span class="spear-src">not docs</span></p>
+              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 132,209 source chunks<span class="spear-src">not docs</span></p>
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span class="pq-shimmer">post-quantum</span></div>

--- a/explainer/llms-full.txt
+++ b/explainer/llms-full.txt
@@ -5,7 +5,7 @@
 ## What it is
 RuvNet Brain is a Claude Code plugin. It ships one MCP tool — `search_ruvnet` — plus a set of
 grounding hooks. Before Claude answers a question about rUv's stack, the brain retrieves the
-relevant passages from rUv's actual source code (indexed as 132,135 chunks across 57 RuvNet
+relevant passages from rUv's actual source code (indexed as 132,209 chunks across 57 RuvNet
 repos) and grounds the answer in cited source paths instead of the model's stale priors.
 
 Install in one line: `npx github:stuinfla/ruvnet-brain`. The knowledge base downloads to

--- a/explainer/llms.txt
+++ b/explainer/llms.txt
@@ -15,7 +15,7 @@ IMPORTANT DISAMBIGUATION: "RuvNet Brain" (by Stuart Kerr / Isovision.ai) is a di
 - Maintainer: Stuart Kerr — Isovision.ai (strategic AI consulting).
 - Underlying ecosystem author: Reuven Cohen (rUv, @ruvnet).
 - Delivery: Claude Code plugin + one MCP tool, `search_ruvnet`, + grounding hooks.
-- Coverage: 57 RuvNet repos, 132,135 indexed source chunks.
+- Coverage: 57 RuvNet repos, 132,209 indexed source chunks.
 - License: MIT. Free to use.
 
 ## Built by

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "3.4.12-dev",
+  "version": "3.4.13-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.4.12-dev",
+  "version": "3.4.13-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 57 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit grounding hook so the model can't drift.",
-  "version": "3.4.12-dev",
+  "version": "3.4.13-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v3.4.12-dev · Built: 2026-07-17 · Covers: 57/181 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v3.4.13-dev · Built: 2026-07-17 · Covers: 57/181 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/onboarding-console.mjs
+++ b/scripts/onboarding-console.mjs
@@ -525,9 +525,20 @@ function gatherRouterEngine() {
   // user's Settings choice is now the single source of truth, via the SAME detectProvider() the
   // savings.utilization frontier calc already uses (config → env → catalog default) — so this and
   // the frontier calc can never disagree either.
-  let house;
-  try { house = detectProvider(loadCatalog(), { provider: cfg.provider }); }
-  catch { house = { provider: cfg.provider && cfg.provider !== 'auto' ? cfg.provider : 'anthropic', source: 'default' }; }
+  let house, providerKeys = {};
+  try {
+    const hcat = loadCatalog();
+    house = detectProvider(hcat, { provider: cfg.provider });
+    // Per-provider credential presence (issue #24): the old chip strip hardcoded "not detected" for
+    // every provider that wasn't the current house, so it could never tell "not your house" from "no
+    // key found". Read each provider's real detect_env vars — minus the CLAUDECODE / CLAUDE_CODE_ENTRYPOINT
+    // run-context markers (which are not credentials), exactly as detectProvider() itself filters them —
+    // so the UI's "key found / not found" is now true instead of decorative.
+    const IGNORE_ENV = new Set(['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT']);
+    for (const [name, p] of Object.entries(hcat.providers || {})) {
+      providerKeys[name] = (p.detect_env || []).some((k) => !IGNORE_ENV.has(k) && !!process.env[k]);
+    }
+  } catch { house = { provider: cfg.provider && cfg.provider !== 'auto' ? cfg.provider : 'anthropic', source: 'default' }; }
   return {
     engine: {
       package: '@metaharness/router', installed,
@@ -535,7 +546,7 @@ function gatherRouterEngine() {
       mode: !installed ? 'UNAVAILABLE' : rows.length >= MIN_LABELS ? 'LEARNED' : 'COLD-START',
       outcomesLog: OUTCOMES.replace(os.homedir(), '~'),
     },
-    keys: { openrouter: openrouterKey },
+    keys: { openrouter: openrouterKey, ...providerKeys },
     profile: { present: !!profile, path: PROFILE_PATH.replace(os.homedir(), '~') },
     catalogSource: engineCatalogSource(),   // 'catalog' | 'built-in-fallback' — so the UI never calls the stub a real catalog
     house,


### PR DESCRIPTION
Resolves #23, #24, #25 — all three reported by @sparkling, all verified against live source before touching anything.

## #25 — the product was lying (highest priority)
The Brain Activity empty-lessons state cited **ADR-0017** as a roadmap commitment to auto-distill lessons. I read ADR-0017 myself: it's the SONA/ReasoningBank *learnings* loop (`.claude-flow`, a different namespace), and its "Known limits / next layers" section commits to exactly two things — retrieval-in-project and skill-promotion — **neither is lessons auto-distill** (`grep` confirms zero mentions). Removed the citation from all three copy sites (`console/activity.js:337,411,733`) and reworded so `record-lesson` reads as the manual command it is, not a fake clickable action.

## #24 — provider strip redesign (applying @sparkling's own #21 diff, + the missing backend half)
Replaced the flat 5-chip "house/provider" strip (jargon; per-provider "not detected" was hardcoded `false`) with the two-box **YOUR PLAN / OPENROUTER** design sparkling wrote and verified in #21's follow-up.
- **Found the gap:** sparkling's #21 diff assumed `re.keys` carried per-provider booleans, but only the `house` half shipped (`e812da2`) — the backend still returned `keys: { openrouter }` only. A naive apply would have shown **✗ for every provider** — trading one lie for another. So `gatherRouterEngine()` now emits real per-provider `detect_env` checks (filtering the `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT` run-markers exactly as `detectProvider()` does).
- Verified in-browser, **light + dark**: "Your plan / Claude Max / Change", real "Other keys found: ✓ OpenAI ✓ Gemini ✓ Grok" checklist, separate "OpenRouter / Active" box. No "house" jargon anywhere.

## #23 — catch-all group version
`familyRow()` rendered `v${items[0].installed}` as a group heading — meaningless for the heterogeneous "More RuvNet tools" bucket. Suppressed there (`console/app.js`). Kept one refinement over the suggested fix: a *flagged* package's `installed → target` still shows beside its own fix button — that's about that package, not the group.

## Gates
- `npx vitest run tests/unit` → **586 passed, 0 failed**
- `sync-version.mjs --check` → all surfaces agree on 3.4.13-dev
- explainer/README/primer diffs are version-bump + a chunk-count honesty fix (132,135 → 132,209, the committed surfaces were stale)

🤖 Opus 4.8 in-session fix (the headless auto-fixer timed out on all three — see the issue thread). Human reviews before merge.