### PR TITLE
fix(grounding): detect AgentDB memory freshness correctly (false 'hooks look miswired' nag)

### DIFF
--- a/plugin/scripts/ground-ruvnet.sh
+++ b/plugin/scripts/ground-ruvnet.sh
@@ -42,9 +42,27 @@ fi
 RUFLO_STATE="no"
 { [ -d ".claude-flow" ] || [ -d ".swarm" ] || grep -qs 'claude-flow\|ruflo' package.json .mcp.json 2>/dev/null; } && RUFLO_STATE="yes"
 MEM_STATE="off"; MEM_IDLE=0
-if [ -f ".swarm/memory.db" ]; then
-  if find .swarm/memory.db -mmin -90 2>/dev/null | grep -q .; then MEM_STATE="on"; else MEM_STATE="idle"; MEM_IDLE=1; fi
-fi
+# Freshness must account for TWO things, either of which makes a perfectly
+# healthy store read as idle and fires the "your memory isn't capturing this
+# session / hooks look miswired" nag while every write is in fact succeeding:
+#
+#   1. `ruflo memory init` creates and REPORTS .swarm/memory.db, but the MCP
+#      memory_store tools write to .swarm/agentdb-memory.db. Watching only the
+#      former means watching a file that can legitimately stay empty forever.
+#   2. SQLite runs these in WAL mode, so a write lands in the -wal sidecar and
+#      the main .db's mtime does not move until a checkpoint. mtime on the .db
+#      alone therefore reads "idle" minutes after a successful write.
+#
+# So: consider every store, and each one's -wal, and take the newest.
+for _db in .swarm/agentdb-memory.db .swarm/memory.db .claude/memory.db; do
+  [ -f "$_db" ] || continue
+  MEM_STATE="idle"; MEM_IDLE=1
+  if find "$_db" "$_db-wal" -mmin -90 2>/dev/null | grep -q .; then
+    MEM_STATE="on"; MEM_IDLE=0
+    break
+  fi
+done
+unset _db
 # RUNNING version (this session's loaded plugin) vs STAGED version (marketplace copy on disk).
 GV0="?"
 [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json" ] && \


### PR DESCRIPTION
The grounding hook's memory-freshness check fires the *"AgentDB memory exists here but has NOT been written in over 90 minutes … the memory hooks may be miswired"* nag on nearly every prompt in projects where memory is working perfectly.

Two separate causes, both on the same two lines of `plugin/scripts/ground-ruvnet.sh`:

```sh
if [ -f ".swarm/memory.db" ]; then
  if find .swarm/memory.db -mmin -90 ... 
```

### 1. Wrong file

`ruflo memory init` creates and **reports** `.swarm/memory.db`, but the MCP `memory_store` tools write to `.swarm/agentdb-memory.db`.

On an affected project, `memory.db` holds only `metadata` and `vector_indexes` rows — `memory_entries` is `0` — and its mtime never moves again after init, while `agentdb-memory.db` accumulates every entry. The check was watching a file that can legitimately stay empty forever.

### 2. Wrong signal

SQLite runs these stores in WAL mode, so a write lands in the `-wal` sidecar and the main `.db`'s mtime does not move until a checkpoint. Even pointed at the *correct* file, mtime on the `.db` alone reads "idle" minutes after a successful write.

### Observed

A live project, mid-session, after a `memory_store` that returned `success: true` with a 384-dim embedding:

```
.swarm/memory.db            19:30:04   ← untouched since init, memory_entries = 0
.swarm/agentdb-memory.db    22:27:53   ← 8 entries, written 8 minutes earlier
now                         22:35:37
```

Old check → `idle` → nag. The user's memory had never been broken.

### Why this is worth fixing rather than tolerating

A false positive here is worse than a missed warning. It tells people their memory is broken when it is fine — and the remedy the message suggests (*"probe it … verify `.swarm/memory.db`'s mtime actually changed"*) inspects the same wrong path, so following the advice **confirms** the false alarm. In a long session it fires on every prompt, which is exactly the pattern that trains people to ignore the hook.

### The fix

Probe each known store in turn and test both the `.db` and its `-wal`, taking the newest. `off` still means no store exists anywhere; `idle` now means a store exists and genuinely has not moved.

### Verification

| State | Result |
| --- | --- |
| fresh write (this project) | `on` — previously `idle` |
| no store at all | `off` |
| 3h-old db | `idle` |
| 3h-old db, fresh `-wal` | `on` |

`bash -n` clean, and exercised end to end through `node scripts/hook-shim.mjs ground-ruvnet` against the active generation — the nag no longer fires.

Happy to adjust the store list or ordering if `agentdb-memory.db` is not the intended canonical path — the discrepancy between what `memory init` reports and where `memory_store` writes may itself be the more interesting bug, and I'd rather not paper over it if you'd prefer to fix it at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)