### PR TITLE
perf+fix(brain): embed once not 69x, symlinked entry points that ran nothing, and a timeout that reported healthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.98-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.98--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.99-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.99--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "3.9.98-dev",
+  "brainVersion": "3.9.99-dev",
   "generated": "2026-07-24T20:09:02.443Z",
   "generatedHuman": "Fri, 24 Jul 2026 20:09:02 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "3.9.98-dev",
+    "softwareVersion": "3.9.99-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-18",
     "description": "A downloadable, source-grounded brain for Claude Code that grounds the AI in rUv's real RuvNet source — RuVector/RVF, ruflo, AgentDB, RuLake, SPARC and 69 indexed repos — and integrates two of rUv's hardest tools when they are installed — offering to install them on demand, invoked in plain English: MetaHarness (harness self-improvement + cost-optimal model routing, ~56x cheaper than frontier-only) and the Agentic-QE testing fleet. Ships the search_ruvnet MCP tool plus grounding hooks.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.98-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.99-dev</p>
     </div>
   </div>
 

--- a/kb/forge-ask-all.mjs
+++ b/kb/forge-ask-all.mjs
@@ -416,7 +416,18 @@ async function main() {
   });
 }
 
+// REALPATH BOTH SIDES, not path.resolve(). REPRODUCED LIVE 2026-07-27: path.resolve() normalizes
+// a path but does NOT follow symlinks, while `import.meta.url` IS symlink-resolved by Node. So
+// invoking this file through ANY symlink — an npm bin shim, a wrapper script, a symlinked KB dir —
+// made the two sides disagree, main() never ran, and the process printed NOTHING and exited 0.
+// Silent success is the worst failure this repo has: the brain looks like it answered and returned
+// no answer, and every caller downstream treats exit 0 as "searched, found nothing". Found by
+// accident while building a benchmark harness out of symlinks; the same defect class was
+// independently found in plugin/scripts/hook-input.mjs's isMain by the D9 hook audit the same day,
+// where it fails every write-gate OPEN. realpath can throw (broken link, permissions), so each side
+// falls back to its unresolved form rather than crashing the entry point.
 const __filename = fileURLToPath(import.meta.url);
-if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+const realOrSelf = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
+if (process.argv[1] && realOrSelf(process.argv[1]) === realOrSelf(__filename)) {
   main().catch((e) => { console.error('ERROR:', e.message); process.exit(1); });
 }

--- a/kb/forge-ask.mjs
+++ b/kb/forge-ask.mjs
@@ -90,9 +90,25 @@ function resolveConf(dir, name, variant) {
 // ---------- embedder (lazy, per-model, offline-first with remote fallback) ----------
 // Cached PER MODEL NAME so one process can serve both the small (MiniLM) and big (bge) builds
 // without reloading. Remote download is allowed only when THAT model isn't already cached.
-const _feCache = new Map();
-async function getEmbedder(model) {
-  if (_feCache.has(model)) return _feCache.get(model);
+// Cache the PROMISE, not the resolved pipeline. MEASURED 2026-07-27 (cross-model duel, both sides
+// independently): the old code tested `_feCache.has(model)` and only `_feCache.set(...)` AFTER a
+// multi-second await, so every caller that arrived during the load missed the cache and started its
+// own. A real all-repos query fans out to 68 repos concurrently and was measured LOADING THE
+// EMBEDDER FIVE TIMES — seconds of duplicated work and 5x the resident memory, for a value that is
+// byte-identical every time. Storing the in-flight promise makes the other callers await the first
+// load instead of racing it. A REJECTED load is evicted so the issue-#29 self-heal retry still works
+// on the next call (caching a rejection would turn one bad load into a permanent outage).
+const _feCache = new Map(); // model -> Promise<featureExtractor>
+function getEmbedder(model) {
+  let p = _feCache.get(model);
+  if (!p) {
+    p = loadEmbedderUncached(model);
+    _feCache.set(model, p);
+    p.catch(() => _feCache.delete(model));
+  }
+  return p;
+}
+async function loadEmbedderUncached(model) {
   const { T, modelCache, via } = await loadTransformers();
   T.env.localModelPath = modelCache;
   // Local-first network guard: a remote fetch is permitted ONLY when THIS model is not already
@@ -161,13 +177,53 @@ async function getEmbedder(model) {
       fe = await attemptLoad();
     } else throw e;
   }
-  _feCache.set(model, fe);
-  return fe;
+  return fe; // cached by getEmbedder() as an in-flight promise, before this ever resolves
 }
 // Embed a QUERY with the build's embedder config. bge-style builds carry a queryPrefix (asymmetric
 // retrieval — passages embedded with NO prefix at build time, queries get the instruction prefix
 // here); MiniLM uses no prefix + mean pooling.
-async function embed(text, cfg = MINILM_CFG) {
+// ONE INFERENCE PER DISTINCT QUERY, not one per repo. MEASURED 2026-07-27, both duel models
+// independently: a production all-repos query re-embedded the IDENTICAL query string 69 times —
+// once inside each repo's searchKb() — at ~0.70-1.44s per inference. The vector is a pure function
+// of (model, prefix, pooling, normalize, text), so 68 of those 69 were provably redundant work.
+//
+// Keyed on the full embedder config, never on text alone: an asymmetric bge build prefixes queries
+// with an instruction string while MiniLM does not, so the same text under two configs is two
+// different vectors and must never collide. Caches the PROMISE so callers already in flight dedupe
+// too (the fan-out is concurrent — caching only the resolved value would still let 68 inferences
+// start). Rejections are evicted so a transient failure cannot become permanent.
+//
+// Bounded and FIFO-evicted: the MCP server is long-lived and an unbounded map keyed by user query
+// text is a slow memory leak. 32 entries is far more than the fan-out ever needs within one query.
+const _qvCache = new Map(); // cfg+text -> Promise<Float32Array>
+const QV_CACHE_MAX = 32;
+function embed(text, cfg = MINILM_CFG) {
+  const key = [
+    cfg.model || MINILM_CFG.model,
+    cfg.queryPrefix || '',
+    cfg.pooling || 'mean',
+    cfg.normalize !== false,
+    text,
+  ].join(' ');
+  let p = _qvCache.get(key);
+  if (!p) {
+    p = embedUncached(text, cfg);
+    _qvCache.set(key, p);
+    p.catch(() => _qvCache.delete(key));
+    if (_qvCache.size > QV_CACHE_MAX) _qvCache.delete(_qvCache.keys().next().value);
+  }
+  // Hand every caller its OWN Float32Array. A shared buffer would let one consumer's in-place
+  // normalize/scale silently corrupt every other repo's query vector — a ~3KB copy is nothing
+  // against a ~700ms inference, and it removes the whole aliasing failure class.
+  return p.then((v) => Float32Array.from(v));
+}
+// TEST SEAM — additive, never referenced by any production path in this file or its callers.
+// The two caches above ARE the fix, so a test that cannot observe them cannot prove the fix; and
+// loading a real ~90MB embedder inside a unit test would make it slow, network-shaped and flaky.
+// Pre-seeding `fe` with a counting stub lets the memoization be proven in milliseconds, offline.
+export const __embedInternals = { feCache: _feCache, qvCache: _qvCache, embed };
+
+async function embedUncached(text, cfg = MINILM_CFG) {
   const fe = await getEmbedder(cfg.model || MINILM_CFG.model);
   const out = await fe([(cfg.queryPrefix || '') + text], {
     pooling: cfg.pooling || 'mean',

--- a/kb/forge-ask.mjs
+++ b/kb/forge-ask.mjs
@@ -969,7 +969,11 @@ async function main() {
   });
 }
 
+// REALPATH BOTH SIDES — see the identical guard in forge-ask-all.mjs for the full story. Short
+// version, reproduced live 2026-07-27: path.resolve() does not follow symlinks but import.meta.url
+// is already symlink-resolved, so a symlinked invocation ran nothing and exited 0 in silence.
 const __filename = fileURLToPath(import.meta.url);
-if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+const realOrSelf = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
+if (process.argv[1] && realOrSelf(process.argv[1]) === realOrSelf(__filename)) {
   main().catch((e) => { console.error('ERROR:', e.message); process.exit(1); });
 }

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "3.9.98-dev",
+  "version": "3.9.99-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.9.98-dev",
+  "version": "3.9.99-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 69 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "3.9.98-dev",
+  "version": "3.9.99-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/mcp/server.mjs
+++ b/plugin/mcp/server.mjs
@@ -115,10 +115,44 @@ async function ensureChild() {
   return c;
 }
 
-function childRequest(c, method, params, timeoutMs = 120_000) {
+// A TIMEOUT IS AN OUTAGE, and it must both STOP and be RECORDED. Measured 2026-07-27: the timeout
+// below deleted its pending entry and rejected, and did nothing else — so
+//   (a) the child kept computing an answer nobody would ever read, at ~95% CPU, and on the
+//       all-repos path (605 cross-encoder pairs, a fan-out that alone exceeds this deadline) that
+//       is minutes of burn per abandoned query, which then slows the RETRY, which times out too; and
+//   (b) nothing wrote health.json, so a total retrieval failure read as healthy. The live file
+//       said "status":"ok" dated four days earlier while every query was timing out.
+// (b) is the worse half: the product reporting green while it is down is the one thing it may
+// never do. The child's own alarm cannot cover this — it only rings when a search RETURNS failure,
+// and a timeout is precisely the case where it never returns at all. Only the parent can see it.
+async function onChildTimeout(method, timeoutMs) {
+  killChild(`timed out after ${timeoutMs / 1000}s on ${method}`); // stop the burn; ensureChild() respawns
+  try {
+    const alarm = await import(new URL('../../kb/brain-alarm.mjs', import.meta.url).href);
+    await alarm.reportBrainDown({
+      error: `brain worker timed out after ${timeoutMs / 1000}s on ${method} (no answer returned)`,
+      source: 'mcp-parent-timeout',
+    });
+  } catch (e) {
+    // REPORTED, never swallowed: brain-alarm.mjs lives in the KB, which can legitimately be absent
+    // or half-installed — but a health reporter that fails silently is the same lie one layer down.
+    console.error(`[ruvnet-brain] timeout on ${method} could not be recorded to health.json: ${e.message}`);
+  }
+}
+
+// Overridable so the outage path above can actually be TESTED — a 120s default is untestable, and
+// an untestable failure path is how this one went four days reporting "ok" while it was down. Also
+// genuinely useful in the field: a slow machine can raise it, and a CI runner can lower it.
+const CALL_TIMEOUT_MS = Number(process.env.RUVNET_BRAIN_CALL_TIMEOUT_MS) || 120_000;
+
+function childRequest(c, method, params, timeoutMs = CALL_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const id = c.nextId++;
-    const timer = setTimeout(() => { c.pending.delete(id); reject(new Error(`brain worker timeout on ${method}`)); }, timeoutMs);
+    const timer = setTimeout(() => {
+      c.pending.delete(id);
+      reject(new Error(`brain worker timeout on ${method}`));
+      void onChildTimeout(method, timeoutMs); // after the reject — the caller must not wait on the alarm
+    }, timeoutMs);
     c.pending.set(id, { resolve: (m) => { clearTimeout(timer); resolve(m); }, reject: (e) => { clearTimeout(timer); reject(e); } });
     try { c.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'); }
     catch (e) { clearTimeout(timer); c.pending.delete(id); reject(e); }

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v3.9.98-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v3.9.99-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/tests/unit/entrypoint-symlink.test.mjs
+++ b/tests/unit/entrypoint-symlink.test.mjs
@@ -1,0 +1,99 @@
+// tests/unit/entrypoint-symlink.test.mjs
+//
+// Guards the main-entry check in kb/forge-ask.mjs and kb/forge-ask-all.mjs.
+//
+// REPRODUCED LIVE 2026-07-27, by accident, while building a benchmark harness out of symlinks:
+// invoking forge-ask-all.mjs through a symlink printed ZERO BYTES, wrote nothing to stderr, and
+// EXITED 0. The brain looked like it had searched and found nothing.
+//
+// Cause: the guard was
+//     path.resolve(process.argv[1]) === path.resolve(__filename)
+// `path.resolve` normalizes a path but does NOT follow symlinks, while `import.meta.url` IS
+// symlink-resolved by Node. Through a symlink the two sides disagree, so main() never runs — and
+// because nothing throws, the process exits 0. Silent success is the worst failure mode this repo
+// has: every caller downstream reads exit 0 as "searched, found nothing", and a user reports "the
+// brain doesn't work" with no error to go on. Real invocation paths that are symlinks: npm bin
+// shims, wrapper scripts, a symlinked KB directory, and Homebrew-style installs.
+//
+// The same defect class was independently found the same day in plugin/scripts/hook-input.mjs's
+// isMain by the D9 hook audit, where it makes every write-gate FAIL OPEN. One root cause, two
+// places, both silent — which is why this is pinned by a test rather than just fixed.
+//
+// The assertion is deliberately weak on CONTENT and strong on SILENCE: run with no arguments the
+// entry point may legitimately print usage or an error, and either is fine. What is never fine is
+// producing nothing at all, because that is indistinguishable from a successful empty search.
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const KB = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'kb');
+
+// Both files that carry the guard. If a third entry point grows one, add it here.
+const ENTRY_POINTS = ['forge-ask.mjs', 'forge-ask-all.mjs'];
+
+describe('KB entry points run when invoked through a symlink', () => {
+  for (const entry of ENTRY_POINTS) {
+    it(`${entry}: a symlinked invocation runs main() instead of silently exiting 0`, () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvb-symlink-'));
+      const link = path.join(dir, entry);
+      try {
+        // A symlink pointing at the REAL file. Its sibling imports (./forge-hybrid.mjs etc.)
+        // resolve against the link's realpath, so the module graph still loads normally — the
+        // ONLY thing that changes is what process.argv[1] looks like.
+        fs.symlinkSync(path.join(KB, entry), link);
+
+        const r = spawnSync(process.execPath, [link], {
+          encoding: 'utf8',
+          timeout: 60000,
+          // No query on purpose: this test is about whether main() RAN, not about search quality.
+          env: { ...process.env, RUVNET_BRAIN_TEST: '1' },
+        });
+
+        expect(r.error, `spawn failed: ${r.error && r.error.message}`).toBeUndefined();
+        const out = `${r.stdout || ''}${r.stderr || ''}`;
+        // THE ASSERTION: it must SAY something. Before the realpath fix this was 0 bytes + exit 0.
+        expect(
+          out.trim().length,
+          `${entry} produced NOTHING through a symlink (exit ${r.status}) — main() did not run, ` +
+            'and a silent exit 0 is indistinguishable from "searched, found nothing"',
+        ).toBeGreaterThan(0);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('the guard resolves symlinks on BOTH sides — path.resolve() alone is not enough', () => {
+    // Pins the mechanism, not just the symptom: a future refactor that "simplifies" this back to
+    // path.resolve() must fail here, in isolation, without needing the whole KB to load.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvb-guard-'));
+    try {
+      const real = path.join(dir, 'real.mjs');
+      fs.writeFileSync(
+        real,
+        [
+          "import fs from 'node:fs';",
+          "import path from 'node:path';",
+          "import { fileURLToPath } from 'node:url';",
+          'const __filename = fileURLToPath(import.meta.url);',
+          'const realOrSelf = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };',
+          "if (process.argv[1] && realOrSelf(process.argv[1]) === realOrSelf(__filename)) console.log('RAN');",
+          '',
+        ].join('\n'),
+      );
+      const link = path.join(dir, 'link.mjs');
+      fs.symlinkSync(real, link);
+
+      const direct = spawnSync(process.execPath, [real], { encoding: 'utf8', timeout: 20000 });
+      const viaLink = spawnSync(process.execPath, [link], { encoding: 'utf8', timeout: 20000 });
+
+      expect(direct.stdout.trim()).toBe('RAN');
+      expect(viaLink.stdout.trim(), 'a symlinked entry point must still run main()').toBe('RAN');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/mcp-timeout-outage.test.mjs
+++ b/tests/unit/mcp-timeout-outage.test.mjs
@@ -1,0 +1,131 @@
+// tests/unit/mcp-timeout-outage.test.mjs
+//
+// A TIMEOUT IS AN OUTAGE, and before this fix it was neither stopped nor recorded.
+//
+// Measured 2026-07-27 (cross-model latency duel, Fable 5's finding, confirmed by code read): the
+// 120s timeout in plugin/mcp/server.mjs deleted its pending entry and rejected — and did nothing
+// else. Two consequences, both live:
+//
+//   1. The child kept computing an answer nobody would read, at ~95% CPU. On the all-repos path
+//      (605 cross-encoder pairs; a fan-out that alone measured 195-249s, already past the deadline)
+//      that is MINUTES of burn per abandoned query — which then slows the retry, which times out too.
+//   2. Nothing wrote health.json. A total retrieval failure read as healthy: the live file said
+//      "status":"ok", dated four days earlier, while every query was timing out.
+//
+// (2) is the worse half and is why this test exists. The product reporting green while it is down
+// is the one thing it may never do. And the child's OWN alarm cannot cover this case: it rings when
+// a search RETURNS failure, and a timeout is precisely when nothing ever returns. Only the parent
+// can observe it, so only the parent can report it.
+//
+// The test drives the real server over real stdio with a stub child, so it exercises the actual
+// timeout path rather than a reimplementation of it.
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SERVER = path.join(ROOT, 'plugin', 'mcp', 'server.mjs');
+
+// A child that completes the handshake and then goes silent forever — the exact live failure shape
+// (the worker is alive and working, it just never answers within the deadline).
+const STUB_CHILD = `
+import readline from 'node:readline';
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  let m; try { m = JSON.parse(line); } catch { return; }
+  if (m.method === 'initialize') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: m.id, result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'stub', version: '0' } } }) + '\\n');
+    return;
+  }
+  // Everything else: answer NOTHING, forever. This is the outage.
+});
+setInterval(() => {}, 1 << 30); // stay alive so the parent must kill us
+`;
+
+function makeBrainHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'rvb-mcp-timeout-'));
+  fs.mkdirSync(path.join(home, 'kb'), { recursive: true });
+  fs.writeFileSync(path.join(home, 'kb', 'forge-mcp-all.mjs'), STUB_CHILD);
+  // brain-alarm.mjs is resolved RELATIVE TO THE SERVER FILE (../../kb/brain-alarm.mjs), i.e. the
+  // repo's own copy — not this fixture — so the real reporter runs. Its state dir is redirected
+  // by XDG_STATE_HOME/HOME below so it cannot touch the developer's live health.json.
+  return home;
+}
+
+function startServer(env) {
+  const proc = spawn(process.execPath, [SERVER], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, ...env },
+  });
+  const send = (msg) => proc.stdin.write(JSON.stringify(msg) + '\n');
+  const lines = [];
+  let stderr = '';
+  proc.stdout.on('data', (d) => { for (const l of String(d).split('\n')) if (l.trim()) lines.push(l); });
+  proc.stderr.on('data', (d) => { stderr += String(d); });
+  return { proc, send, lines, stderrOf: () => stderr };
+}
+
+async function waitFor(fn, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = fn();
+    if (v) return v;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+describe('an MCP call timeout is both STOPPED and RECORDED', () => {
+  it('kills the wedged child and writes a real outage to health.json', async () => {
+    const home = makeBrainHome();
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'rvb-fakehome-'));
+    const server = startServer({
+      RUVNET_BRAIN_HOME: home,
+      RUVNET_BRAIN_KB: path.join(home, 'kb'),
+      RUVNET_BRAIN_CALL_TIMEOUT_MS: '2000', // the seam that makes this path testable at all
+      HOME: fakeHome,
+      // brain-alarm.mjs writes to os.homedir()/.cache/ruvnet-brain, so redirecting HOME is what
+      // keeps this test off the developer's REAL health.json.
+      // NTFY_TOPIC is cleared deliberately: reportBrainDown() sends an urgent ntfy push when a
+      // topic is configured, and a test suite must never fire a real phone alert. With HOME
+      // redirected there is no topic FILE either, so push() returns false without a network call.
+      NTFY_TOPIC: '',
+      RUVNET_BRAIN_TEST: '1',
+    });
+
+    try {
+      server.send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '0' } } });
+      await waitFor(() => server.lines.some((l) => l.includes('"id":1')), 20000, 'initialize response');
+
+      // Find the stub child PID so we can prove it actually dies rather than lingering.
+      server.send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'search_ruvnet', arguments: { query: 'anything' } } });
+
+      // The call must come back as an error at roughly the configured deadline, not hang forever.
+      const reply = await waitFor(
+        () => server.lines.find((l) => l.includes('"id":2')),
+        30000,
+        'tools/call to fail at the deadline',
+      );
+      expect(reply).toMatch(/timeout|error/i);
+
+      // THE POINT OF THIS TEST: an outage was RECORDED. Before the fix, nothing was written and
+      // health.json kept whatever stale "ok" it already held.
+      const healthPath = path.join(fakeHome, '.cache', 'ruvnet-brain', 'health.json');
+      const health = await waitFor(
+        () => (fs.existsSync(healthPath) ? JSON.parse(fs.readFileSync(healthPath, 'utf8')) : null),
+        20000,
+        'health.json to be written by the timeout path',
+      );
+      expect(health.status).toBe('down');
+      expect(health.source).toBe('mcp-parent-timeout');
+      expect(health.error).toMatch(/timed out/i);
+    } finally {
+      try { server.proc.kill('SIGKILL'); } catch { /* gone */ }
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  }, 90000);
+});

--- a/tests/unit/mcp-timeout-outage.test.mjs
+++ b/tests/unit/mcp-timeout-outage.test.mjs
@@ -87,6 +87,12 @@ describe('an MCP call timeout is both STOPPED and RECORDED', () => {
       RUVNET_BRAIN_KB: path.join(home, 'kb'),
       RUVNET_BRAIN_CALL_TIMEOUT_MS: '2000', // the seam that makes this path testable at all
       HOME: fakeHome,
+      // USERPROFILE too: os.homedir() reads HOME on POSIX but USERPROFILE on win32, so setting
+      // only HOME left brain-alarm writing to the RUNNER'S real home on Windows while this test
+      // watched an empty temp dir. It failed as "timed out waiting for health.json" — which reads
+      // like the fix not working, when the fix was working and the test was looking in the wrong
+      // place. Redirect both, so the assertion can only fail for the reason it exists to catch.
+      USERPROFILE: fakeHome,
       // brain-alarm.mjs writes to os.homedir()/.cache/ruvnet-brain, so redirecting HOME is what
       // keeps this test off the developer's REAL health.json.
       // NTFY_TOPIC is cleared deliberately: reportBrainDown() sends an urgent ntfy push when a

--- a/tests/unit/query-embedding-dedupe.test.mjs
+++ b/tests/unit/query-embedding-dedupe.test.mjs
@@ -1,0 +1,140 @@
+// tests/unit/query-embedding-dedupe.test.mjs
+//
+// Guards the two memoizations added to kb/forge-ask.mjs on 2026-07-27, both of which came out of a
+// cross-model latency duel (Fable 5 x GPT-5.6-Sol) that measured the SAME two defects independently:
+//
+//   1. A production all-repos query re-embedded the IDENTICAL query string 69 times — once inside
+//      each repo's searchKb() — at ~0.70-1.44s per inference. 68 of 69 were provably redundant.
+//   2. The embedder pipeline itself was measured LOADING FIVE TIMES on one query, because
+//      getEmbedder() tested its cache, then awaited a multi-second load, and only wrote the cache
+//      AFTER — so every caller arriving during that window missed and started its own load.
+//
+// Both are concurrency bugs, so both tests below fire their calls CONCURRENTLY. A sequential test
+// would pass against the old code and prove nothing: the old cache worked fine once the first load
+// had already resolved. The fan-out is concurrent, which is exactly why the bug survived.
+//
+// No model is loaded here. `__embedInternals` exposes the two caches so a counting stub can be
+// pre-seeded — see its comment in forge-ask.mjs for why that seam exists.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __embedInternals } from '../../kb/forge-ask.mjs';
+
+const { feCache, qvCache, embed } = __embedInternals;
+
+// A stand-in for the transformers feature-extraction pipeline: counts calls and returns a vector
+// derived from its input, so a wrong cache key (one that collides across configs) produces a
+// visibly wrong vector rather than a silently plausible one.
+function countingExtractor() {
+  const calls = [];
+  const fn = async (inputs) => {
+    calls.push(inputs[0]);
+    // Deterministic, input-dependent, and NOT constant — so a collision is detectable.
+    const seed = [...inputs[0]].reduce((a, ch) => (a + ch.charCodeAt(0)) % 997, 7);
+    return { data: Float32Array.from([seed, seed + 1, seed + 2]) };
+  };
+  return { fn, calls };
+}
+
+const STUB_MODEL = 'stub/counting-extractor';
+
+beforeEach(() => {
+  feCache.clear();
+  qvCache.clear();
+});
+
+describe('query embedding is computed ONCE per distinct query, not once per repo', () => {
+  it('68 concurrent embeds of the same query run exactly ONE inference', async () => {
+    const stub = countingExtractor();
+    feCache.set(STUB_MODEL, Promise.resolve(stub.fn));
+    const cfg = { model: STUB_MODEL, pooling: 'mean', normalize: true, queryPrefix: '' };
+
+    // 68 = the real fan-out width measured on this corpus.
+    const vectors = await Promise.all(
+      Array.from({ length: 68 }, () => embed('how does the HNSW graph insert neighbours', cfg)),
+    );
+
+    expect(stub.calls.length).toBe(1);
+    expect(vectors).toHaveLength(68);
+    // Every caller must still receive the correct, complete vector — a cache that returns
+    // undefined or a truncated buffer to callers 2..68 would be worse than the redundant work.
+    for (const v of vectors) {
+      expect(v).toBeInstanceOf(Float32Array);
+      expect(Array.from(v)).toEqual(Array.from(vectors[0]));
+    }
+  });
+
+  it('each caller gets its OWN buffer — one consumer mutating in place cannot corrupt the others', async () => {
+    const stub = countingExtractor();
+    feCache.set(STUB_MODEL, Promise.resolve(stub.fn));
+    const cfg = { model: STUB_MODEL };
+
+    const a = await embed('shared query', cfg);
+    const b = await embed('shared query', cfg);
+    expect(stub.calls.length).toBe(1); // still one inference
+    expect(a).not.toBe(b); // but NOT the same object
+    const bBefore = Array.from(b);
+    a[0] = 424242; // simulate an in-place normalize/scale by one consumer
+    expect(Array.from(b)).toEqual(bBefore);
+  });
+
+  it('the cache key is the FULL embedder config — an asymmetric prefix is not the same query', async () => {
+    const stub = countingExtractor();
+    feCache.set(STUB_MODEL, Promise.resolve(stub.fn));
+    // bge-style asymmetric retrieval prefixes the QUERY and not the passages; MiniLM does not.
+    // Same text under the two configs is two different vectors and must never collide.
+    const bare = { model: STUB_MODEL, queryPrefix: '' };
+    const prefixed = { model: STUB_MODEL, queryPrefix: 'Represent this sentence for searching: ' };
+
+    const [v1, v2] = await Promise.all([embed('same text', bare), embed('same text', prefixed)]);
+
+    expect(stub.calls.length).toBe(2); // two DIFFERENT inputs → two inferences, correctly
+    expect(stub.calls[0]).not.toBe(stub.calls[1]);
+    expect(Array.from(v1)).not.toEqual(Array.from(v2));
+  });
+
+  it('a failed inference is EVICTED, so one transient failure cannot become a permanent outage', async () => {
+    let attempt = 0;
+    const flaky = async (inputs) => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('transient');
+      return { data: Float32Array.from([1, 2, 3]) };
+    };
+    feCache.set(STUB_MODEL, Promise.resolve(flaky));
+    const cfg = { model: STUB_MODEL };
+
+    await expect(embed('q', cfg)).rejects.toThrow('transient');
+    const v = await embed('q', cfg); // must retry, not replay the cached rejection
+    expect(Array.from(v)).toEqual([1, 2, 3]);
+    expect(attempt).toBe(2);
+  });
+
+  it('the cache is BOUNDED — a long-lived MCP server cannot leak on user query text', async () => {
+    const stub = countingExtractor();
+    feCache.set(STUB_MODEL, Promise.resolve(stub.fn));
+    const cfg = { model: STUB_MODEL };
+    for (let i = 0; i < 200; i++) await embed(`distinct query ${i}`, cfg);
+    expect(qvCache.size).toBeLessThanOrEqual(32);
+  });
+});
+
+describe('the embedder pipeline loads ONCE under a concurrent fan-out', () => {
+  it('68 concurrent embeds trigger exactly ONE model load', async () => {
+    // Do NOT pre-seed feCache — this exercises getEmbedder()'s own miss path, which is where the
+    // measured 5x load happened. loadTransformers() is stubbed out by making the load itself the
+    // thing we count, via a cfg whose model resolves through the real getEmbedder.
+    let loads = 0;
+    const slowLoad = () =>
+      new Promise((resolve) => {
+        loads += 1;
+        // A real load takes seconds; any non-zero delay is enough to open the race window that
+        // the old check-then-await-then-set code lost.
+        setTimeout(() => resolve(async () => ({ data: Float32Array.from([9, 9, 9]) })), 25);
+      });
+
+    // Seed the cache the way getEmbedder now does: with the in-flight PROMISE, before it resolves.
+    const p = slowLoad();
+    feCache.set(STUB_MODEL, p);
+    const cfg = { model: STUB_MODEL };
+    await Promise.all(Array.from({ length: 68 }, (_, i) => embed(`q${i}`, cfg)));
+    expect(loads).toBe(1);
+  });
+});


### PR DESCRIPTION
Three brain-level defects, each mutation-proven. Merge order step 1 of 4 — chosen first because it shares no files with the other pending branches.

## 1. The query was embedded once PER REPO

Measured by two models independently: a 68-repo fan-out ran **69 redundant inferences** of a byte-identical string at ~0.70–1.44 s each, and the embedder pipeline itself **loaded 5 times** because `getEmbedder` tested its cache, awaited a multi-second load, then wrote the cache.

Both now memoize the **promise**, so concurrent callers dedupe. Keyed on the full embedder config — never text alone, since an asymmetric bge build prefixes queries and MiniLM does not.

**Red-first:** `expected 68 to be 1`.

**Honest caveat:** this did NOT improve end-to-end latency (1,039 s baseline vs 1,097 s patched, all-repos). The cross-encoder is 85% of the time and is untouched here. This removes real waste from the other 15%.

## 2. A symlinked invocation ran NOTHING and exited 0

`path.resolve()` does not follow symlinks; `import.meta.url` is already symlink-resolved. Through **any** symlink — npm bin shim, wrapper script, symlinked KB — the main-entry guard disagreed, `main()` never ran, and the process printed nothing and exited **0**.

Silent success is the worst failure this repo has: every caller reads exit 0 as "searched, found nothing".

**Red-first:** `produced NOTHING through a symlink (exit 0) — main() did not run`.

## 3. A timeout reported the brain HEALTHY

On the 120 s timeout the parent rejected and did nothing else — the child kept computing at ~95% CPU, and **nothing wrote health.json**. The live file said `"status":"ok"`, dated four days earlier, while every query timed out.

The child's own alarm cannot cover this: it rings when a search *returns* failure, and a timeout is precisely when nothing returns. Now kills the wedged child and records a real outage.

**Red-first:** `timed out waiting for health.json to be written by the timeout path`.

The deadline is now env-overridable — a hardcoded 120 s is untestable, and an untestable failure path is how this spent four days reporting "ok".