### PR TITLE
feat: the Stable Spine — restart-free updates for every piece (ADR-023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 3.4.16-dev — updated 2026-07-18 11:07 EDT](https://img.shields.io/badge/version_3.4.16--dev-updated_2026--07--18_11:07_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 3.4.17-dev — updated 2026-07-18 11:07 EDT](https://img.shields.io/badge/version_3.4.17--dev-updated_2026--07--18_11:07_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "3.4.16-dev",
+  "brainVersion": "3.4.17-dev",
   "generated": "2026-07-17T13:40:00.285Z",
   "generatedHuman": "Fri, 17 Jul 2026 13:40:00 GMT",
   "coverage": {

--- a/docs/INTELLIGENT-UPDATING.md
+++ b/docs/INTELLIGENT-UPDATING.md
@@ -107,11 +107,15 @@ preserving JSON-RPC id continuity is a protocol minefield, not a 15-line patch. 
 - `plugin/mcp/server.mjs` becomes a **real, minimal MCP stdio server** (frozen shell): it owns the
   protocol — `initialize`, `tools/list`, `tools/call` — and declares `search_ruvnet` itself, with a
   **fixed tool schema**. The client connection is never proxied, never replayed, never dropped.
-- On each `tools/call`, it reads `active.json` (cheap), and `await import(codeRoot/…/query-engine
-  ?gen=N)` — the implementation for the **current generation**. Module-scope warm state (loaded
-  models, open indexes) is keyed by generation: reload cost is paid once per update, not per call.
-  The server takes a **lease** on the generation it's serving so GC can't pull it out from under an
-  in-flight call.
+- Delegation, **as built** (the brain has no importable query library — it ships a stdio server,
+  so a dynamic-import design would have meant forking it): the stable server supervises a **warm
+  child worker** (the KB's own `forge-mcp-all.mjs`, unchanged) over a **private handshake** — the
+  parent sends its OWN `initialize` with parent-allocated ids and forwards `tools/call` with id
+  remapping in both directions. The client's handshake is never replayed to anyone. On a generation
+  change (`active.json`) or a KB-track code change (the worker file's mtime), the child is
+  respawned **between requests only** (pending-count drain gate); warm model state costs one reload
+  per update, not per call. The server takes a **lease** on the generation it's serving so GC can't
+  pull it out from under an in-flight call.
 - A call already in flight completes on its generation; the next call gets the new one. No swap
   logic, no id remapping, no child supervision — the entire class of findings 7–9 evaporates.
 - If a new generation's import or first query fails → serve the previous generation, write a loud

--- a/docs/adr/0023-intelligent-updating-stable-spine.md
+++ b/docs/adr/0023-intelligent-updating-stable-spine.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-023
 title: Intelligent Updating — the Stable Spine (auto-update every piece; restart only for declarations)
-status: Proposed
+status: Accepted
 date: 2026-07-18
 authors: [Stuart Kerr, Claude Code]
 tags: [updating, self-update, plugin, hot-reload, rollback, mcp, hooks]
@@ -11,7 +11,7 @@ relates: [ADR-020, ADR-021, ADR-022]
 
 # ADR-0023 — Intelligent Updating: the Stable Spine
 
-**Status**: Proposed (design under adversarial two-model review; flips on the implementing change-set)
+**Status**: Accepted (implemented in the feat/stable-spine change-set: hook-shim.mjs + dispatch-table hooks.json, stable MCP server with warm supervised worker, update-apply.mjs engine with lock/txn/gates/GC/rollback/dev-mode, session-start seed + honest shellChanged nag, release.mjs A2 classifier — 17 engine/shim tests green)
 
 **Design provenance**: mirrors the house self-update pattern in cognitum-v0-appliance's ADR-248
 (manifest → verify → atomic swap → health-gate → retained-prev rollback). A GPT-5.6 adversarial

--- a/docs/reviews/0023-gpt56-redteam.md
+++ b/docs/reviews/0023-gpt56-redteam.md
@@ -1,0 +1,403 @@
+# ADR-0023 Red-Team Review — GPT-5.6
+
+Reviewer stance: adversarial architecture review of `docs/adr/0023-intelligent-updating-stable-spine.md` against the actual code in `plugin/hooks/hooks.json`, `plugin/mcp/server.mjs`, `plugin/scripts/session-start.sh`, `bin/install.mjs`, `scripts/release.mjs`, and the effective bundled updater `kb/forge-update.mjs` because `scripts/forge-update.mjs` is absent.
+
+One thing I agree with: splitting boot-frozen declarations from invoked behavior is the right direction. Everything below is about the places where this ADR either does not implement that split, implements it unsafely, or chooses a more complex mechanism than needed.
+
+1. **BLOCKER — The ADR is marked Accepted, but the described spine is not implemented.**
+
+   `plugin/hooks/hooks.json` still invokes `${CLAUDE_PLUGIN_ROOT}/scripts/*.sh` and `${CLAUDE_PLUGIN_ROOT}/scripts/learn-flush.mjs` directly (`hooks.json:11`, `:21`, `:33`, `:45`, `:55`, `:65`, `:75`, `:87`, `:99`). `plugin/mcp/server.mjs` is still a one-shot `spawn('node', [MCP], { stdio: 'inherit' })` launcher (`server.mjs:41`). `scripts/update-apply.mjs` does not exist. `scripts/forge-update.mjs` does not exist. `scripts/release.mjs` has no gate for hook shim presence, reload-stamp behavior, `requiresRestart`, or spine integrity. As written, the ADR is not an accepted design record for shipped behavior; it is a future implementation sketch with production claims.
+
+   Superior alternative: downgrade the ADR status to Proposed until the shell shims, update engine, proxy semantics, release gates, and failure tests are present. Add release gates that fail if hooks still reference `${CLAUDE_PLUGIN_ROOT}/scripts/` directly or if `scripts/update-apply.mjs` is missing.
+
+2. **BLOCKER — The migration needs one final restart, and the ADR hides that bootstrap cost.**
+
+   The only way existing installed versions can start using a hook shim is for Claude Code to load a new `hooks.json`. Today it has frozen direct commands. A background marketplace update in `session-start.sh:233-236` can stage a new plugin, but this running process will still use the old hook declarations until restart. The ADR says the every-session restart nag is deleted, but the first delivery of the stable spine necessarily requires a one-time restart.
+
+   Superior alternative: define an explicit two-phase migration: release N installs the boot shim and honestly asks for one restart; release N+1 and later can hot-swap body code. The release manifest should carry `migrationRequiresRestart: true` for the first spine release even if later body-only releases do not.
+
+3. **BLOCKER — The code/body split is internally inconsistent: executable MCP code still lives in the KB data directory.**
+
+   ADR-0023 says `versions/` holds code and `kb/` holds data. Actual behavior runs executable code from `~/.cache/ruvnet-brain/kb/forge-mcp-all.mjs` (`server.mjs:19-21`), ships tool code into the bundle (`build-bundle.mjs:204`), and the effective updater overwrites the KB directory including `.mjs` files (`kb/forge-update.mjs:196`). This is exactly the executable-data coupling the ADR claims to remove.
+
+   Superior alternative: move all runtime code into `versions/<codeVersion>/plugin/...` or `versions/<digest>/runtime/...`; keep `kb/` to `.rvf`, passages, metadata, and model/data files only. The stable MCP server should load a fixed tool schema and delegate to code under the active code root while passing `KB_DIR` as data.
+
+4. **BLOCKER — Current install and update paths mutate the live KB in place and are crash-corruptible.**
+
+   `bin/install.mjs` extracts directly into `cacheDir` (`install.mjs:382`), then removes live paths before renaming extracted entries into place (`install.mjs:405-406`). A crash, `unzip` failure after partial writes, power loss, or concurrent reader during this window can leave a missing or mixed-version KB. `kb/forge-update.mjs` backs up the live dir (`forge-update.mjs:195`) and then `copyTree(extractDir, KB_DIR)` overwrites files one by one (`forge-update.mjs:115-120`, `:196`). Its “local files untouched” comments stop being true after line 196.
+
+   Superior alternative: extract to `versions/<digest>.staging`, validate there, rename staging to immutable `versions/<digest>`, then atomically update a tiny pointer. Never unzip or copy over the active tree.
+
+5. **BLOCKER — There is no cross-process lock, so two sessions can race the same spine/update.**
+
+   `session-start.sh` rate-limits by writing a timestamp (`session-start.sh:205-208`) but does not lock. It can launch multiple `claude plugin update` jobs (`session-start.sh:233-236`) across simultaneous Claude windows. `bin/install.mjs` and `kb/forge-update.mjs` mutate the same `~/.cache/ruvnet-brain/kb` path without a lock. ADR-0023 adds a shared `current` symlink but does not define a lock around unpack/health/flip/stamp. Two sessions can download different versions, both validate, then flip in last-writer-wins order. Worse, one can run health checks against a tree another is replacing.
+
+   Superior alternative: use a per-home lock directory such as `~/.cache/ruvnet-brain/.update.lock` acquired with atomic `mkdir`, containing pid/host/start/targetVersion, with stale-lock rules. Every entry point that writes cache state must use the same lock.
+
+6. **BLOCKER — The proposed symlink spine is not a portable Windows design.**
+
+   The current hooks already declare `"_platform": "posix"` and hard-code `/bin/bash` (`hooks.json:3`, `:11`, etc.). ADR-0023 doubles down on a POSIX symlink `current -> versions/<active-version>/`. Native Windows symlink creation often requires Developer Mode or elevated privileges. Directory junctions have different behavior, require absolute targets, and do not behave identically to POSIX symlinks under rename/delete. The installer has Windows accommodations for `.cmd` shims and PowerShell extraction (`install.mjs:136-146`, `:361-394`), but the ADR’s core update primitive is POSIX-biased.
+
+   Superior alternative: do not use a symlink as the control plane. Use an atomically rewritten `active.json` pointer containing `{ codeRoot, kbRoot, version, digest, previous, manifestSig }`, and have stable Node shims read it. This works on macOS, Linux, and Windows without symlink privileges.
+
+7. **BLOCKER — The MCP hot-swap proxy design is much harder than the ADR admits and is not compatible with `stdio: inherit`.**
+
+   The existing MCP launcher cannot cache or replay anything because it wires Claude Code directly to the child with inherited stdio (`server.mjs:40-41`). A real hot-swap proxy must parse JSON-RPC messages, track request ids, understand initialization state, forward stderr separately, handle process death, and multiplex stdin/stdout. ADR-0023 treats this as a small addition to the existing proxy, but the existing proxy is not a proxy in the protocol sense; it is just a process launcher.
+
+   Superior alternative: replace the MCP child-proxy plan with a stable MCP server that declares `search_ruvnet` itself and, on each tool call, dispatches to the active implementation through a private API. If warm models require a worker, keep a worker behind an internal request protocol, not a replayed external MCP handshake.
+
+8. **BLOCKER — Replaying `initialize` risks invalid JSON-RPC/MCP state unless ids and notifications are remapped.**
+
+   MCP initialization is not just one request. The client sends `initialize`, receives a response, then sends an `initialized` notification. If the proxy replays the cached `initialize` with the original client id to a new child, the child will respond with the same id; the proxy must swallow it without confusing pending client requests. It also needs to replay `initialized` if the child expects it. If the client sends batches or overlapping requests, the proxy must not mistake a child response id for a client id after restart.
+
+   Superior alternative: if a child MCP server must remain, allocate proxy-private ids for all child requests, map ids both directions, cache both `initialize` and `initialized`, and test against real MCP traffic including notifications, batches, and concurrent requests. This is not a 15-line proxy change.
+
+9. **BLOCKER — The ADR’s “between requests” swap rule ignores concurrent requests and streaming.**
+
+   It says “Never swap mid-request; queue and swap between requests.” That only works if the client has at most one in-flight request. MCP/JSON-RPC permits concurrent requests and notifications; even if Claude Code is currently sequential, the plugin should not encode that assumption into an architecture whose purpose is resilience. A reload stamp observed while one request is pending must defer until all pending ids drain. Child death mid-request must return a JSON-RPC error for that id, not exit the parent process.
+
+   Superior alternative: explicit state machine: `activeGeneration`, `pendingRequestCount`, `reloadPending`, `draining`, `spawnCandidate`, `healthProbeCandidate`, `promoteCandidate`. No swap while `pendingRequestCount > 0`; no parent exit for child crash unless boot initialization cannot ever succeed.
+
+10. **MAJOR — The ADR claims verify-before-flip, but current signature policy still allows unsigned extraction.**
+
+   `bin/install.mjs` has a good embedded Ed25519 verifier, but `SIGNING_REQUIRED = false` and missing signatures warn-and-proceed (`install.mjs:1902-1912`). There is also a user-facing `--no-verify` override. The effective updater has a legacy bootstrap branch that applies one unsigned update when verifier/key are absent (`forge-update.mjs:183-189`). That contradicts the ADR’s “SHA-256 verify” safety claim.
+
+   Superior alternative: make signed manifest and signed bundle mandatory before enabling unattended update. For legacy installs without a verifier/key, refuse `forge-update.mjs --apply` and instruct the user to update via the npm installer, where the trust root is embedded in the package code.
+
+11. **MAJOR — SHA-256 alone is not a supply-chain trust boundary.**
+
+   ADR-0023 says “fetch manifest -> download -> SHA-256 verify.” If the manifest and bundle come from the same GitHub release/channel and the manifest is not signed by a pinned key, a compromised release can publish a matching malicious hash. The code already understands this better than the ADR: `install.mjs` and `build-bundle.mjs` include Ed25519 verifier/key handling (`install.mjs:26-39`, `build-bundle.mjs:221-230`). The ADR regresses the security model by naming hash verification but not signature verification as a hard requirement.
+
+   Superior alternative: require a signed manifest whose public key is shipped in the boot shell. The manifest should bind version, digest, artifact URL, tool declarations, `requiresRestart`, and compatibility range.
+
+12. **MAJOR — Archive extraction is not fenced against path traversal or unsafe entries.**
+
+   Both `bin/install.mjs` and `kb/forge-update.mjs` delegate extraction to `unzip`/`Expand-Archive` without pre-validating archive entries (`install.mjs:382`, `:391-394`; `forge-update.mjs:191`). Signature verification lowers risk only when signatures are mandatory and trusted. Today they are not mandatory in the installer and not available for legacy auto-apply. A malicious archive with `../`, absolute paths, symlinks, or odd permissions is an avoidable footgun.
+
+   Superior alternative: preflight the zip central directory before extraction, reject absolute paths, parent traversal, device files, and symlinks, and extract into a private staging dir only after signature verification.
+
+13. **MAJOR — `current` as an executable pointer in a user-writable cache is a TOCTOU execution surface.**
+
+   The hook shim would execute `~/.cache/ruvnet-brain/current/plugin/scripts/<name>`. Any process running as the user can rewrite `current` to arbitrary code between shim path resolution and `exec`, or can replace the target after a check unless the shim verifies the resolved realpath and signed manifest immediately before execution. Same-user compromise is not usually defended against, but this plugin explicitly runs code that changes model behavior, and the ADR is making the cache path a code root.
+
+   Superior alternative: the shim should read `active.json`, resolve `codeRoot`, require it to be under `~/.cache/ruvnet-brain/versions/`, verify the version manifest signature or a stored digest receipt, then exec by file descriptor where possible or at least avoid a separate check/use gap. Also require parent directory permissions not group/world-writable.
+
+14. **MAJOR — Hook hot-swap can make one Claude turn internally inconsistent.**
+
+   Hooks fire at `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `SessionEnd`. If `current` flips mid-turn, grounding can come from version A, a pre-tool policy gate from version B, and learning flush from version C. The ADR treats “updates the moment current flips” as purely good, but multi-hook workflows need epoch consistency or explicit forward-compatible contracts.
+
+   Superior alternative: stamp a session or turn epoch. At SessionStart, write the active version into a session env/file and have all hooks for that session use that epoch by default; allow explicit hot mode only for stateless hooks. If mid-session hot updates are required, define compatibility contracts for hook stdout formats and blocking exit codes.
+
+15. **MAJOR — The route-dispatch blocking contract is fragile under a generic shim.**
+
+   `route-dispatch.sh` deliberately exits 2 and is not guarded by `|| true` (`hooks.json:55`). The ADR says `exec` preserves exit codes, but the actual hook migration must preserve which hooks are fail-open and which are fail-closed. A naive `hook-shim.sh <name>` used under the existing `|| true` convention would silently disable the cost-control wall. The ADR does not define a manifest of hook criticality.
+
+   Superior alternative: hook declarations should call `node hook-shim.mjs route-dispatch --mode=blocking` for blocking hooks and `--mode=advisory` for fail-open hooks, with tests proving exit 2 survives only for the intended matchers.
+
+16. **MAJOR — The proposed hook shim is POSIX-only and omits `.mjs` hooks.**
+
+   ADR-0023 describes `hook-shim.sh <name>` resolving `current/plugin/scripts/<name>`. Current hooks include shell scripts and a Node script (`learn-flush.mjs`, `hooks.json:99`). Some hook names include extensions in declarations, some ADR prose examples omit them. Without a typed script manifest, the shim will either hard-code extensions or fail on non-shell hooks.
+
+   Superior alternative: use a Node shim with a small dispatch table: hook id -> relative executable, interpreter, advisory/blocking mode, timeout expectations, and minimum body version. Node is already required for MCP and installer.
+
+17. **MAJOR — `forge-update.mjs` is not cross-platform even though the product claims Windows support.**
+
+   The installer supports PowerShell `Expand-Archive` fallback (`install.mjs:361-394`), but the bundled updater uses `execFileSync('unzip', ...)` only (`forge-update.mjs:191`). On native Windows, scheduled or manual `forge-update.mjs --apply` will fail even if the original install worked. This directly violates the ADR’s install-path convergence claim.
+
+   Superior alternative: share one extraction implementation between installer and updater, or move update application entirely into `bin/install.mjs`/`scripts/update-apply.mjs` and stop shipping a divergent updater inside the KB.
+
+18. **MAJOR — Release gating does not know the restart contract exists.**
+
+   ADR-0023 requires a manifest field `requiresRestart: true` only for boot-frozen declaration changes. `plugin/.claude-plugin/plugin.json` has no such field. `scripts/release.mjs` only runs version sync, tests, publish, and `verify-channels` (`release.mjs:49-96`). There is no diff classifier for hooks, skills, commands, MCP tool names, shim/proxy code, or manifest compatibility. This means the “honest restart contract” will immediately drift.
+
+   Superior alternative: generate a release manifest during release. Gate it by diffing the previous release: changes under `plugin/hooks/`, `plugin/skills/`, `plugin/commands/`, `.mcp.json`, `plugin/mcp/server.mjs`, and hook shim/proxy files must either set `requiresRestart: true` or fail release.
+
+19. **MAJOR — Auto-update from `session-start.sh` is the wrong place to apply a code-body update.**
+
+   Hooks have tight timeouts (`hooks.json:12`, `:22`, etc.). `session-start.sh` already backgrounds network work (`session-start.sh:218-223`, `:233-236`) and writes notices to fd 3 after the main hook output. If `session-start` also drives `update-apply.mjs` as the ADR says, it either races Claude Code hook timeout/lifecycle or must background a writer that outlives the hook with no lock and weak observability.
+
+   Superior alternative: session-start should only enqueue a check or trigger a detached updater with locking and durable logs. The updater should not be coupled to hook stdout injection.
+
+20. **MAJOR — Health gates are too shallow for a code payload that is executed as hooks and MCP.**
+
+   ADR-0023 proposes `bash -n`, `node --check`, and one CLI smoke query. `bash -n` does not prove runtime dependencies, env assumptions, hook JSON parsing, advisory vs blocking output shape, or Windows behavior. `node --check` does not catch missing imports. One CLI query does not prove MCP initialization, `tools/list`, `tools/call`, duplicate request ids, or reload.
+
+   Superior alternative: health gate the candidate with the same integration battery users exercise: parse hooks, execute each hook with representative Claude hook JSON, assert exit semantics, start the stable MCP server against the candidate, run `initialize`, `tools/list`, and one `tools/call`, then kill/reload and assert the client connection survives.
+
+21. **MAJOR — Post-flip rollback is claimed but not designed for the hard failure cases.**
+
+   ADR-0023 says “A failed post-flip probe = auto-flip back.” It does not say what happens if the process crashes after flip before writing `.reload-stamp`, if rollback flip fails, if both previous and new versions fail, or if another updater flips again between probe and rollback. Current `kb/forge-update.mjs` merely leaves a backup on guard failure and tells the user to restore it (`forge-update.mjs:207-208`); there is no automatic restore.
+
+   Superior alternative: model update states explicitly: `idle`, `candidate-ready`, `active`, `rollback-needed`, `rollback-complete`. Persist a transaction record before the flip. On every shim/proxy start, detect incomplete transactions and recover deterministically under lock.
+
+22. **MAJOR — The installer fallback can clobber the live KB while the MCP server is reading it.**
+
+   `runUpdate()` falls back from `forge-update.mjs --apply` to running the installer with `--force` (`install.mjs:923-927`). That code path extracts directly into the live `cacheDir` and removes entries (`install.mjs:382`, `:405`). A running MCP child launched from `~/.cache/ruvnet-brain/kb/forge-mcp-all.mjs` may be importing files, reading passages, or writing health state at the same time.
+
+   Superior alternative: all updater paths, including fallback, must install to an inactive version directory and then flip an active pointer. No code path should ever `unzip -o` into the live KB.
+
+23. **MAJOR — The ADR does not define cleanup/retention, so the immutable version store will grow without bound.**
+
+   The ADR says keep previous for rollback, but does not define retention count, disk budget, GC lock rules, or protection for versions still used by active MCP workers. This bundle is large; unbounded `versions/<v>` directories will matter quickly.
+
+   Superior alternative: retain active + previous + last-known-good + any version with a live lease file. GC only under update lock and never delete a version whose lease heartbeat is fresh.
+
+24. **MAJOR — The “dev mode current -> checkout” path can bypass all gates.**
+
+   ADR-0023 allows `current` to point at a git checkout. That is useful for maintainers, but it also means hooks can execute unvalidated working-tree code and MCP can hot-load code whose dependencies are not installed. The ADR does not isolate dev mode from normal users or require an explicit marker.
+
+   Superior alternative: make dev mode opt-in via `~/.cache/ruvnet-brain/dev.json`, require the target to be the current repo root with a marker file, print dev mode in the banner, and never let auto-update overwrite or flip away from it.
+
+25. **MINOR — The ADR’s fallback-to-plugin-dir story can mask a broken spine indefinitely.**
+
+   Falling back to `${CLAUDE_PLUGIN_ROOT}` if the spine is missing sounds fail-safe, but it can silently pin users to an old boot version and hide update corruption. The current session banner already cares about truthful running version (`session-start.sh:274-293`); a silent fallback would undercut that.
+
+   Superior alternative: fallback only for first install or explicitly marked recovery. Otherwise emit a loud hook/MCP health warning that `current` is missing and name the frozen fallback version.
+
+26. **MINOR — The reload stamp is under-specified and can be missed or spuriously triggered.**
+
+   ADR-0023 uses `~/.cache/ruvnet-brain/.reload-stamp`, but does not define contents, atomic write, monotonicity, or relation to active version. Timestamp files can miss events on coarse filesystems or produce false positives from partial writes.
+
+   Superior alternative: make the stamp the same atomic `active.json` pointer. Include generation number and digest. The proxy compares parsed generation, not file mtime.
+
+27. **MINOR — The release process publishes before full live verification.**
+
+   `scripts/release.mjs --publish` pushes, publishes, updates the npm dist-tag, then runs `verify-channels` (`release.mjs:66-96`). If live verification fails after publish, users can already consume the broken release. This is not new in ADR-0023, but a stable-spine architecture raises the stakes because update adoption becomes automatic.
+
+   Superior alternative: split release into “stage artifact and verify by immutable URL” before moving `latest`/active manifest, then promote the signed manifest pointer last.
+
+28. **MINOR — The ADR does not name ownership boundaries for code updates vs KB updates.**
+
+   It says KB data stays on its own track, but actual bundle tooling still packages code and KB together (`build-bundle.mjs:197-230`). Without two manifests and two active pointers, a KB refresh can change executable behavior and a code refresh can change knowledge state.
+
+   Superior alternative: maintain separate signed manifests: `code-manifest.json` and `kb-manifest.json`. The code manifest declares hook/MCP compatibility; the KB manifest declares data schema compatibility. The active pointer binds a compatible pair.
+
+29. **MINOR — Tests currently encode sequential MCP behavior and would not catch hot-swap bugs.**
+
+   `plugin/test/run-tests.mjs` says requests are sent sequentially, “the way a real MCP client behaves” according to its comment. ADR-0023’s proxy would need tests for duplicate ids, concurrent requests, child restart during request, notifications, and reload boundaries. Existing tests will give false confidence.
+
+   Superior alternative: add a protocol test harness with a fake child MCP server and scripted JSON-RPC traffic. Assert the proxy never leaks the replayed initialize response and never breaks client id continuity.
+
+30. **MINOR — The hook shell assumes `/bin/bash`, while several scripts claim `/bin/sh`.**
+
+   `session-start.sh` declares `#!/bin/sh`, but hooks execute it with `/bin/bash` (`hooks.json:11`, `:21`). A stable shim should not perpetuate this ambiguity. The health gate should validate under the actual interpreter used in the hook declaration, not merely `bash -n every hook script`.
+
+   Superior alternative: each hook entry in the dispatch table should name its interpreter. Validate with that interpreter and with representative stdin.
+
+## Simpler Architecture I Would Prefer
+
+The strictly better version is a stable Node shell, not a symlink-centered shell:
+
+1. Freeze only these boot declarations in the Claude Code plugin: hook commands call `node ${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs <hook-id>`, and `.mcp.json` calls `node ${CLAUDE_PLUGIN_ROOT}/mcp/server.mjs`.
+2. Store active state in `~/.cache/ruvnet-brain/active.json`, atomically written by temp-file + rename. It names `codeRoot`, `kbRoot`, generation, version, digest, previous, compatibility range, and signed manifest receipt.
+3. Install code to immutable `~/.cache/ruvnet-brain/versions/<digest>/`. Install KB data to immutable `~/.cache/ruvnet-brain/kb-versions/<digest>/` or keep `kb/current-data` as a separate pointer. Never mutate the active tree.
+4. Use one updater implementation for install, manual update, session-triggered update, and nightly update. It must acquire a lock, download, verify signed manifest and artifact, extract to staging, run health gates, rename staging to immutable final, then update `active.json`.
+5. Make the MCP server stable and fixed-schema. On `search_ruvnet`, it reads `active.json` and delegates to the active implementation. If keeping a warm worker is required, the worker should speak a private request protocol; do not replay external MCP handshakes.
+6. Treat restart truthfully: any change to `hooks.json`, `.mcp.json`, command/skill declarations, hook shim, or stable MCP server requires a restart. Everything else is body code/data and can update behind `active.json`.
+
+This keeps the good idea from ADR-0023, removes Windows symlink dependency, avoids MCP handshake replay, gives crash consistency, and creates one control plane that release gates can actually test.
+
+tokens used
+112,752
+The sandbox rejected the write to `docs/adr/0023-gpt56-redteam.md` because this session is read-only, so here is the full review content to stdout.
+
+```markdown
+# ADR-0023 Red-Team Review — GPT-5.6
+
+Reviewer stance: adversarial architecture review of `docs/adr/0023-intelligent-updating-stable-spine.md` against the actual code in `plugin/hooks/hooks.json`, `plugin/mcp/server.mjs`, `plugin/scripts/session-start.sh`, `bin/install.mjs`, `scripts/release.mjs`, and the effective bundled updater `kb/forge-update.mjs` because `scripts/forge-update.mjs` is absent.
+
+One thing I agree with: splitting boot-frozen declarations from invoked behavior is the right direction. Everything below is about the places where this ADR either does not implement that split, implements it unsafely, or chooses a more complex mechanism than needed.
+
+1. **BLOCKER — The ADR is marked Accepted, but the described spine is not implemented.**
+
+   `plugin/hooks/hooks.json` still invokes `${CLAUDE_PLUGIN_ROOT}/scripts/*.sh` and `${CLAUDE_PLUGIN_ROOT}/scripts/learn-flush.mjs` directly (`hooks.json:11`, `:21`, `:33`, `:45`, `:55`, `:65`, `:75`, `:87`, `:99`). `plugin/mcp/server.mjs` is still a one-shot `spawn('node', [MCP], { stdio: 'inherit' })` launcher (`server.mjs:41`). `scripts/update-apply.mjs` does not exist. `scripts/forge-update.mjs` does not exist. `scripts/release.mjs` has no gate for hook shim presence, reload-stamp behavior, `requiresRestart`, or spine integrity. As written, the ADR is not an accepted design record for shipped behavior; it is a future implementation sketch with production claims.
+
+   Superior alternative: downgrade the ADR status to Proposed until the shell shims, update engine, proxy semantics, release gates, and failure tests are present. Add release gates that fail if hooks still reference `${CLAUDE_PLUGIN_ROOT}/scripts/` directly or if `scripts/update-apply.mjs` is missing.
+
+2. **BLOCKER — The migration needs one final restart, and the ADR hides that bootstrap cost.**
+
+   The only way existing installed versions can start using a hook shim is for Claude Code to load a new `hooks.json`. Today it has frozen direct commands. A background marketplace update in `session-start.sh:233-236` can stage a new plugin, but this running process will still use the old hook declarations until restart. The ADR says the every-session restart nag is deleted, but the first delivery of the stable spine necessarily requires a one-time restart.
+
+   Superior alternative: define an explicit two-phase migration: release N installs the boot shim and honestly asks for one restart; release N+1 and later can hot-swap body code. The release manifest should carry `migrationRequiresRestart: true` for the first spine release even if later body-only releases do not.
+
+3. **BLOCKER — The code/body split is internally inconsistent: executable MCP code still lives in the KB data directory.**
+
+   ADR-0023 says `versions/` holds code and `kb/` holds data. Actual behavior runs executable code from `~/.cache/ruvnet-brain/kb/forge-mcp-all.mjs` (`server.mjs:19-21`), ships tool code into the bundle (`build-bundle.mjs:204`), and the effective updater overwrites the KB directory including `.mjs` files (`kb/forge-update.mjs:196`). This is exactly the executable-data coupling the ADR claims to remove.
+
+   Superior alternative: move all runtime code into `versions/<codeVersion>/plugin/...` or `versions/<digest>/runtime/...`; keep `kb/` to `.rvf`, passages, metadata, and model/data files only. The stable MCP server should load a fixed tool schema and delegate to code under the active code root while passing `KB_DIR` as data.
+
+4. **BLOCKER — Current install and update paths mutate the live KB in place and are crash-corruptible.**
+
+   `bin/install.mjs` extracts directly into `cacheDir` (`install.mjs:382`), then removes live paths before renaming extracted entries into place (`install.mjs:405-406`). A crash, `unzip` failure after partial writes, power loss, or concurrent reader during this window can leave a missing or mixed-version KB. `kb/forge-update.mjs` backs up the live dir (`forge-update.mjs:195`) and then `copyTree(extractDir, KB_DIR)` overwrites files one by one (`forge-update.mjs:115-120`, `:196`). Its “local files untouched” comments stop being true after line 196.
+
+   Superior alternative: extract to `versions/<digest>.staging`, validate there, rename staging to immutable `versions/<digest>`, then atomically update a tiny pointer. Never unzip or copy over the active tree.
+
+5. **BLOCKER — There is no cross-process lock, so two sessions can race the same spine/update.**
+
+   `session-start.sh` rate-limits by writing a timestamp (`session-start.sh:205-208`) but does not lock. It can launch multiple `claude plugin update` jobs (`session-start.sh:233-236`) across simultaneous Claude windows. `bin/install.mjs` and `kb/forge-update.mjs` mutate the same `~/.cache/ruvnet-brain/kb` path without a lock. ADR-0023 adds a shared `current` symlink but does not define a lock around unpack/health/flip/stamp. Two sessions can download different versions, both validate, then flip in last-writer-wins order. Worse, one can run health checks against a tree another is replacing.
+
+   Superior alternative: use a per-home lock directory such as `~/.cache/ruvnet-brain/.update.lock` acquired with atomic `mkdir`, containing pid/host/start/targetVersion, with stale-lock rules. Every entry point that writes cache state must use the same lock.
+
+6. **BLOCKER — The proposed symlink spine is not a portable Windows design.**
+
+   The current hooks already declare `"_platform": "posix"` and hard-code `/bin/bash` (`hooks.json:3`, `:11`, etc.). ADR-0023 doubles down on a POSIX symlink `current -> versions/<active-version>/`. Native Windows symlink creation often requires Developer Mode or elevated privileges. Directory junctions have different behavior, require absolute targets, and do not behave identically to POSIX symlinks under rename/delete. The installer has Windows accommodations for `.cmd` shims and PowerShell extraction (`install.mjs:136-146`, `:361-394`), but the ADR’s core update primitive is POSIX-biased.
+
+   Superior alternative: do not use a symlink as the control plane. Use an atomically rewritten `active.json` pointer containing `{ codeRoot, kbRoot, version, digest, previous, manifestSig }`, and have stable Node shims read it. This works on macOS, Linux, and Windows without symlink privileges.
+
+7. **BLOCKER — The MCP hot-swap proxy design is much harder than the ADR admits and is not compatible with `stdio: inherit`.**
+
+   The existing MCP launcher cannot cache or replay anything because it wires Claude Code directly to the child with inherited stdio (`server.mjs:40-41`). A real hot-swap proxy must parse JSON-RPC messages, track request ids, understand initialization state, forward stderr separately, handle process death, and multiplex stdin/stdout. ADR-0023 treats this as a small addition to the existing proxy, but the existing proxy is not a proxy in the protocol sense; it is just a process launcher.
+
+   Superior alternative: replace the MCP child-proxy plan with a stable MCP server that declares `search_ruvnet` itself and, on each tool call, dispatches to the active implementation through a private API. If warm models require a worker, keep a worker behind an internal request protocol, not a replayed external MCP handshake.
+
+8. **BLOCKER — Replaying `initialize` risks invalid JSON-RPC/MCP state unless ids and notifications are remapped.**
+
+   MCP initialization is not just one request. The client sends `initialize`, receives a response, then sends an `initialized` notification. If the proxy replays the cached `initialize` with the original client id to a new child, the child will respond with the same id; the proxy must swallow it without confusing pending client requests. It also needs to replay `initialized` if the child expects it. If the client sends batches or overlapping requests, the proxy must not mistake a child response id for a client id after restart.
+
+   Superior alternative: if a child MCP server must remain, allocate proxy-private ids for all child requests, map ids both directions, cache both `initialize` and `initialized`, and test against real MCP traffic including notifications, batches, and concurrent requests. This is not a 15-line proxy change.
+
+9. **BLOCKER — The ADR’s “between requests” swap rule ignores concurrent requests and streaming.**
+
+   It says “Never swap mid-request; queue and swap between requests.” That only works if the client has at most one in-flight request. MCP/JSON-RPC permits concurrent requests and notifications; even if Claude Code is currently sequential, the plugin should not encode that assumption into an architecture whose purpose is resilience. A reload stamp observed while one request is pending must defer until all pending ids drain. Child death mid-request must return a JSON-RPC error for that id, not exit the parent process.
+
+   Superior alternative: explicit state machine: `activeGeneration`, `pendingRequestCount`, `reloadPending`, `draining`, `spawnCandidate`, `healthProbeCandidate`, `promoteCandidate`. No swap while `pendingRequestCount > 0`; no parent exit for child crash unless boot initialization cannot ever succeed.
+
+10. **MAJOR — The ADR claims verify-before-flip, but current signature policy still allows unsigned extraction.**
+
+   `bin/install.mjs` has a good embedded Ed25519 verifier, but `SIGNING_REQUIRED = false` and missing signatures warn-and-proceed (`install.mjs:1902-1912`). There is also a user-facing `--no-verify` override. The effective updater has a legacy bootstrap branch that applies one unsigned update when verifier/key are absent (`forge-update.mjs:183-189`). That contradicts the ADR’s “SHA-256 verify” safety claim.
+
+   Superior alternative: make signed manifest and signed bundle mandatory before enabling unattended update. For legacy installs without a verifier/key, refuse `forge-update.mjs --apply` and instruct the user to update via the npm installer, where the trust root is embedded in the package code.
+
+11. **MAJOR — SHA-256 alone is not a supply-chain trust boundary.**
+
+   ADR-0023 says “fetch manifest -> download -> SHA-256 verify.” If the manifest and bundle come from the same GitHub release/channel and the manifest is not signed by a pinned key, a compromised release can publish a matching malicious hash. The code already understands this better than the ADR: `install.mjs` and `build-bundle.mjs` include Ed25519 verifier/key handling (`install.mjs:26-39`, `build-bundle.mjs:221-230`). The ADR regresses the security model by naming hash verification but not signature verification as a hard requirement.
+
+   Superior alternative: require a signed manifest whose public key is shipped in the boot shell. The manifest should bind version, digest, artifact URL, tool declarations, `requiresRestart`, and compatibility range.
+
+12. **MAJOR — Archive extraction is not fenced against path traversal or unsafe entries.**
+
+   Both `bin/install.mjs` and `kb/forge-update.mjs` delegate extraction to `unzip`/`Expand-Archive` without pre-validating archive entries (`install.mjs:382`, `:391-394`; `forge-update.mjs:191`). Signature verification lowers risk only when signatures are mandatory and trusted. Today they are not mandatory in the installer and not available for legacy auto-apply. A malicious archive with `../`, absolute paths, symlinks, or odd permissions is an avoidable footgun.
+
+   Superior alternative: preflight the zip central directory before extraction, reject absolute paths, parent traversal, device files, and symlinks, and extract into a private staging dir only after signature verification.
+
+13. **MAJOR — `current` as an executable pointer in a user-writable cache is a TOCTOU execution surface.**
+
+   The hook shim would execute `~/.cache/ruvnet-brain/current/plugin/scripts/<name>`. Any process running as the user can rewrite `current` to arbitrary code between shim path resolution and `exec`, or can replace the target after a check unless the shim verifies the resolved realpath and signed manifest immediately before execution. Same-user compromise is not usually defended against, but this plugin explicitly runs code that changes model behavior, and the ADR is making the cache path a code root.
+
+   Superior alternative: the shim should read `active.json`, resolve `codeRoot`, require it to be under `~/.cache/ruvnet-brain/versions/`, verify the version manifest signature or a stored digest receipt, then exec by file descriptor where possible or at least avoid a separate check/use gap. Also require parent directory permissions not group/world-writable.
+
+14. **MAJOR — Hook hot-swap can make one Claude turn internally inconsistent.**
+
+   Hooks fire at `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `SessionEnd`. If `current` flips mid-turn, grounding can come from version A, a pre-tool policy gate from version B, and learning flush from version C. The ADR treats “updates the moment current flips” as purely good, but multi-hook workflows need epoch consistency or explicit forward-compatible contracts.
+
+   Superior alternative: stamp a session or turn epoch. At SessionStart, write the active version into a session env/file and have all hooks for that session use that epoch by default; allow explicit hot mode only for stateless hooks. If mid-session hot updates are required, define compatibility contracts for hook stdout formats and blocking exit codes.
+
+15. **MAJOR — The route-dispatch blocking contract is fragile under a generic shim.**
+
+   `route-dispatch.sh` deliberately exits 2 and is not guarded by `|| true` (`hooks.json:55`). The ADR says `exec` preserves exit codes, but the actual hook migration must preserve which hooks are fail-open and which are fail-closed. A naive `hook-shim.sh <name>` used under the existing `|| true` convention would silently disable the cost-control wall. The ADR does not define a manifest of hook criticality.
+
+   Superior alternative: hook declarations should call `node hook-shim.mjs route-dispatch --mode=blocking` for blocking hooks and `--mode=advisory` for fail-open hooks, with tests proving exit 2 survives only for the intended matchers.
+
+16. **MAJOR — The proposed hook shim is POSIX-only and omits `.mjs` hooks.**
+
+   ADR-0023 describes `hook-shim.sh <name>` resolving `current/plugin/scripts/<name>`. Current hooks include shell scripts and a Node script (`learn-flush.mjs`, `hooks.json:99`). Some hook names include extensions in declarations, some ADR prose examples omit them. Without a typed script manifest, the shim will either hard-code extensions or fail on non-shell hooks.
+
+   Superior alternative: use a Node shim with a small dispatch table: hook id -> relative executable, interpreter, advisory/blocking mode, timeout expectations, and minimum body version. Node is already required for MCP and installer.
+
+17. **MAJOR — `forge-update.mjs` is not cross-platform even though the product claims Windows support.**
+
+   The installer supports PowerShell `Expand-Archive` fallback (`install.mjs:361-394`), but the bundled updater uses `execFileSync('unzip', ...)` only (`forge-update.mjs:191`). On native Windows, scheduled or manual `forge-update.mjs --apply` will fail even if the original install worked. This directly violates the ADR’s install-path convergence claim.
+
+   Superior alternative: share one extraction implementation between installer and updater, or move update application entirely into `bin/install.mjs`/`scripts/update-apply.mjs` and stop shipping a divergent updater inside the KB.
+
+18. **MAJOR — Release gating does not know the restart contract exists.**
+
+   ADR-0023 requires a manifest field `requiresRestart: true` only for boot-frozen declaration changes. `plugin/.claude-plugin/plugin.json` has no such field. `scripts/release.mjs` only runs version sync, tests, publish, and `verify-channels` (`release.mjs:49-96`). There is no diff classifier for hooks, skills, commands, MCP tool names, shim/proxy code, or manifest compatibility. This means the “honest restart contract” will immediately drift.
+
+   Superior alternative: generate a release manifest during release. Gate it by diffing the previous release: changes under `plugin/hooks/`, `plugin/skills/`, `plugin/commands/`, `.mcp.json`, `plugin/mcp/server.mjs`, and hook shim/proxy files must either set `requiresRestart: true` or fail release.
+
+19. **MAJOR — Auto-update from `session-start.sh` is the wrong place to apply a code-body update.**
+
+   Hooks have tight timeouts (`hooks.json:12`, `:22`, etc.). `session-start.sh` already backgrounds network work (`session-start.sh:218-223`, `:233-236`) and writes notices to fd 3 after the main hook output. If `session-start` also drives `update-apply.mjs` as the ADR says, it either races Claude Code hook timeout/lifecycle or must background a writer that outlives the hook with no lock and weak observability.
+
+   Superior alternative: session-start should only enqueue a check or trigger a detached updater with locking and durable logs. The updater should not be coupled to hook stdout injection.
+
+20. **MAJOR — Health gates are too shallow for a code payload that is executed as hooks and MCP.**
+
+   ADR-0023 proposes `bash -n`, `node --check`, and one CLI smoke query. `bash -n` does not prove runtime dependencies, env assumptions, hook JSON parsing, advisory vs blocking output shape, or Windows behavior. `node --check` does not catch missing imports. One CLI query does not prove MCP initialization, `tools/list`, `tools/call`, duplicate request ids, or reload.
+
+   Superior alternative: health gate the candidate with the same integration battery users exercise: parse hooks, execute each hook with representative Claude hook JSON, assert exit semantics, start the stable MCP server against the candidate, run `initialize`, `tools/list`, and one `tools/call`, then kill/reload and assert the client connection survives.
+
+21. **MAJOR — Post-flip rollback is claimed but not designed for the hard failure cases.**
+
+   ADR-0023 says “A failed post-flip probe = auto-flip back.” It does not say what happens if the process crashes after flip before writing `.reload-stamp`, if rollback flip fails, if both previous and new versions fail, or if another updater flips again between probe and rollback. Current `kb/forge-update.mjs` merely leaves a backup on guard failure and tells the user to restore it (`forge-update.mjs:207-208`); there is no automatic restore.
+
+   Superior alternative: model update states explicitly: `idle`, `candidate-ready`, `active`, `rollback-needed`, `rollback-complete`. Persist a transaction record before the flip. On every shim/proxy start, detect incomplete transactions and recover deterministically under lock.
+
+22. **MAJOR — The installer fallback can clobber the live KB while the MCP server is reading it.**
+
+   `runUpdate()` falls back from `forge-update.mjs --apply` to running the installer with `--force` (`install.mjs:923-927`). That code path extracts directly into the live `cacheDir` and removes entries (`install.mjs:382`, `:405`). A running MCP child launched from `~/.cache/ruvnet-brain/kb/forge-mcp-all.mjs` may be importing files, reading passages, or writing health state at the same time.
+
+   Superior alternative: all updater paths, including fallback, must install to an inactive version directory and then flip an active pointer. No code path should ever `unzip -o` into the live KB.
+
+23. **MAJOR — The ADR does not define cleanup/retention, so the immutable version store will grow without bound.**
+
+   The ADR says keep previous for rollback, but does not define retention count, disk budget, GC lock rules, or protection for versions still used by active MCP workers. This bundle is large; unbounded `versions/<v>` directories will matter quickly.
+
+   Superior alternative: retain active + previous + last-known-good + any version with a live lease file. GC only under update lock and never delete a version whose lease heartbeat is fresh.
+
+24. **MAJOR — The “dev mode current -> checkout” path can bypass all gates.**
+
+   ADR-0023 allows `current` to point at a git checkout. That is useful for maintainers, but it also means hooks can execute unvalidated working-tree code and MCP can hot-load code whose dependencies are not installed. The ADR does not isolate dev mode from normal users or require an explicit marker.
+
+   Superior alternative: make dev mode opt-in via `~/.cache/ruvnet-brain/dev.json`, require the target to be the current repo root with a marker file, print dev mode in the banner, and never let auto-update overwrite or flip away from it.
+
+25. **MINOR — The ADR’s fallback-to-plugin-dir story can mask a broken spine indefinitely.**
+
+   Falling back to `${CLAUDE_PLUGIN_ROOT}` if the spine is missing sounds fail-safe, but it can silently pin users to an old boot version and hide update corruption. The current session banner already cares about truthful running version (`session-start.sh:274-293`); a silent fallback would undercut that.
+
+   Superior alternative: fallback only for first install or explicitly marked recovery. Otherwise emit a loud hook/MCP health warning that `current` is missing and name the frozen fallback version.
+
+26. **MINOR — The reload stamp is under-specified and can be missed or spuriously triggered.**
+
+   ADR-0023 uses `~/.cache/ruvnet-brain/.reload-stamp`, but does not define contents, atomic write, monotonicity, or relation to active version. Timestamp files can miss events on coarse filesystems or produce false positives from partial writes.
+
+   Superior alternative: make the stamp the same atomic `active.json` pointer. Include generation number and digest. The proxy compares parsed generation, not file mtime.
+
+27. **MINOR — The release process publishes before full live verification.**
+
+   `scripts/release.mjs --publish` pushes, publishes, updates the npm dist-tag, then runs `verify-channels` (`release.mjs:66-96`). If live verification fails after publish, users can already consume the broken release. This is not new in ADR-0023, but a stable-spine architecture raises the stakes because update adoption becomes automatic.
+
+   Superior alternative: split release into “stage artifact and verify by immutable URL” before moving `latest`/active manifest, then promote the signed manifest pointer last.
+
+28. **MINOR — The ADR does not name ownership boundaries for code updates vs KB updates.**
+
+   It says KB data stays on its own track, but actual bundle tooling still packages code and KB together (`build-bundle.mjs:197-230`). Without two manifests and two active pointers, a KB refresh can change executable behavior and a code refresh can change knowledge state.
+
+   Superior alternative: maintain separate signed manifests: `code-manifest.json` and `kb-manifest.json`. The code manifest declares hook/MCP compatibility; the KB manifest declares data schema compatibility. The active pointer binds a compatible pair.
+
+29. **MINOR — Tests currently encode sequential MCP behavior and would not catch hot-swap bugs.**
+
+   `plugin/test/run-tests.mjs` says requests are sent sequentially, “the way a real MCP client behaves” according to its comment. ADR-0023’s proxy would need tests for duplicate ids, concurrent requests, child restart during request, notifications, and reload boundaries. Existing tests will give false confidence.
+
+   Superior alternative: add a protocol test harness with a fake child MCP server and scripted JSON-RPC traffic. Assert the proxy never leaks the replayed initialize response and never breaks client id continuity.
+
+30. **MINOR — The hook shell assumes `/bin/bash`, while several scripts claim `/bin/sh`.**
+
+   `session-start.sh` declares `#!/bin/sh`, but hooks execute it with `/bin/bash` (`hooks.json:11`, `:21`). A stable shim should not perpetuate this ambiguity. The health gate should validate under the actual interpreter used in the hook declaration, not merely `bash -n every hook script`.
+
+   Superior alternative: each hook entry in the dispatch table should name its interpreter. Validate with that interpreter and with representative stdin.
+
+## Simpler Architecture I Would Prefer
+
+The strictly better version is a stable Node shell, not a symlink-centered shell:
+
+1. Freeze only these boot declarations in the Claude Code plugin: hook commands call `node ${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs <hook-id>`, and `.mcp.json` calls `node ${CLAUDE_PLUGIN_ROOT}/mcp/server.mjs`.
+2. Store active state in `~/.cache/ruvnet-brain/active.json`, atomically written by temp-file + rename. It names `codeRoot`, `kbRoot`, generation, version, digest, previous, compatibility range, and signed manifest receipt.
+3. Install code to immutable `~/.cache/ruvnet-brain/versions/<digest>/`. Install KB data to immutable `~/.cache/ruvnet-brain/kb-versions/<digest>/` or keep `kb/current-data` as a separate pointer. Never mutate the active tree.
+4. Use one updater implementation for install, manual update, session-triggered update, and nightly update. It must acquire a lock, download, verify signed manifest and artifact, extract to staging, run health gates, rename staging to immutable final, then update `active.json`.
+5. Make the MCP server stable and fixed-schema. On `search_ruvnet`, it reads `active.json` and delegates to the active implementation. If keeping a warm worker is required, the worker should speak a private request protocol; do not replay external MCP handshakes.
+6. Treat restart truthfully: any change to `hooks.json`, `.mcp.json`, command/skill declarations, hook shim, or stable MCP server requires a restart. Everything else is body code/data and can update behind `active.json`.
+
+This keeps the good idea from ADR-0023, removes Windows symlink dependency, avoids MCP handshake replay, gives crash consistency, and creates one control plane that release gates can actually test.
+

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "3.4.16-dev",
+    "softwareVersion": "3.4.17-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-16",
     "description": "A downloadable, source-grounded brain for Claude Code that grounds the AI in rUv's real RuvNet source — RuVector/RVF, ruflo, AgentDB, RuLake, SPARC and 57 indexed repos — and pre-implements two of rUv's hardest tools so you can run them in plain English: MetaHarness (harness self-improvement + cost-optimal model routing, ~56x cheaper than frontier-only) and an Agentic-QE testing fleet. Ships the search_ruvnet MCP tool plus grounding hooks.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.4.16-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.4.17-dev</p>
     </div>
   </div>
 

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "3.4.16-dev",
+  "version": "3.4.17-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.4.16-dev",
+  "version": "3.4.17-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 57 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit grounding hook so the model can't drift.",
-  "version": "3.4.16-dev",
+  "version": "3.4.17-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Three hooks. SessionStart (session-start.sh) is the CONFIDENCE SIGNAL \u2014 on a new/resumed session it tells the model to surface a brief 'brain active, user-level, here's how to use it' confirmation so the user KNOWS it's on. UserPromptSubmit (ground-ruvnet.sh) intercepts at the INTENT level \u2014 grounding directive on rUv-stack prompts, a drift gate on classical defaults (fires even with no RuvNet mention), and a TAKE-THE-WHEEL directive on build requests (propose the architecture + why \u2192 one go/no-go \u2192 orchestrate end-to-end with SPARC/Ruflo/parallel agents/AgentDB). PreToolUse (hijack-ruvnet.sh) intercepts at the ACTION level \u2014 when Claude is about to Write/Edit/Bash a classical default it injects the rUv replacement via additionalContext WITHOUT blocking. stdout from these hooks is how the brain makes grounding + orchestration non-optional. The first three scripts exit 0 and are guarded with `|| true` so they can never block a turn. route-dispatch.sh (PreToolUse on Task) is the DELIBERATE EXCEPTION: it exits 2 to BLOCK a subagent dispatch that declares no `model`, because such an agent silently INHERITS the session model (10 agents on a Fable session = 10 agents at $10/$50 per Mtok). Inheritance-by-omission was the biggest cost leak in the harness; an advisory rule did not fix it, so this is a wall, not advice. It is NOT guarded with `|| true` \u2014 swallowing its exit code would restore the bug.",
+  "_note": "STABLE SPINE (ADR-023): every hook routes through hook-shim.mjs, which resolves the ACTIVE generation from ~/.cache/ruvnet-brain/active.json per invocation and executes the hook BODY from that immutable tree — so hook behavior updates the moment update-apply.mjs flips the pointer, with NO Claude Code restart. This file itself is boot-frozen (CC reads it once at startup): its matchers/timeouts and the shim's dispatch table are the near-frozen SHELL — changing them is rare and honestly flagged requiresRestart by the release classifier. Advisory hooks keep `|| true` (they can never block a turn). The THREE blocking hooks (route-dispatch, verify-interface, design-wall) have NO `|| true` — the shim propagates their exact exit codes by typed contract (mode:'blocking' in its table); route-dispatch's deliberate exit-2 wall against model-inheriting subagent fan-outs survives the indirection. Hook semantics themselves are unchanged from the pre-spine file: SessionStart = confidence signal, UserPromptSubmit = intent-level grounding/drift/take-the-wheel, PreToolUse = action-level interception, PostToolUse/SessionEnd = learning capture/flush.",
   "_platform": "posix",
   "hooks": {
     "SessionStart": [
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" session-start || true",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" session-start || true",
             "timeout": 5
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/ground-ruvnet.sh\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" ground-ruvnet || true",
             "timeout": 5
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/hijack-ruvnet.sh\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" hijack-ruvnet || true",
             "timeout": 5
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/route-dispatch.sh\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" route-dispatch",
             "timeout": 5
           }
         ]
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-interface.sh\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" verify-interface",
             "timeout": 5
           }
         ]
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/design-wall.sh\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" design-wall",
             "timeout": 5
           }
         ]
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/bash \"${CLAUDE_PLUGIN_ROOT}/scripts/learn-capture.sh\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" learn-capture || true",
             "timeout": 5
           }
         ]
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/learn-flush.mjs\" || true",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs\" learn-flush || true",
             "timeout": 30
           }
         ]

--- a/plugin/mcp/server.mjs
+++ b/plugin/mcp/server.mjs
@@ -1,43 +1,173 @@
 #!/usr/bin/env node
-// ruvnet-brain MCP launcher.
-// Resolves (or, when published, fetches) the RuvNet brain bundle, then runs the brain's own
-// stdio MCP server (forge-mcp-all.mjs, tool: search_ruvnet) as a transparent stdio proxy.
+// ruvnet-brain MCP server — the Stable Spine's protocol shell (ADR-023 §4, v2 post-red-team).
 //
-// Brain location resolution order:
-//   1) $RUVNET_BRAIN_KB                          (explicit override — used for local/dev)
-//   2) $RUVNET_BRAIN_HOME/kb                      (custom home)
-//   3) ~/.cache/ruvnet-brain/kb                   (default install cache)
-// Model cache: $KB_MODEL_CACHE, else <home>/models (first query downloads HF models there).
+// v1 was a launcher: spawn forge-mcp-all.mjs with stdio:'inherit' and get out of the way. That froze
+// search_ruvnet's behavior at session start. v2 makes THIS process the stable protocol owner:
 //
-// Phase 3 (publish): if the brain is absent and $RUVNET_BRAIN_RELEASE is set, download+unzip
-// the release bundle into the cache before launching. Until then we fail loudly with guidance.
+//   • The CLIENT connection (Claude Code ⇄ this process) is never proxied, dropped, or replayed.
+//     This file answers initialize / ping / tools/list itself and owns every client id.
+//   • The BRAIN runs in a warm CHILD (the KB's own forge-mcp-all.mjs, unchanged) that this process
+//     supervises over a PRIVATE handshake: parent sends its OWN initialize with parent-allocated
+//     ids and forwards tools/call with id remapping — the client's handshake is never replayed to
+//     anyone (red-team findings 7/8: no external-handshake replay, ids remapped both directions).
+//   • HOT SWAP: between requests (never mid-flight — finding 9: swap only when pendingCount === 0),
+//     the child is respawned when the spine generation changes (active.json) or the brain's own
+//     code file changed on disk (KB-track update). The NEXT call answers from the new brain; a call
+//     in flight completes on the old one. Claude Code notices nothing.
+//   • LEASE (finding 23): this process leases the generation it serves (leases/mcp-<pid>.json,
+//     refreshed per call) so update-apply.mjs --gc never collects a tree still being served.
+//   • Child death: pending calls get a JSON-RPC error (never a parent exit); the child respawns
+//     lazily on the next call. If the brain is absent entirely, tools/call returns an honest
+//     soft-error tool result with install guidance — the tool stays registered, never vanishes.
+//
+// Brain location resolution (unchanged from v1):
+//   1) $RUVNET_BRAIN_KB   2) $RUVNET_BRAIN_HOME/kb   3) ~/.cache/ruvnet-brain/kb
+// Model cache: $KB_MODEL_CACHE, else <home>/models.
+//
+// SHELL CONTRACT: this file is boot-frozen (CC spawns it once per session). Changing IT — or the
+// tool's declared name/schema — is a shell change, honestly flagged requiresRestart by the release
+// classifier. Everything it delegates to updates hot.
+
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import readline from 'node:readline';
 
-const HOME = process.env.RUVNET_BRAIN_HOME || path.join(os.homedir(), '.cache', 'ruvnet-brain');
-const KB = process.env.RUVNET_BRAIN_KB || path.join(HOME, 'kb');
-const MCP = path.join(KB, 'forge-mcp-all.mjs');
+const BRAIN_HOME = process.env.RUVNET_BRAIN_HOME || path.join(os.homedir(), '.cache', 'ruvnet-brain');
+const KB = process.env.RUVNET_BRAIN_KB || path.join(BRAIN_HOME, 'kb');
+const CHILD_MCP = path.join(KB, 'forge-mcp-all.mjs');
+const ACTIVE = path.join(BRAIN_HOME, 'active.json');
+const LEASES = path.join(BRAIN_HOME, 'leases');
+const LEASE = path.join(LEASES, `mcp-${process.pid}.json`);
 
-function die(msg) {
-  process.stderr.write(`[ruvnet-brain] ${msg}\n`);
-  process.exit(1);
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_INFO = { name: 'ruvnet-brain', version: '2.0.0' };
+// Static fallback tool declaration — same name + inputSchema the brain declares (the SCHEMA is the
+// frozen contract; the description is data and is refreshed from the live child when one is up).
+const FALLBACK_TOOLS = [{
+  name: 'search_ruvnet',
+  description: 'Source-grounded knowledge base for the RuvNet ecosystem. (Brain bundle not installed on this machine — calls will return install guidance.)',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Natural-language question or keywords about any part of RuvNet.' },
+      k: { type: 'integer', description: 'Number of documents to return (default 6).', default: 6 },
+    },
+    required: ['query'],
+  },
+}];
+
+const out = (obj) => process.stdout.write(JSON.stringify(obj) + '\n');
+const clientOk = (id, result) => out({ jsonrpc: '2.0', id, result });
+const clientErr = (id, code, message) => out({ jsonrpc: '2.0', id, error: { code, message } });
+const readJSON = (f) => { try { return JSON.parse(fs.readFileSync(f, 'utf8')); } catch { return null; } };
+
+function currentGeneration() {
+  const a = readJSON(ACTIVE);
+  let brainMtime = 0;
+  try { brainMtime = fs.statSync(CHILD_MCP).mtimeMs; } catch { /* brain absent */ }
+  return `${a?.generation ?? 0}:${brainMtime}`;
+}
+function refreshLease() {
+  try {
+    fs.mkdirSync(LEASES, { recursive: true });
+    fs.writeFileSync(LEASE, JSON.stringify({ pid: process.pid, version: readJSON(ACTIVE)?.version ?? null, at: new Date().toISOString() }));
+  } catch { /* lease is best-effort */ }
+}
+process.on('exit', () => { try { fs.rmSync(LEASE, { force: true }); } catch { /* gone */ } });
+
+// ── the warm child + private protocol ───────────────────────────────────────────────────────────
+let child = null;            // { proc, generation, nextId, pending: Map<childId, {resolve, reject}> }
+let pendingCount = 0;        // client tools/call requests currently in flight (drain gate for swaps)
+
+function killChild(reason) {
+  if (!child) return;
+  const c = child; child = null;
+  for (const [, p] of c.pending) p.reject(new Error(`brain worker ${reason}`));
+  c.pending.clear();
+  try { c.proc.kill('SIGTERM'); } catch { /* already dead */ }
 }
 
-if (!fs.existsSync(MCP)) {
-  die(
-    `brain not found at ${KB}.\n` +
-      `  • dev/local: set RUVNET_BRAIN_KB to your brain's kb dir (the one with forge-mcp-all.mjs), or\n` +
-      `    symlink it:  mkdir -p ${HOME} && ln -s /path/to/ruvnet-brain/kb ${KB}\n` +
-      `  • published: this will fetch the brain bundle from the GitHub Release automatically (Phase 3).`,
-  );
+async function ensureChild() {
+  const gen = currentGeneration();
+  if (child && child.generation !== gen && pendingCount === 0) killChild('superseded by a newer generation');
+  if (child) return child;
+  if (!fs.existsSync(CHILD_MCP)) return null;
+
+  const env = { ...process.env, KB_DIR: KB };
+  if (!env.KB_MODEL_CACHE) env.KB_MODEL_CACHE = path.join(BRAIN_HOME, 'models');
+  const proc = spawn(process.execPath, [CHILD_MCP], { stdio: ['pipe', 'pipe', 'inherit'], env });
+  const c = { proc, generation: gen, nextId: 1, pending: new Map() };
+  const rl = readline.createInterface({ input: proc.stdout });
+  rl.on('line', (line) => {
+    let msg; try { msg = JSON.parse(line); } catch { return; }
+    const waiter = c.pending.get(msg.id);
+    if (waiter) { c.pending.delete(msg.id); waiter.resolve(msg); }
+  });
+  proc.on('exit', () => { if (child === c) child = null; for (const [, p] of c.pending) p.reject(new Error('brain worker exited')); c.pending.clear(); });
+  proc.on('error', () => { if (child === c) child = null; });
+  child = c;
+
+  // PRIVATE handshake — parent-owned id, never the client's (finding 8).
+  try { await childRequest(c, 'initialize', { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'ruvnet-brain-shell', version: SERVER_INFO.version } }, 10_000); }
+  catch { killChild('failed initialize'); return null; }
+  return c;
 }
 
-const env = { ...process.env, KB_DIR: KB };
-if (!env.KB_MODEL_CACHE) env.KB_MODEL_CACHE = path.join(HOME, 'models');
+function childRequest(c, method, params, timeoutMs = 120_000) {
+  return new Promise((resolve, reject) => {
+    const id = c.nextId++;
+    const timer = setTimeout(() => { c.pending.delete(id); reject(new Error(`brain worker timeout on ${method}`)); }, timeoutMs);
+    c.pending.set(id, { resolve: (m) => { clearTimeout(timer); resolve(m); }, reject: (e) => { clearTimeout(timer); reject(e); } });
+    try { c.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'); }
+    catch (e) { clearTimeout(timer); c.pending.delete(id); reject(e); }
+  });
+}
 
-// Transparent stdio proxy — the brain's MCP server speaks JSON-RPC on stdin/stdout.
-const child = spawn('node', [MCP], { stdio: 'inherit', env });
-child.on('error', (e) => die(`failed to launch brain MCP server: ${e.message}`));
-child.on('exit', (code) => process.exit(code ?? 0));
+// ── client protocol ─────────────────────────────────────────────────────────────────────────────
+async function handleClient(msg) {
+  const { id, method, params } = msg;
+  if (id === undefined || id === null) return; // notifications need no answer
+  switch (method) {
+    case 'initialize':
+      return clientOk(id, { protocolVersion: PROTOCOL_VERSION, capabilities: { tools: {} }, serverInfo: SERVER_INFO });
+    case 'ping':
+      return clientOk(id, {});
+    case 'tools/list': {
+      const c = await ensureChild();
+      if (c) {
+        try { const r = await childRequest(c, 'tools/list', {}, 15_000); if (r.result?.tools?.length) return clientOk(id, r.result); }
+        catch { /* fall through to the static declaration */ }
+      }
+      return clientOk(id, { tools: FALLBACK_TOOLS });
+    }
+    case 'tools/call': {
+      if (params?.name !== 'search_ruvnet') return clientErr(id, -32602, `unknown tool: ${params?.name}`);
+      refreshLease();
+      const c = await ensureChild();
+      if (!c) {
+        return clientOk(id, { content: [{ type: 'text', text: `search_ruvnet error: the brain bundle is not installed at ${KB}. Install it with: npx github:stuinfla/ruvnet-brain  (or set RUVNET_BRAIN_KB to your brain's kb dir).` }], isError: true });
+      }
+      pendingCount++;
+      try {
+        const r = await childRequest(c, 'tools/call', params);
+        if (r.error) return clientErr(id, r.error.code ?? -32603, r.error.message ?? 'brain worker error');
+        return clientOk(id, r.result);
+      } catch (e) {
+        return clientOk(id, { content: [{ type: 'text', text: `search_ruvnet error: ${e.message}` }], isError: true });
+      } finally {
+        pendingCount--;
+      }
+    }
+    default:
+      return clientErr(id, -32601, `unknown method: ${method}`);
+  }
+}
+
+const clientRl = readline.createInterface({ input: process.stdin });
+clientRl.on('line', (line) => {
+  let msg; try { msg = JSON.parse(line); } catch { return; } // malformed line: ignore, never crash
+  handleClient(msg).catch((e) => { if (msg.id !== undefined && msg.id !== null) clientErr(msg.id, -32603, e.message); });
+});
+clientRl.on('close', () => { killChild('client disconnected'); process.exit(0); });

--- a/plugin/scripts/hook-shim.mjs
+++ b/plugin/scripts/hook-shim.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// hook-shim.mjs — the Stable Spine's hook dispatcher (ADR-023, docs/INTELLIGENT-UPDATING.md §3).
+//
+// THE ONE JOB: make hook BEHAVIOR update without a Claude Code restart. CC freezes
+// ${CLAUDE_PLUGIN_ROOT} at boot (a version-named cache dir), so any hook command pointing there is
+// trapped at the boot-time version. This shim is the only thing hooks.json points at; it resolves
+// the ACTIVE generation from ~/.cache/ruvnet-brain/active.json ONCE per invocation and executes the
+// hook body from that immutable versions/<v>/ tree. Update = rewrite active.json (atomic, by
+// scripts/update-apply.mjs) → the very next hook fire runs the new code. No restart.
+//
+// SHELL CONTRACT (this file is boot-frozen — treat as near-frozen ABI, per DDD-0003):
+//   • Self-contained: node:fs/path/child_process only, no imports from the body.
+//   • Typed dispatch table (red-team findings 15/16/30): each hook declares its file, interpreter,
+//     and mode. `blocking` hooks propagate their exact exit code (route-dispatch's deliberate
+//     exit-2 wall survives by CONTRACT); `advisory` hooks can never block a turn — any failure,
+//     including a missing file, exits 0.
+//   • Containment (finding 13): a codeRoot is honored ONLY if it resolves under
+//     ~/.cache/ruvnet-brain/versions/ — or is the explicit dev-mode checkout declared in
+//     ~/.cache/ruvnet-brain/dev.json (finding 24).
+//   • Loud fallback (finding 25): no spine / broken spine / missing body file → run the sibling in
+//     ${CLAUDE_PLUGIN_ROOT} AND emit one stderr line naming the frozen fallback, so a broken spine
+//     can never masquerade as health. First-install (spine never seeded) stays quiet.
+//   • Per-invocation consistency (finding 14, accepted middle): active.json is read once; the whole
+//     invocation runs from one immutable tree — a hook never straddles two generations.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const BRAIN_HOME = process.env.RUVNET_BRAIN_HOME || path.join(os.homedir(), '.cache', 'ruvnet-brain');
+const ACTIVE = path.join(BRAIN_HOME, 'active.json');
+const DEV = path.join(BRAIN_HOME, 'dev.json');
+const VERSIONS = path.join(BRAIN_HOME, 'versions');
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+// The dispatch table — hook id → { file (relative to <codeRoot>/plugin/scripts), interpreter, mode }.
+// Adding a hook here is a SHELL change (requiresRestart); changing a hook's BODY never is.
+const TABLE = {
+  'session-start':    { file: 'session-start.sh',    interpreter: 'bash', mode: 'advisory' },
+  'ground-ruvnet':    { file: 'ground-ruvnet.sh',    interpreter: 'bash', mode: 'advisory' },
+  'hijack-ruvnet':    { file: 'hijack-ruvnet.sh',    interpreter: 'bash', mode: 'advisory' },
+  'route-dispatch':   { file: 'route-dispatch.sh',   interpreter: 'bash', mode: 'blocking' },
+  'verify-interface': { file: 'verify-interface.sh', interpreter: 'bash', mode: 'blocking' },
+  'design-wall':      { file: 'design-wall.sh',      interpreter: 'bash', mode: 'blocking' },
+  'learn-capture':    { file: 'learn-capture.sh',    interpreter: 'bash', mode: 'advisory' },
+  'learn-flush':      { file: 'learn-flush.mjs',     interpreter: 'node', mode: 'advisory' },
+};
+
+const hookId = process.argv[2];
+const entry = TABLE[hookId];
+if (!entry) {
+  process.stderr.write(`[hook-shim] unknown hook id: ${JSON.stringify(hookId)} — known: ${Object.keys(TABLE).join(', ')}\n`);
+  process.exit(0); // an unknown id is a shell bug, but it must never block the user's turn
+}
+
+/** Resolve the active code root. Returns { root, source } or null (→ fallback). */
+function resolveCodeRoot() {
+  // Dev mode wins when explicitly declared and the target still looks like the checkout it names.
+  try {
+    const dev = JSON.parse(fs.readFileSync(DEV, 'utf8'));
+    if (dev && dev.codeRoot && fs.existsSync(path.join(dev.codeRoot, 'scripts'))) {
+      return { root: dev.codeRoot, source: 'dev' };
+    }
+  } catch { /* no dev mode */ }
+  try {
+    const active = JSON.parse(fs.readFileSync(ACTIVE, 'utf8'));
+    if (!active || typeof active.codeRoot !== 'string') return null;
+    const root = path.isAbsolute(active.codeRoot) ? active.codeRoot : path.join(BRAIN_HOME, active.codeRoot);
+    const real = fs.realpathSync(root);
+    // Containment: only ever execute from the immutable version store.
+    if (!real.startsWith(fs.realpathSync(VERSIONS) + path.sep)) return null;
+    return { root: real, source: `gen ${active.generation ?? '?'}` };
+  } catch { return null; }
+}
+
+// Run one hook body. No shell is ever involved: spawnSync with an argument array, interpreter
+// chosen from the typed table — never from input.
+function runHook(file) {
+  if (!fs.existsSync(file)) return 0; // nothing to run — never invent a failure
+  const cmd = entry.interpreter === 'node' ? process.execPath : '/bin/bash';
+  const r = spawnSync(cmd, [file], { stdio: 'inherit', env: process.env });
+  if (r.error) {
+    process.stderr.write(`[hook-shim] ${entry.file}: ${r.error.message}\n`);
+    return entry.mode === 'blocking' ? 1 : 0;
+  }
+  // Blocking hooks: the exit code IS the contract (route-dispatch's exit-2 wall). Advisory: always 0.
+  return entry.mode === 'blocking' ? (r.status ?? 0) : 0;
+}
+
+const FALLBACK_FILE = path.join(PLUGIN_ROOT, 'scripts', entry.file);
+const spine = resolveCodeRoot();
+if (spine) {
+  // codeRoot IS a plugin-payload root (versions/<v>/ mirrors the plugin dir: scripts/, hooks/, mcp/).
+  const spineFile = path.join(spine.root, 'scripts', entry.file);
+  if (fs.existsSync(spineFile)) {
+    process.exit(runHook(spineFile));
+  }
+  // Spine resolved but the body file is missing — fall back LOUDLY (finding 25).
+  process.stderr.write(`[hook-shim] spine (${spine.source}) missing ${entry.file} — falling back to frozen plugin\n`);
+  process.exit(runHook(FALLBACK_FILE));
+} else {
+  // No spine at all. First-install is the normal quiet case; a previously-seeded-but-broken spine
+  // still lands here — the seed marker distinguishes them so breakage is loud, first-run silent.
+  if (fs.existsSync(path.join(BRAIN_HOME, '.spine-seeded'))) {
+    process.stderr.write(`[hook-shim] spine unreadable — running frozen plugin fallback (run: node scripts/update-apply.mjs --doctor)\n`);
+  }
+  process.exit(runHook(FALLBACK_FILE));
+}

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -197,6 +197,27 @@ if [ ! -f "$PREF_FILE" ]; then
   echo ""
 fi
 
+# ── STABLE SPINE (ADR-023): seed on first run; honest restart notice only when the SHELL changed ──
+SPINE_HOME="$HOME/.cache/ruvnet-brain"
+if command -v node >/dev/null 2>&1 && [ -f "$(dirname "$0")/update-apply.mjs" ]; then
+  if [ ! -f "$SPINE_HOME/active.json" ]; then
+    # Zero-step migration: seed the spine from THIS running plugin install, detached + engine-locked.
+    ( node "$(dirname "$0")/update-apply.mjs" --seed >"$SPINE_HOME/.seed.log" 2>&1 ) &
+  else
+    # The ONE honest nag (replaces the old every-session "restart to load"): fires ONLY when the
+    # active generation changed boot-frozen declarations vs what this CC process booted with.
+    SPINE_V=$(grep -m1 '"version"' "$SPINE_HOME/active.json" 2>/dev/null | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+    SHELL_CHANGED=$(grep -m1 '"shellChanged"' "$SPINE_HOME/active.json" 2>/dev/null | grep -c 'true' || true)
+    BOOT_V=""
+    [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json" ] && \
+      BOOT_V=$(grep -m1 '"version"' "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+    if [ "$SHELL_CHANGED" = "1" ] && [ -n "$BOOT_V" ] && [ -n "$SPINE_V" ] && [ "$BOOT_V" != "$SPINE_V" ]; then
+      echo "[RuvNet Brain — v$SPINE_V changed boot-level declarations (the rare case); this session booted v$BOOT_V's]"
+      echo "Tell the user ONE line: \"🧠 RuvNet Brain v$SPINE_V changed a boot-level declaration — one restart picks it up (\`claude --continue\` keeps this whole conversation). Everything else already updated live.\""
+    fi
+  fi
+fi
+
 # Check EVERY session start, deduped to once per 15 min (a burst of window-opens = one check).
 # The check is a single 3s-capped fetch of a ~1KB raw file — negligible. The old ~20h limit meant
 # a release shipped an hour after your last check stayed invisible until TOMORROW — day-long
@@ -231,13 +252,19 @@ if [ "$NOW" -gt 0 ] && [ $((NOW - LAST)) -gt 900 ]; then
   if [ -n "$LOCAL_V" ] && [ -n "$REMOTE_V" ] && [ "$LOCAL_V" != "$REMOTE_V" ]; then
     AUTO_PREF=$(cat "$PREF_FILE" 2>/dev/null || echo "")
     if [ "$AUTO_PREF" = "yes" ] && command -v claude >/dev/null 2>&1; then
+      # STABLE SPINE (ADR-023): download via CC's trusted marketplace path as before, then hand the
+      # staged payload to the ONE update engine — gate, atomic active.json flip, receipt. Hook
+      # BEHAVIOR from the new version goes live in THIS session on the very next hook fire; the MCP
+      # worker swaps between calls. The engine is locked (concurrency-1 across all sessions) and
+      # detached — this hook never blocks on it.
       ( claude plugin marketplace update ruvnet-brain >"$STATE_DIR/.last-auto-update.log" 2>&1
         claude plugin update ruvnet-brain@ruvnet-brain >>"$STATE_DIR/.last-auto-update.log" 2>&1
+        node "$(dirname "$0")/update-apply.mjs" --auto >>"$STATE_DIR/.last-auto-update.log" 2>&1
       ) &
-      echo "[RuvNet Brain — downloading v$REMOTE_V in the background; THIS SESSION STILL RUNS v$LOCAL_V]"
-      echo "Tell the user this PLAINLY, near the top of your first response — be exact about running vs staged, never imply the new version is active:"
-      echo "  \"🧠 You're running RuvNet Brain v$LOCAL_V. I found v$REMOTE_V and I'm downloading it in the background now — when it finishes it will be STAGED, not active. Loading it costs you nothing: exit and run \`claude --continue\` (or reopen and resume this session) — your whole conversation comes right back, on the new version. I can't hot-swap myself in memory (Claude Code loads plugins only at process start), but with --continue a restart loses nothing. Or just keep working on v$LOCAL_V and it loads whenever you next restart naturally.\""
-      echo "If the user asks which version they're on at any point, the answer is v$LOCAL_V until they restart. Don't repeat this notice later in the same session."
+      echo "[RuvNet Brain — v$REMOTE_V is downloading and will AUTO-APPLY via the Stable Spine (ADR-023); this session picks up the new behavior live]"
+      echo "Tell the user ONE short line, near the top of your first response:"
+      echo "  \"🧠 RuvNet Brain v$REMOTE_V is installing in the background — behavior updates go live in this session automatically (no restart). If this release changed boot-level declarations, I'll tell you at your next session start — that's the only case a restart ever helps.\""
+      echo "Don't repeat this notice later in the same session."
       echo ""
     else
       echo "[RuvNet Brain — update available, auto-update not enabled]"

--- a/plugin/scripts/update-apply.mjs
+++ b/plugin/scripts/update-apply.mjs
@@ -105,9 +105,14 @@ function gateCandidate(dir) {
   if (fs.existsSync(hooksJson)) {
     try { JSON.parse(fs.readFileSync(hooksJson, 'utf8')); } catch (e) { problems.push(`hooks.json unparseable: ${e.message}`); }
   }
+  // Interpreter-true, platform-honest: bash-check .sh only where /bin/bash exists (the hooks are
+  // "_platform":"posix"-declared — on Windows they never execute, so a bash syntax check there
+  // would be checking with an interpreter the machine doesn't have). node --check gates everywhere.
+  const haveBash = fs.existsSync('/bin/bash');
   for (const f of fs.existsSync(scripts) ? fs.readdirSync(scripts) : []) {
     const p = path.join(scripts, f);
     if (f.endsWith('.sh')) {
+      if (!haveBash) continue;
       const r = spawnSync('/bin/bash', ['-n', p], { encoding: 'utf8' });
       if (r.status !== 0) problems.push(`bash -n ${f}: ${(r.stderr || '').trim()}`);
     } else if (f.endsWith('.mjs') || f.endsWith('.js')) {

--- a/plugin/scripts/update-apply.mjs
+++ b/plugin/scripts/update-apply.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// update-apply.mjs — THE single writer of the Stable Spine (ADR-023, docs/INTELLIGENT-UPDATING.md,
+// DDD-0003 INV-2). Every path that changes what code runs — seed/migration, unattended session
+// update, manual apply, rollback, dev mode, GC — goes through here, under one lock, with a
+// persisted transaction record. Consumers (hook-shim.mjs, mcp/server.mjs) only ever READ.
+//
+//   node scripts/update-apply.mjs --seed              # migrate: seed the spine from the running plugin install
+//   node scripts/update-apply.mjs --auto              # unattended: newest CC-staged plugin version → gate → flip
+//   node scripts/update-apply.mjs --from-dir <path>   # apply a specific plugin payload dir
+//   node scripts/update-apply.mjs --rollback          # flip back to `previous` (instant)
+//   node scripts/update-apply.mjs --dev [pluginDir]   # dev mode: point codeRoot at a git checkout's plugin/
+//   node scripts/update-apply.mjs --dev-off
+//   node scripts/update-apply.mjs --gc                # collect unreferenced generations (leases respected)
+//   node scripts/update-apply.mjs --doctor            # report spine state, honestly
+//
+// Layout under ~/.cache/ruvnet-brain/ (all writes atomic temp+rename; NO symlinks — works
+// unprivileged on macOS/Linux/Windows, red-team finding 6):
+//   active.json          { generation, version, codeRoot, previous:{...}, flippedAt }
+//   versions/<v>/        immutable plugin-payload copies (scripts/, hooks/, mcp/, …)
+//   .update.lock/        mkdir-atomic lock dir (owner.json inside; stale-pid reclaimed) [finding 5]
+//   update-txn.json      transaction record; crash recovery is deterministic            [finding 21]
+//   update-receipts.jsonl  append-only ledger of every check/gate/flip/rollback
+//   leases/<gen>.json    consumers lease the generation they serve; GC never collects a fresh lease [finding 23]
+//   dev.json             opt-in dev-mode marker; --auto NEVER flips away from dev        [finding 24]
+//
+// TRUST BOUNDARY for unattended applies (findings 10/11, honest v1 scope): --auto applies ONLY
+// version dirs that Claude Code's own marketplace update already staged locally (integrity: GitHub
+// over TLS + CC's git clone of the marketplace). Applying a downloaded BUNDLE unattended requires
+// the Ed25519-signed path (bin/install.mjs owns the key) and is wired there, not here. --from-dir
+// is interactive-only by definition (a human typed the path).
+//
+// This engine NEVER touches kb/ (DDD-0003 INV-6): KB data has its own lifecycle and fence.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const BRAIN_HOME = process.env.RUVNET_BRAIN_HOME || path.join(os.homedir(), '.cache', 'ruvnet-brain');
+const ACTIVE = path.join(BRAIN_HOME, 'active.json');
+const VERSIONS = path.join(BRAIN_HOME, 'versions');
+const LOCK = path.join(BRAIN_HOME, '.update.lock');
+const TXN = path.join(BRAIN_HOME, 'update-txn.json');
+const RECEIPTS = path.join(BRAIN_HOME, 'update-receipts.jsonl');
+const LEASES = path.join(BRAIN_HOME, 'leases');
+const DEV = path.join(BRAIN_HOME, 'dev.json');
+const SEEDED = path.join(BRAIN_HOME, '.spine-seeded');
+const CC_PLUGIN_CACHE = path.join(os.homedir(), '.claude', 'plugins', 'cache', 'ruvnet-brain', 'ruvnet-brain');
+const LEASE_FRESH_MS = 6 * 3600_000; // a lease older than 6h is stale (its process is long gone)
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const val = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : d; };
+
+// ── atomic primitives ────────────────────────────────────────────────────────────────────────────
+function writeAtomic(file, content) {
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, content);
+  fs.renameSync(tmp, file); // atomic on macOS/Linux/Windows
+}
+function readJSON(file) { try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; } }
+function receipt(event, data) {
+  try { fs.appendFileSync(RECEIPTS, JSON.stringify({ ts: new Date().toISOString(), event, ...data }) + '\n'); } catch { /* ledger must not break the engine */ }
+}
+
+// ── the lock (finding 5): atomic mkdir; stale-pid reclaim (issue-fix.mjs house pattern) ──────────
+function acquireLock(target) {
+  fs.mkdirSync(BRAIN_HOME, { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      fs.mkdirSync(LOCK); // atomic: exists → EEXIST
+      writeAtomic(path.join(LOCK, 'owner.json'), JSON.stringify({ pid: process.pid, host: os.hostname(), target, startedAt: new Date().toISOString() }));
+      return true;
+    } catch {
+      const owner = readJSON(path.join(LOCK, 'owner.json'));
+      try { if (owner && owner.pid) { process.kill(owner.pid, 0); return false; } } catch { /* stale */ }
+      try { fs.rmSync(LOCK, { recursive: true, force: true }); } catch { /* race — retry once */ }
+    }
+  }
+  return false;
+}
+function releaseLock() { try { fs.rmSync(LOCK, { recursive: true, force: true }); } catch { /* gone */ } }
+
+// ── crash recovery (finding 21): resolve any incomplete transaction BEFORE new work ─────────────
+function recoverTxn() {
+  const txn = readJSON(TXN);
+  if (!txn || txn.state === 'active' || txn.state === 'rolled-back') return;
+  // candidate-ready but never flipped: the candidate dir is valid & gated — leave it (a future run
+  // may flip it); staging remnants are junk. Either way the active pointer was never touched, so
+  // the world is the OLD world. Clean staging, close the txn honestly.
+  for (const d of fs.existsSync(VERSIONS) ? fs.readdirSync(VERSIONS) : []) {
+    if (d.includes('.staging-')) { try { fs.rmSync(path.join(VERSIONS, d), { recursive: true, force: true }); } catch { /* best effort */ } }
+  }
+  writeAtomic(TXN, JSON.stringify({ ...txn, state: 'recovered-old-world', recoveredAt: new Date().toISOString() }));
+  receipt('TxnRecovered', { from: txn.state, target: txn.to });
+}
+
+// ── gates (finding 20): interpreter-true syntax + structural checks on the CANDIDATE ────────────
+function gateCandidate(dir) {
+  const problems = [];
+  const scripts = path.join(dir, 'scripts');
+  if (!fs.existsSync(scripts)) problems.push('no scripts/ dir — not a plugin payload');
+  const hooksJson = path.join(dir, 'hooks', 'hooks.json');
+  if (fs.existsSync(hooksJson)) {
+    try { JSON.parse(fs.readFileSync(hooksJson, 'utf8')); } catch (e) { problems.push(`hooks.json unparseable: ${e.message}`); }
+  }
+  for (const f of fs.existsSync(scripts) ? fs.readdirSync(scripts) : []) {
+    const p = path.join(scripts, f);
+    if (f.endsWith('.sh')) {
+      const r = spawnSync('/bin/bash', ['-n', p], { encoding: 'utf8' });
+      if (r.status !== 0) problems.push(`bash -n ${f}: ${(r.stderr || '').trim()}`);
+    } else if (f.endsWith('.mjs') || f.endsWith('.js')) {
+      const r = spawnSync(process.execPath, ['--check', p], { encoding: 'utf8' });
+      if (r.status !== 0) problems.push(`node --check ${f}: ${(r.stderr || '').trim()}`);
+    }
+  }
+  return problems;
+}
+
+// ── copy a payload into an immutable version dir (staged; never into a live dir) ────────────────
+function stagePayload(srcDir, version) {
+  fs.mkdirSync(VERSIONS, { recursive: true });
+  const staging = path.join(VERSIONS, `${version}.staging-${process.pid}`);
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.cpSync(srcDir, staging, { recursive: true, dereference: true });
+  return staging;
+}
+function promote(staging, version) {
+  const finalDir = path.join(VERSIONS, version);
+  fs.rmSync(finalDir, { recursive: true, force: true }); // re-promote of same version is legal (idempotent)
+  fs.renameSync(staging, finalDir);
+  return finalDir;
+}
+
+// ── the flip: rewrite active.json (THE update) ──────────────────────────────────────────────────
+// The SHELL set — files Claude Code binds at boot. If none of these changed between generations,
+// the update is fully live with no restart and session-start stays silent; if any did, the ONE
+// honest nag fires (the release classifier computes the same thing publish-side; this is the
+// client-side truth for locally-applied generations). Red-team finding 18's client half.
+const SHELL_PATHS = ['hooks/hooks.json', 'scripts/hook-shim.mjs', 'mcp/server.mjs', '.mcp.json'];
+function shellDiff(prevRootAbs, nextRootAbs) {
+  const changed = [];
+  for (const rel of SHELL_PATHS) {
+    const a = (() => { try { return fs.readFileSync(path.join(prevRootAbs, rel), 'utf8'); } catch { return null; } })();
+    const b = (() => { try { return fs.readFileSync(path.join(nextRootAbs, rel), 'utf8'); } catch { return null; } })();
+    if (a !== b) changed.push(rel);
+  }
+  // skills/ and commands/ are boot-loaded markdown: any file-set or content difference counts.
+  for (const dir of ['skills', 'commands']) {
+    const list = (root) => { try { return fs.readdirSync(path.join(root, dir), { recursive: true }).sort().join('|'); } catch { return ''; } };
+    if (list(prevRootAbs) !== list(nextRootAbs)) changed.push(`${dir}/`);
+  }
+  return changed;
+}
+
+function flip(version, codeRootAbs, why) {
+  const prev = readJSON(ACTIVE);
+  const prevRootAbs = prev?.codeRoot ? (path.isAbsolute(prev.codeRoot) ? prev.codeRoot : path.join(BRAIN_HOME, prev.codeRoot)) : null;
+  const shellChanged = prevRootAbs && fs.existsSync(prevRootAbs) ? shellDiff(prevRootAbs, codeRootAbs) : [];
+  const next = {
+    generation: (prev?.generation ?? 0) + 1,
+    version,
+    codeRoot: path.relative(BRAIN_HOME, codeRootAbs),
+    previous: prev ? { generation: prev.generation, version: prev.version, codeRoot: prev.codeRoot } : null,
+    shellChanged: shellChanged.length > 0,
+    shellChangedPaths: shellChanged,
+    flippedAt: new Date().toISOString(),
+  };
+  writeAtomic(TXN, JSON.stringify({ state: 'flipping', from: prev?.version ?? null, to: version }));
+  writeAtomic(ACTIVE, JSON.stringify(next, null, 2));
+  writeAtomic(TXN, JSON.stringify({ state: 'active', from: prev?.version ?? null, to: version }));
+  try { fs.writeFileSync(SEEDED, next.flippedAt); } catch { /* marker best-effort */ }
+  receipt('SpineFlipped', { from: prev?.version ?? null, to: version, generation: next.generation, why });
+  console.log(`✓ spine flipped: ${prev?.version ?? '(none)'} → ${version} (generation ${next.generation}) — live on the next hook fire / MCP call`);
+  return next;
+}
+
+function applyFromDir(srcDir, version, why) {
+  writeAtomic(TXN, JSON.stringify({ state: 'staging', to: version }));
+  const staging = stagePayload(srcDir, version);
+  const problems = gateCandidate(staging);
+  receipt('CandidateGated', { version, passed: problems.length === 0, problems: problems.slice(0, 5) });
+  if (problems.length) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    writeAtomic(TXN, JSON.stringify({ state: 'gate-failed', to: version, problems: problems.slice(0, 5) }));
+    console.error(`✗ candidate ${version} FAILED the gate — spine untouched, users stay on the working version:`);
+    for (const p of problems) console.error(`  · ${p}`);
+    return false;
+  }
+  writeAtomic(TXN, JSON.stringify({ state: 'candidate-ready', to: version }));
+  const finalDir = promote(staging, version);
+  flip(version, finalDir, why);
+  return true;
+}
+
+// ── GC (finding 23): keep active + previous + fresh leases; collect the rest ────────────────────
+function gc() {
+  const active = readJSON(ACTIVE);
+  const keep = new Set();
+  if (active?.codeRoot) keep.add(path.basename(active.codeRoot));
+  if (active?.previous?.codeRoot) keep.add(path.basename(active.previous.codeRoot));
+  if (fs.existsSync(LEASES)) {
+    for (const f of fs.readdirSync(LEASES)) {
+      const p = path.join(LEASES, f);
+      try {
+        if (Date.now() - fs.statSync(p).mtimeMs < LEASE_FRESH_MS) {
+          const lease = readJSON(p);
+          if (lease?.version) keep.add(lease.version);
+        } else fs.rmSync(p, { force: true });
+      } catch { /* skip */ }
+    }
+  }
+  let removed = 0;
+  for (const d of fs.existsSync(VERSIONS) ? fs.readdirSync(VERSIONS) : []) {
+    if (!keep.has(d) && !d.includes('.staging-')) {
+      try { fs.rmSync(path.join(VERSIONS, d), { recursive: true, force: true }); removed++; } catch { /* busy */ }
+    }
+  }
+  receipt('GcRan', { kept: [...keep], removed });
+  console.log(`gc: kept ${[...keep].join(', ') || '(none)'} · removed ${removed}`);
+}
+
+// ── sources ─────────────────────────────────────────────────────────────────────────────────────
+function newestStagedCC() {
+  if (!fs.existsSync(CC_PLUGIN_CACHE)) return null;
+  const semverish = (v) => v.split(/[.-]/).map((x) => (Number.isFinite(+x) ? +x : x));
+  const cmp = (a, b) => { const A = semverish(a), B = semverish(b); for (let i = 0; i < Math.max(A.length, B.length); i++) { if ((A[i] ?? 0) === (B[i] ?? 0)) continue; if (typeof A[i] === 'number' && typeof B[i] === 'number') return A[i] - B[i]; return String(A[i] ?? '') < String(B[i] ?? '') ? -1 : 1; } return 0; };
+  const dirs = fs.readdirSync(CC_PLUGIN_CACHE).filter((d) => !d.startsWith('.') && fs.existsSync(path.join(CC_PLUGIN_CACHE, d, 'scripts')));
+  if (!dirs.length) return null;
+  dirs.sort(cmp);
+  const v = dirs[dirs.length - 1];
+  return { version: v, dir: path.join(CC_PLUGIN_CACHE, v) };
+}
+function versionOfPayload(dir, fallback) {
+  const pj = readJSON(path.join(dir, '.claude-plugin', 'plugin.json'));
+  return pj?.version || fallback;
+}
+
+// ── modes ───────────────────────────────────────────────────────────────────────────────────────
+function main() {
+  fs.mkdirSync(BRAIN_HOME, { recursive: true });
+
+  if (has('--doctor')) {
+    const active = readJSON(ACTIVE); const dev = readJSON(DEV); const txn = readJSON(TXN);
+    console.log('spine doctor —', BRAIN_HOME);
+    console.log('  active :', active ? `${active.version} (gen ${active.generation}, flipped ${active.flippedAt})` : 'NOT SEEDED — hooks run the frozen plugin fallback');
+    console.log('  prev   :', active?.previous ? `${active.previous.version} (gen ${active.previous.generation})` : '(none)');
+    console.log('  dev    :', dev ? `ON → ${dev.codeRoot}` : 'off');
+    console.log('  txn    :', txn ? txn.state : '(clean)');
+    console.log('  staged :', (() => { const s = newestStagedCC(); return s ? `${s.version} in CC plugin cache` : '(none found)'; })());
+    return 0;
+  }
+
+  if (has('--dev-off')) { fs.rmSync(DEV, { force: true }); receipt('DevOff', {}); console.log('dev mode OFF — active.json governs again'); return 0; }
+  if (has('--dev')) {
+    const target = path.resolve(val('--dev', path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'plugin')));
+    if (!fs.existsSync(path.join(target, 'scripts'))) { console.error(`✗ ${target} has no scripts/ — point --dev at a checkout's plugin/ dir`); return 1; }
+    writeAtomic(DEV, JSON.stringify({ codeRoot: target, setAt: new Date().toISOString() }, null, 2));
+    receipt('DevOn', { codeRoot: target });
+    console.log(`dev mode ON → ${target} (edits are live on save; --auto will never flip away; turn off: --dev-off)`);
+    return 0;
+  }
+
+  if (!acquireLock(argv.join(' '))) { console.log('another update is in progress — exiting (concurrency 1).'); return 0; }
+  try {
+    recoverTxn();
+
+    if (has('--rollback')) {
+      const active = readJSON(ACTIVE);
+      if (!active?.previous) { console.error('✗ nothing to roll back to (no previous generation recorded)'); return 1; }
+      const prevRoot = path.isAbsolute(active.previous.codeRoot) ? active.previous.codeRoot : path.join(BRAIN_HOME, active.previous.codeRoot);
+      if (!fs.existsSync(prevRoot)) { console.error(`✗ previous generation's payload is gone (${prevRoot}) — cannot roll back`); return 1; }
+      flip(active.previous.version, prevRoot, 'rollback');
+      receipt('RollbackFlipped', { to: active.previous.version });
+      return 0;
+    }
+
+    if (has('--seed')) {
+      const src = process.env.CLAUDE_PLUGIN_ROOT && fs.existsSync(path.join(process.env.CLAUDE_PLUGIN_ROOT, 'scripts'))
+        ? { dir: process.env.CLAUDE_PLUGIN_ROOT, version: versionOfPayload(process.env.CLAUDE_PLUGIN_ROOT, 'seeded') }
+        : (() => { const s = newestStagedCC(); return s ? { dir: s.dir, version: versionOfPayload(s.dir, s.version) } : null; })();
+      if (!src) { console.error('✗ nothing to seed from (no CLAUDE_PLUGIN_ROOT, no CC-staged version)'); return 1; }
+      return applyFromDir(src.dir, src.version, 'seed') ? 0 : 1;
+    }
+
+    if (has('--from-dir')) {
+      const dir = path.resolve(val('--from-dir'));
+      if (!dir || !fs.existsSync(dir)) { console.error('✗ --from-dir requires an existing payload dir'); return 1; }
+      return applyFromDir(dir, versionOfPayload(dir, `dir-${Date.now()}`), 'from-dir') ? 0 : 1;
+    }
+
+    // --auto (default): unattended — newest CC-staged version, only if newer than active.
+    const dev = readJSON(DEV);
+    if (dev) { receipt('AutoSkippedDev', {}); console.log('dev mode is ON — --auto never flips away from a checkout (finding 24).'); return 0; }
+    const staged = newestStagedCC();
+    const active = readJSON(ACTIVE);
+    if (!staged) { console.log('no CC-staged version found — nothing to apply.'); return 0; }
+    const stagedVersion = versionOfPayload(staged.dir, staged.version);
+    if (active && active.version === stagedVersion) { console.log(`already on ${stagedVersion} — nothing to do.`); return 0; }
+    receipt('UpdateChecked', { active: active?.version ?? null, staged: stagedVersion });
+    return applyFromDir(staged.dir, stagedVersion, active ? 'auto-update' : 'auto-seed') ? 0 : 1;
+  } finally {
+    releaseLock();
+    if (has('--gc') || !has('--no-gc')) { try { gc(); } catch { /* GC never fails the run */ } }
+  }
+}
+
+process.exit(main());

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v3.4.16-dev · Built: 2026-07-17 · Covers: 57/181 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v3.4.17-dev · Built: 2026-07-17 · Covers: 57/181 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/issue-fix.mjs
+++ b/scripts/issue-fix.mjs
@@ -390,11 +390,35 @@ export async function run({ dryRun = false, simulate = [], now = Date.now(), rep
     // (2026-07-17: this line used to hardcode 'completed' regardless of outcome — it marked 6 issues
     // done while producing zero branches/comments/logs. That is faking, not fixing. Never again.)
     const succeeded = SUCCESS_OUTCOMES.has(outcome.outcome);
+    // NEVER-SILENT-TO-GITHUB (2026-07-18): on 2026-07-18 the fixer ran FIVE times against three
+    // fresh issues, timed out or no-actioned every attempt, alerted only via ntfy — and the ISSUE
+    // PAGE showed nothing. From the reporter's side that is indistinguishable from "nobody looked",
+    // which cost exactly the trust this automation exists to build. A failed attempt now leaves a
+    // visible comment on the issue itself (deduped: at most one failure comment per issue per 24h,
+    // so hourly retries don't spam), fail-open like ntfy — commenting must never break the run.
+    const prevRec = fixState[String(issue.number)] || {};
+    let failureCommentAt = prevRec.failureCommentAt || null;
+    if (!succeeded) {
+      const lastNote = Date.parse(failureCommentAt || 0) || 0;
+      if (now - lastNote >= 24 * 3600_000) {
+        const why = outcome.outcome === 'timeout-failed'
+          ? `hit its ${Math.round(TIMEOUT_MS / 60000)}-minute wall-clock limit before reaching a verified outcome`
+          : `exited without producing a verifiable artifact (no branch pushed, no comment posted)`;
+        const body = `🤖 Automated issue-fix run (issue-fix.mjs) — a human reviews before anything merges.\n\n`
+          + `Status: the automated fixer attempted this issue and **${why}**. It has NOT been forgotten: `
+          + `the attempt is logged locally, the maintainer has been alerted, and the fixer retries within the hour `
+          + `until a fix branch or an honest triage lands here. This note exists so a failed attempt is never `
+          + `silent on the issue page.`;
+        const r = spawnSync(GH_BIN, ['issue', 'comment', String(issue.number), '--repo', repo, '--body', body], { encoding: 'utf8' });
+        if (r.status === 0) failureCommentAt = new Date(now).toISOString();
+      }
+    }
     fixState[String(issue.number)] = {
       attemptedAt: new Date(now).toISOString(),
       status: succeeded ? 'completed' : 'failed',
       outcome: outcome.outcome,
       branch: succeeded ? (outcome.branch || null) : null,
+      failureCommentAt,
       logPath,
     };
     state[FIX_NS] = fixState;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -50,6 +50,36 @@ console.log(`\n${c.b('RuvNet Brain — release / definition-of-done')} ${c.dim('
 step('A', 'version single-source-of-truth agrees across every surface');
 runOrDie('version sync', process.execPath, ['scripts/sync-version.mjs', '--check']);
 
+// A2. Stable Spine restart classifier (ADR-023, red-team finding 18): diff the boot-frozen SHELL
+// (hooks.json, hook-shim, MCP server, .mcp.json, skills/, commands/) against the previous release
+// tag and SAY OUT LOUD whether this release needs a restart. The classification is computed, never
+// remembered — the same shellDiff logic runs client-side in update-apply.mjs at every flip, so the
+// user-facing nag stays honest even if this print is ignored. Informational at ship time; the
+// releasing human sees exactly which shell files changed.
+step('A2', 'Stable Spine — does this release change the boot-frozen shell? (requiresRestart classifier)');
+{
+  const { execFileSync } = await import('node:child_process');
+  const SHELL = ['plugin/hooks/hooks.json', 'plugin/scripts/hook-shim.mjs', 'plugin/mcp/server.mjs', 'plugin/.mcp.json', 'plugin/skills', 'plugin/commands'];
+  let prevTag = '';
+  try { prevTag = execFileSync('git', ['describe', '--tags', '--abbrev=0'], { encoding: 'utf8' }).trim(); } catch { /* no tags yet */ }
+  if (!prevTag) {
+    console.log(c.dim('  no previous release tag — classifier has no baseline (first spine release: requiresRestart=true by definition)'));
+  } else {
+    let changed = [];
+    try {
+      const out = execFileSync('git', ['diff', '--name-only', `${prevTag}..HEAD`, '--', ...SHELL], { encoding: 'utf8' }).trim();
+      changed = out ? out.split('\n') : [];
+    } catch { /* diff failure = unknown; say so, never guess green */ changed = ['(diff failed — treat as changed)']; }
+    if (changed.length) {
+      console.log(`  ${c.y('requiresRestart: TRUE')} — shell changed vs ${prevTag}:`);
+      for (const f of changed) console.log(`    · ${f}`);
+      console.log(c.dim('  users get ONE honest restart notice (session-start reads active.json.shellChanged); everything else is live.'));
+    } else {
+      console.log(`  ${c.g('requiresRestart: false')} — no shell change vs ${prevTag}; this release goes fully live with zero restarts.`);
+    }
+  }
+}
+
 // B. the full brain test suite (the 60/60)
 step('B', 'full test suite (npm test)');
 runOrDie('npm test', 'npm', ['test']);

--- a/scripts/update-apply.mjs
+++ b/scripts/update-apply.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// Thin repo-side wrapper: the REAL Stable Spine engine ships inside the plugin payload
+// (plugin/scripts/update-apply.mjs) so every install path carries it. This wrapper exists for
+// maintainers working in the repo and for the checkpoint/CI entry point.
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const ENGINE = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'plugin', 'scripts', 'update-apply.mjs');
+process.exit(spawnSync(process.execPath, [ENGINE, ...process.argv.slice(2)], { stdio: 'inherit' }).status ?? 1);

--- a/tests/unit/hook-shim.test.mjs
+++ b/tests/unit/hook-shim.test.mjs
@@ -1,0 +1,103 @@
+// hook-shim.test.mjs — the Stable Spine's hook dispatcher (ADR-023 §3). Runs the REAL
+// plugin/scripts/hook-shim.mjs as a subprocess against a temp RUVNET_BRAIN_HOME + a fake
+// CLAUDE_PLUGIN_ROOT. Execution fixtures need bash → honest skipIf(win32), matching the
+// derived-status.test.mjs convention.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const SHIM = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'plugin', 'scripts', 'hook-shim.mjs');
+
+let HOME_DIR, PLUGIN_ROOT;
+const run = (hookId) => spawnSync(process.execPath, [SHIM, hookId], {
+  encoding: 'utf8',
+  env: { ...process.env, RUVNET_BRAIN_HOME: HOME_DIR, CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+});
+
+/** Seed a spine generation whose scripts print/exit as instructed. */
+function seedSpine(version, scripts) {
+  const root = path.join(HOME_DIR, 'versions', version);
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  for (const [name, body] of Object.entries(scripts)) fs.writeFileSync(path.join(root, 'scripts', name), body);
+  fs.writeFileSync(path.join(HOME_DIR, 'active.json'), JSON.stringify({ generation: 1, version, codeRoot: path.join('versions', version) }));
+  fs.writeFileSync(path.join(HOME_DIR, '.spine-seeded'), 'yes');
+  return root;
+}
+
+beforeEach(() => {
+  HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'shim-home-'));
+  PLUGIN_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'shim-plugin-'));
+  fs.mkdirSync(path.join(PLUGIN_ROOT, 'scripts'), { recursive: true });
+});
+afterEach(() => { fs.rmSync(HOME_DIR, { recursive: true, force: true }); fs.rmSync(PLUGIN_ROOT, { recursive: true, force: true }); });
+
+describe.skipIf(process.platform === 'win32')('hook-shim.mjs — restart-free hook dispatch', () => {
+  it('THE core promise: flipping the spine changes what a hook runs, same process boundary, no restart', () => {
+    seedSpine('1.0.0', { 'ground-ruvnet.sh': '#!/bin/bash\necho FROM-GEN-1\n' });
+    expect(run('ground-ruvnet').stdout).toMatch(/FROM-GEN-1/);
+    // "update": new generation lands, active.json flips — exactly what update-apply does
+    seedSpine('2.0.0', { 'ground-ruvnet.sh': '#!/bin/bash\necho FROM-GEN-2\n' });
+    expect(run('ground-ruvnet').stdout).toMatch(/FROM-GEN-2/); // next fire = new code. No restart.
+  });
+
+  it('BLOCKING mode propagates the exact exit code — route-dispatch\'s exit-2 wall survives', () => {
+    seedSpine('1.0.0', { 'route-dispatch.sh': '#!/bin/bash\necho BLOCKED >&2\nexit 2\n' });
+    const r = run('route-dispatch');
+    expect(r.status).toBe(2); // not 0, not 1 — the CONTRACT code
+    expect(r.stderr).toMatch(/BLOCKED/);
+  });
+
+  it('ADVISORY mode can never block a turn — a crashing hook still exits 0', () => {
+    seedSpine('1.0.0', { 'ground-ruvnet.sh': '#!/bin/bash\nexit 97\n' });
+    expect(run('ground-ruvnet').status).toBe(0);
+  });
+
+  it('no spine at all (first install) → quiet fallback to the frozen plugin dir', () => {
+    fs.writeFileSync(path.join(PLUGIN_ROOT, 'scripts', 'ground-ruvnet.sh'), '#!/bin/bash\necho FROZEN-FALLBACK\n');
+    const r = run('ground-ruvnet');
+    expect(r.stdout).toMatch(/FROZEN-FALLBACK/);
+    expect(r.stderr).not.toMatch(/hook-shim/); // first install is NOT an error — stays quiet
+  });
+
+  it('a seeded-then-broken spine falls back LOUDLY (finding 25: silence would mask corruption)', () => {
+    fs.writeFileSync(path.join(HOME_DIR, '.spine-seeded'), 'yes');
+    fs.writeFileSync(path.join(HOME_DIR, 'active.json'), '{corrupt json');
+    fs.writeFileSync(path.join(PLUGIN_ROOT, 'scripts', 'ground-ruvnet.sh'), '#!/bin/bash\necho FROZEN-FALLBACK\n');
+    const r = run('ground-ruvnet');
+    expect(r.stdout).toMatch(/FROZEN-FALLBACK/); // still works…
+    expect(r.stderr).toMatch(/spine unreadable/); // …but says so
+  });
+
+  it('containment (finding 13): a codeRoot OUTSIDE versions/ is refused → fallback, never executed', () => {
+    const evil = fs.mkdtempSync(path.join(os.tmpdir(), 'evil-'));
+    fs.mkdirSync(path.join(evil, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(evil, 'scripts', 'ground-ruvnet.sh'), '#!/bin/bash\necho PWNED\n');
+    fs.mkdirSync(path.join(HOME_DIR, 'versions'), { recursive: true });
+    fs.writeFileSync(path.join(HOME_DIR, 'active.json'), JSON.stringify({ generation: 1, version: 'x', codeRoot: evil }));
+    fs.writeFileSync(path.join(PLUGIN_ROOT, 'scripts', 'ground-ruvnet.sh'), '#!/bin/bash\necho FROZEN-FALLBACK\n');
+    const r = run('ground-ruvnet');
+    expect(r.stdout).not.toMatch(/PWNED/);
+    expect(r.stdout).toMatch(/FROZEN-FALLBACK/);
+    fs.rmSync(evil, { recursive: true, force: true });
+  });
+
+  it('dev mode wins over active.json and executes the checkout directly', () => {
+    seedSpine('1.0.0', { 'ground-ruvnet.sh': '#!/bin/bash\necho FROM-VERSIONS\n' });
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-checkout-'));
+    fs.mkdirSync(path.join(checkout, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(checkout, 'scripts', 'ground-ruvnet.sh'), '#!/bin/bash\necho FROM-DEV-CHECKOUT\n');
+    fs.writeFileSync(path.join(HOME_DIR, 'dev.json'), JSON.stringify({ codeRoot: checkout }));
+    expect(run('ground-ruvnet').stdout).toMatch(/FROM-DEV-CHECKOUT/);
+    fs.rmSync(checkout, { recursive: true, force: true });
+  });
+
+  it('an unknown hook id never blocks the turn (exit 0) and names the known table', () => {
+    const r = run('not-a-real-hook');
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/unknown hook id/);
+    expect(r.stderr).toMatch(/route-dispatch/); // the table is named, aiding diagnosis
+  });
+});

--- a/tests/unit/update-apply.test.mjs
+++ b/tests/unit/update-apply.test.mjs
@@ -25,7 +25,9 @@ function makePayload(version, { badScript = false } = {}) {
   fs.mkdirSync(path.join(dir, '.claude-plugin'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'scripts', 'ok.sh'), '#!/bin/bash\necho ok\n');
   fs.writeFileSync(path.join(dir, 'scripts', 'ok.mjs'), 'console.log("ok");\n');
-  if (badScript) fs.writeFileSync(path.join(dir, 'scripts', 'broken.sh'), '#!/bin/bash\nif [ ; then fi\n');
+  // The broken fixture is a .mjs, not a .sh: node --check gates on EVERY platform, so the
+  // gate-refusal test proves refusal on Windows too (bash -n only runs where /bin/bash exists).
+  if (badScript) fs.writeFileSync(path.join(dir, 'scripts', 'broken.mjs'), 'const = broken syntax here(\n');
   fs.writeFileSync(path.join(dir, 'hooks', 'hooks.json'), '{"hooks":{}}\n');
   fs.writeFileSync(path.join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'ruvnet-brain', version }));
   return dir;
@@ -59,7 +61,7 @@ describe('update-apply.mjs — the single writer of the spine', () => {
     const r = run('--from-dir', bad);
     expect(r.status).not.toBe(0);
     expect(r.stderr + r.stdout).toMatch(/FAILED the gate/);
-    expect(r.stderr + r.stdout).toMatch(/broken\.sh/); // the failure is NAMED, not generic
+    expect(r.stderr + r.stdout).toMatch(/broken\.mjs/); // the failure is NAMED, not generic
     expect(active().version).toBe(before.version);     // old world intact
     fs.rmSync(good, { recursive: true, force: true }); fs.rmSync(bad, { recursive: true, force: true });
   });

--- a/tests/unit/update-apply.test.mjs
+++ b/tests/unit/update-apply.test.mjs
@@ -1,0 +1,150 @@
+// update-apply.test.mjs — the Stable Spine engine (ADR-023). Every test runs the REAL
+// scripts/update-apply.mjs as a subprocess against a temp RUVNET_BRAIN_HOME — no mocks of the
+// engine itself. Windows-safe by design (no symlinks anywhere), so no win32 skip.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ENGINE = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'update-apply.mjs');
+
+let HOME_DIR;
+const run = (...args) => spawnSync(process.execPath, [ENGINE, ...args], {
+  encoding: 'utf8',
+  env: { ...process.env, RUVNET_BRAIN_HOME: HOME_DIR, CLAUDE_PLUGIN_ROOT: '' },
+});
+const active = () => { try { return JSON.parse(fs.readFileSync(path.join(HOME_DIR, 'active.json'), 'utf8')); } catch { return null; } };
+
+/** A minimal valid plugin payload: scripts/ with one good sh + one good mjs, parseable hooks.json. */
+function makePayload(version, { badScript = false } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `spine-payload-${version}-`));
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'scripts', 'ok.sh'), '#!/bin/bash\necho ok\n');
+  fs.writeFileSync(path.join(dir, 'scripts', 'ok.mjs'), 'console.log("ok");\n');
+  if (badScript) fs.writeFileSync(path.join(dir, 'scripts', 'broken.sh'), '#!/bin/bash\nif [ ; then fi\n');
+  fs.writeFileSync(path.join(dir, 'hooks', 'hooks.json'), '{"hooks":{}}\n');
+  fs.writeFileSync(path.join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'ruvnet-brain', version }));
+  return dir;
+}
+
+beforeEach(() => { HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'spine-home-')); });
+afterEach(() => { fs.rmSync(HOME_DIR, { recursive: true, force: true }); });
+
+describe('update-apply.mjs — the single writer of the spine', () => {
+  it('--from-dir gates, promotes, and flips: active.json points at an immutable versions/<v> copy', () => {
+    const payload = makePayload('9.9.1-test');
+    const r = run('--from-dir', payload);
+    expect(r.status).toBe(0);
+    const a = active();
+    expect(a.version).toBe('9.9.1-test');
+    expect(a.generation).toBe(1);
+    // codeRoot resolves under versions/ and carries the payload
+    const root = path.join(HOME_DIR, a.codeRoot);
+    expect(fs.existsSync(path.join(root, 'scripts', 'ok.sh'))).toBe(true);
+    // the flip IS the update: txn records the completed state
+    const txn = JSON.parse(fs.readFileSync(path.join(HOME_DIR, 'update-txn.json'), 'utf8'));
+    expect(txn.state).toBe('active');
+    fs.rmSync(payload, { recursive: true, force: true });
+  });
+
+  it('a candidate that fails the gate NEVER flips — spine untouched, failure named', () => {
+    const good = makePayload('9.9.1-test');
+    run('--from-dir', good);
+    const before = active();
+    const bad = makePayload('9.9.2-test', { badScript: true });
+    const r = run('--from-dir', bad);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr + r.stdout).toMatch(/FAILED the gate/);
+    expect(r.stderr + r.stdout).toMatch(/broken\.sh/); // the failure is NAMED, not generic
+    expect(active().version).toBe(before.version);     // old world intact
+    fs.rmSync(good, { recursive: true, force: true }); fs.rmSync(bad, { recursive: true, force: true });
+  });
+
+  it('--rollback is an instant flip to previous — generation increments, old payload still on disk', () => {
+    const p1 = makePayload('9.9.1-test'); const p2 = makePayload('9.9.2-test');
+    run('--from-dir', p1); run('--from-dir', p2);
+    expect(active().version).toBe('9.9.2-test');
+    const r = run('--rollback');
+    expect(r.status).toBe(0);
+    const a = active();
+    expect(a.version).toBe('9.9.1-test');
+    expect(a.generation).toBe(3); // rollback is a NEW generation, not a rewind
+    expect(fs.existsSync(path.join(HOME_DIR, a.codeRoot))).toBe(true);
+    fs.rmSync(p1, { recursive: true, force: true }); fs.rmSync(p2, { recursive: true, force: true });
+  });
+
+  it('concurrency: a held lock makes a second run no-op cleanly (never a corrupted spine)', () => {
+    // Hold the lock the way a live engine would: lock dir + owner.json with OUR living pid.
+    fs.mkdirSync(path.join(HOME_DIR, '.update.lock'), { recursive: true });
+    fs.writeFileSync(path.join(HOME_DIR, '.update.lock', 'owner.json'), JSON.stringify({ pid: process.pid }));
+    const payload = makePayload('9.9.1-test');
+    const r = run('--from-dir', payload);
+    expect(r.stdout).toMatch(/another update is in progress/);
+    expect(active()).toBe(null); // nothing was written
+    fs.rmSync(payload, { recursive: true, force: true });
+  });
+
+  it('a STALE lock (dead pid) is reclaimed — the engine never wedges forever', () => {
+    fs.mkdirSync(path.join(HOME_DIR, '.update.lock'), { recursive: true });
+    fs.writeFileSync(path.join(HOME_DIR, '.update.lock', 'owner.json'), JSON.stringify({ pid: 99999999 }));
+    const payload = makePayload('9.9.1-test');
+    const r = run('--from-dir', payload);
+    expect(r.status).toBe(0);
+    expect(active().version).toBe('9.9.1-test');
+    fs.rmSync(payload, { recursive: true, force: true });
+  });
+
+  it('GC keeps active + previous + leased; collects the rest', () => {
+    const p1 = makePayload('9.9.1-test'); const p2 = makePayload('9.9.2-test'); const p3 = makePayload('9.9.3-test');
+    run('--from-dir', p1); run('--from-dir', p2);
+    // lease 9.9.1 the way the MCP server would (fresh mtime)
+    fs.mkdirSync(path.join(HOME_DIR, 'leases'), { recursive: true });
+    fs.writeFileSync(path.join(HOME_DIR, 'leases', 'mcp-test.json'), JSON.stringify({ version: '9.9.1-test' }));
+    run('--from-dir', p3); // now: active=9.9.3, previous=9.9.2, leased=9.9.1 — all three must survive
+    const kept = fs.readdirSync(path.join(HOME_DIR, 'versions'));
+    expect(kept).toContain('9.9.3-test');
+    expect(kept).toContain('9.9.2-test');
+    expect(kept).toContain('9.9.1-test'); // ONLY because of the lease
+    [p1, p2, p3].forEach((p) => fs.rmSync(p, { recursive: true, force: true }));
+  });
+
+  it('dev mode: --auto refuses to flip away from a checkout (finding 24)', () => {
+    const checkout = makePayload('dev-checkout');
+    const r1 = run('--dev', checkout);
+    expect(r1.status).toBe(0);
+    const r2 = run('--auto');
+    expect(r2.stdout).toMatch(/dev mode is ON/);
+    expect(active()).toBe(null); // --auto wrote nothing
+    run('--dev-off');
+    expect(fs.existsSync(path.join(HOME_DIR, 'dev.json'))).toBe(false);
+    fs.rmSync(checkout, { recursive: true, force: true });
+  });
+
+  it('every flip leaves a receipt in the append-only ledger', () => {
+    const payload = makePayload('9.9.1-test');
+    run('--from-dir', payload);
+    const lines = fs.readFileSync(path.join(HOME_DIR, 'update-receipts.jsonl'), 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines.some((e) => e.event === 'CandidateGated' && e.passed === true)).toBe(true);
+    expect(lines.some((e) => e.event === 'SpineFlipped' && e.to === '9.9.1-test')).toBe(true);
+    fs.rmSync(payload, { recursive: true, force: true });
+  });
+
+  it('crash recovery: a dangling staging dir from a dead run is cleaned, world stays old', () => {
+    const p1 = makePayload('9.9.1-test');
+    run('--from-dir', p1);
+    // simulate a crash mid-stage: leftover staging dir + a non-terminal txn
+    fs.mkdirSync(path.join(HOME_DIR, 'versions', '9.9.9-test.staging-424242'), { recursive: true });
+    fs.writeFileSync(path.join(HOME_DIR, 'update-txn.json'), JSON.stringify({ state: 'staging', to: '9.9.9-test' }));
+    const r = run('--doctor'); // doctor takes no lock; use a real locked run to trigger recovery:
+    const p2 = makePayload('9.9.2-test');
+    run('--from-dir', p2);
+    expect(fs.readdirSync(path.join(HOME_DIR, 'versions')).some((d) => d.includes('.staging-424242'))).toBe(false);
+    expect(active().version).toBe('9.9.2-test');
+    expect(r.status).toBe(0);
+    fs.rmSync(p1, { recursive: true, force: true }); fs.rmSync(p2, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Kills the restart-trap permanently. Full design + duel record in-repo: ADR-023 (Accepted), `docs/INTELLIGENT-UPDATING.md` v2, DDD-0003, and the GPT-5.6 30-finding red-team (`docs/reviews/0023-gpt56-redteam.md`) whose accepted findings shaped the final architecture.

**What users get:** every behavioral update (hooks, grounding, fixes, engine) goes live mid-session with zero restarts on npm/npx/git/marketplace installs. The every-session nag dies; the only remaining notice is the truthful, classifier-computed "boot declarations changed" case — like this PR itself (hooks.json + server.mjs changed = the one migration restart).

**Proof:** 17 new tests on the REAL engine/shim (atomic flip, gate-refusal-never-flips, rollback, stale-lock reclaim, GC leases, dev-mode, containment, loud/quiet fallback, blocking exit codes) · 620 units green · smoke 16/0 · live on this machine: spine seeded gen-1, real hooks fired through the real shim, route-dispatch's exit-2 cost wall intact.

Also in this change-set: issue-fix.mjs never-silent hardening — a failed automated attempt posts a visible issue comment (24h dedupe), so "filed 3 hours ago, untouched" can never happen silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ5SrCpqqVyeTLLkZS6Xgu