### PR TITLE
fix(hooks): issue #44 — the interface gate classifies EXECUTABLE STRUCTURE, never a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.98-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.98--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.100-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.100--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "3.9.98-dev",
+  "brainVersion": "3.9.100-dev",
   "generated": "2026-07-24T20:09:02.443Z",
   "generatedHuman": "Fri, 24 Jul 2026 20:09:02 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "3.9.98-dev",
+    "softwareVersion": "3.9.100-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-18",
     "description": "A downloadable, source-grounded brain for Claude Code that grounds the AI in rUv's real RuvNet source — RuVector/RVF, ruflo, AgentDB, RuLake, SPARC and 69 indexed repos — and integrates two of rUv's hardest tools when they are installed — offering to install them on demand, invoked in plain English: MetaHarness (harness self-improvement + cost-optimal model routing, ~56x cheaper than frontier-only) and the Agentic-QE testing fleet. Ships the search_ruvnet MCP tool plus grounding hooks.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.98-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.100-dev</p>
     </div>
   </div>
 

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "3.9.98-dev",
+  "version": "3.9.100-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.9.85-dev",
+  "version": "3.9.93-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "3.9.85-dev",
+      "version": "3.9.93-dev",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.9.98-dev",
+  "version": "3.9.100-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 69 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "3.9.98-dev",
+  "version": "3.9.100-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/scripts/hook-input.mjs
+++ b/plugin/scripts/hook-input.mjs
@@ -16,8 +16,11 @@
 //   printf '%s' "$INPUT" | node hook-input.mjs tool_name        -> prints event.tool_name
 //   printf '%s' "$INPUT" | node hook-input.mjs command          -> prints tool_input.command (|| .command)
 //   printf '%s' "$INPUT" | node hook-input.mjs field a.b.c      -> prints an arbitrary dotted path
-//   printf '%s' "$INPUT" | node hook-input.mjs skeleton         -> prints the command with quoted
-//                                                                   CONTENT masked (issue #41)
+//   printf '%s' "$INPUT" | node hook-input.mjs invocations a,b  -> one TAB-separated line per
+//                                                                   EXECUTABLE invocation of any
+//                                                                   named tool, anywhere in the
+//                                                                   command: `tool<TAB>arg…`
+//                                                                   (issues #12/#17/#41/#44)
 //
 // CONTRACT: prints "" and exits 0 on ANY parse failure or missing field. It NEVER throws to the caller
 // and NEVER exits nonzero on bad input — a gate that breaks the shell protects nothing, so fail-open
@@ -63,31 +66,343 @@ export function field(ev, dottedPath) {
   if (cur == null) return '';
   return typeof cur === 'string' ? cur : String(cur);
 }
+// ── Shell command classification ─────────────────────────────────────────────────────────────────
+//
+// WHY THIS IS A PARSER AND NOT A REGEX (2026-07-27, after issues #12, #13, #17, #41, #44 — four
+// filed defects and one live capture, all in 13 days, all the SAME defect in two different files).
+//
+//   #12 (07-13)  matched a tool name in PROSE and in a different binary (`ruflo-source-patch`).
+//   #13 (07-14)  a bash regex over the JSON payload truncated the command at the first quote.
+//   #41 (07-24)  a `|` inside a quoted grep pattern read as a real shell separator.
+//   #44 (07-26)  invocations nested in `bash -lc '…'`, backticks, and `"$( … )"` bypassed the gate.
+//   #17 (07-17)  design-wall.sh, a DIFFERENT gate: `[[ $CMD == *"git commit"* ]]` fires on prose.
+//                (The reporter said so verbatim in #17 and it was never acted on.)
+//   live (07-27) design-wall.sh blocked a maintainer because the words "agentic-qe integration plan"
+//                appeared inside a HEREDOC. Prose. Again.
+//
+// Every one of those fixes upgraded a pattern match over a FLAT STRING, and the next one arrived
+// within days. The class does not live in any of those patterns; it lives in the decision to ask a
+// string question about a structural fact. `ruflo memory search` is an invocation when `ruflo` is in
+// EXECUTABLE POSITION and text when it is not, and no amount of masking, anchoring, or escaping
+// makes a flat string able to tell those apart — the fifth patch would have failed the same way.
+//
+// THE INVARIANT, from here on: an enforcement gate classifies EXECUTABLE STRUCTURE, never a flat
+// string. This module is the one classifier. There is deliberately no regex fallback path in any
+// gate — a second path is exactly how this class survived four fixes.
+//
+// ── ARCHITECTURAL NOTE: THIS IS STILL THE WRONG BOUNDARY ─────────────────────────────────────────
+// Read this before adding a sixth patch to it.
+//
+// A parser beats the four regexes that preceded it, and it is still GOVERNING AT AN UNSTRUCTURED
+// BOUNDARY. The input is a shell command — a string a human or a model wrote, in a language with
+// quoting, substitution, heredocs, aliases, functions and `eval` — and this file's job is to
+// reconstruct the structure that the string only implies. Reconstruction is inference, inference has
+// a residual error rate, and every one of #12/#13/#41/#44 plus the 07-27 heredoc misfire is a sample
+// from it. Being right about all five is not the same as being right about the next one.
+//
+// rUv's own ecosystem does not do this. It governs where the structure is ALREADY EXPLICIT:
+//   • ruvector/npm/packages/ruvector/bin/mcp-policy.js (ADR-256) decides by TOOL NAME over the MCP
+//     tool registry — an allowlist with a default-deny posture, precedence DENY > ALLOW/PROFILE.
+//     There is no string to parse: the caller already said which tool it wants, by name.
+//   • cognitum-seed's src/cognitum-agent/src/mcp_tools.rs maps tool name → AuthClass over a declared
+//     tool table, and `tool_auth_class()` returns `AuthClass::Paired` for an unknown name — an
+//     explicit SAFE DEFAULT for the case this file has to guess at.
+// Both are total functions over a finite, declared surface. Neither can be fooled by a quote.
+//
+// THE LONG-TERM FIX, recorded so it is not rediscovered a sixth time: move interface verification to
+// the structured boundary — the tool-call surface, where the tool name and its arguments arrive as
+// fields rather than as text to be re-derived — and shrink string handling to the minimum that the
+// remaining raw-Bash surface genuinely requires. This file should get smaller over time, not larger.
+// A new patch here is a signal to move the boundary, not to deepen the parser.
+// Filed as stuinfla/ruvnet-brain#48, which is where this decision lives until an ADR supersedes it.
+// (An earlier draft of this line also claimed an ADR-055 conflict-matrix row; that row was never
+// written — ADR-055 carries F1–F22 and none of them is this. A pointer to a doc that does not say
+// what the pointer claims is the same defect class this file exists to stop: asserting structure
+// that is not actually there.)
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+//
+// WHAT IS A COMMAND, AND WHAT IS DATA:
+//   COMMAND  simple commands split at `;` `&&` `||` `|` `&` newline and group boundaries; `$( … )`
+//            and backticks (live at top level AND inside double quotes); process substitutions
+//            `<( … )`; literal `sh -c` / `bash -lc` / `bash -ic` / `/bin/sh -c` payloads, recursively.
+//   DATA     every quoted ARGUMENT, heredoc bodies, herestrings, `#` comments, single-quoted `$( … )`
+//            (single quotes suppress substitution), and `$(( … ))` arithmetic.
+//   UNKNOWN  a dynamic executable (`$TOOL foo`, `eval "$cmd"`, `bash -c "$cmd"`). The name is not in
+//            the text, so there is nothing to classify: it is reported as NOT a managed invocation
+//            and the gate fails open — #12's lesson, kept.
+
+const SHELL_EXES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
+const NPX_WRAPPERS = new Set(['npx', 'bunx', 'pnpx']);
+const MAX_DEPTH = 8;    // `bash -c 'bash -c "…"'` nests; hostile input must still terminate
+const MAX_NODES = 256;  // and must not produce unbounded output
+
+function baseName(p) { const i = p.lastIndexOf('/'); return i === -1 ? p : p.slice(i + 1); }
+
+/** Skip a double-quoted region; `i` is the index just past the opening quote. Returns the index past its close. */
+function skipDouble(src, i) {
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '\\' && i + 1 < src.length) { i += 2; continue; }
+    if (c === '"') return i + 1;
+    if (c === '`') { i = readBacktick(src, i).next; continue; }
+    if (c === '$' && src[i + 1] === '(') { i = readParen(src, i + 2).next; continue; }
+    i++;
+  }
+  return src.length;
+}
+
+/** Read a `$( … )` body; `start` is the index just past `$(`. Quote- and nesting-aware. */
+function readParen(src, start) {
+  let depth = 1;
+  let i = start;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '\\' && i + 1 < src.length) { i += 2; continue; }
+    if (c === "'") { const e = src.indexOf("'", i + 1); i = e === -1 ? src.length : e + 1; continue; }
+    if (c === '"') { i = skipDouble(src, i + 1); continue; }
+    if (c === '`') { i = readBacktick(src, i).next; continue; }
+    if (c === '(') { depth++; i++; continue; }
+    if (c === ')') { depth--; if (depth === 0) return { body: src.slice(start, i), next: i + 1 }; i++; continue; }
+    i++;
+  }
+  return { body: src.slice(start), next: src.length };
+}
+
+/** Read a backtick substitution; `i` is the index of the opening backtick. */
+function readBacktick(src, i) {
+  let j = i + 1;
+  let body = '';
+  while (j < src.length) {
+    if (src[j] === '\\' && j + 1 < src.length && '$`\\'.includes(src[j + 1])) { body += src[j + 1]; j += 2; continue; }
+    if (src[j] === '`') return { body, next: j + 1 };
+    body += src[j]; j++;
+  }
+  return { body, next: src.length };
+}
+
+/** Skip `$(( … ))` arithmetic — not a command substitution, and its `<<` is not a heredoc. */
+function readArith(src, i) {
+  let depth = 0;
+  let j = i + 1;
+  while (j < src.length) {
+    if (src[j] === '(') depth++;
+    else if (src[j] === ')') { depth--; if (depth === 0) return { next: j + 1 }; }
+    j++;
+  }
+  return { next: src.length };
+}
+
+/** Skip a heredoc body (DATA, never commands) and its terminator line. */
+function skipHeredocBody(src, from, hd) {
+  let i = from;
+  while (i < src.length) {
+    let eol = src.indexOf('\n', i);
+    if (eol === -1) eol = src.length;
+    const line = src.slice(i, eol);
+    i = eol < src.length ? eol + 1 : src.length;
+    if ((hd.strip ? line.replace(/^\t+/, '') : line) === hd.delim) break;
+  }
+  return i;
+}
 
 /**
- * The command with quoted CONTENT masked to '_', so only shell-level metacharacters remain visible.
- * Quote characters themselves survive (offsets are preserved); a backslash-escaped char inside a
- * double-quoted string masks as two bytes (the backslash and the char it escapes). Single quotes take
- * no escapes, matching real shell semantics. An unterminated quote simply masks to the end of the
- * string — never throws, never loops.
- *
- * WHY (issue #41): a command-position regex matched against the RAW command reads a `|`, `;`, `&`,
- * `(`, or newline INSIDE a quoted string (e.g. `grep -E "foo|ruflo init"`) as a real shell separator,
- * so whatever follows is misread as command position. Matching against the skeleton instead removes
- * separators that are not actually shell separators. Outside quotes the skeleton is byte-identical to
- * the original, so capture-group offsets for a real match are unaffected.
+ * Split ONE level of shell text into simple commands (each a word list) plus the source text of
+ * every command substitution found in it. Words carry `dynamic` when any part of them came from an
+ * expansion, because a word whose text is not fully known cannot be classified.
  */
-export function shellSkeleton(cmd) {
-  let out = '';
-  let q = null;
-  for (let i = 0; i < cmd.length; i++) {
-    const ch = cmd[i];
-    if (q === '"' && ch === '\\' && i + 1 < cmd.length) { out += '__'; i++; continue; } // escaped char
-    if (q) { if (ch === q) { q = null; out += ch; } else out += '_'; continue; }
-    if (ch === '"' || ch === "'") { q = ch; out += ch; continue; }
-    out += ch;
+function parseLevel(src) {
+  const nodes = [];
+  const subs = [];
+  let words = [];
+  let cur = null;
+  const heredocQ = [];
+  let i = 0;
+  const n = src.length;
+
+  const add = (t) => { if (!cur) cur = { text: '', dynamic: false }; cur.text += t; };
+  const mark = () => { if (!cur) cur = { text: '', dynamic: false }; cur.dynamic = true; };
+  const endWord = () => { if (cur) { words.push(cur); cur = null; } };
+  const endNode = () => { endWord(); if (words.length) nodes.push(words); words = []; };
+
+  while (i < n) {
+    const ch = src[i];
+
+    if (ch === '\\' && i + 1 < n) {                       // escape: the next byte is literal text
+      if (src[i + 1] !== '\n') add(src[i + 1]);           // (a `\<newline>` is a line continuation)
+      i += 2; continue;
+    }
+
+    if (ch === "'") {                                     // single quotes: literal, no escapes, no
+      const e = src.indexOf("'", i + 1);                  // substitution — pure DATA
+      const end = e === -1 ? n : e;
+      add(src.slice(i + 1, end));
+      i = end + 1; continue;
+    }
+
+    if (ch === '"') {                                     // double quotes: DATA, except substitutions
+      i++;
+      if (!cur) cur = { text: '', dynamic: false };
+      while (i < n) {
+        const c = src[i];
+        if (c === '\\' && i + 1 < n && '$`"\\\n'.includes(src[i + 1])) {
+          if (src[i + 1] !== '\n') add(src[i + 1]);
+          i += 2; continue;
+        }
+        if (c === '"') { i++; break; }
+        if (c === '`') { const r = readBacktick(src, i); subs.push(r.body); mark(); i = r.next; continue; }
+        if (c === '$' && src[i + 1] === '(' && src[i + 2] === '(') { mark(); i = readArith(src, i).next; continue; }
+        if (c === '$' && src[i + 1] === '(') { const r = readParen(src, i + 2); subs.push(r.body); mark(); i = r.next; continue; }
+        if (c === '$') { mark(); add('$'); i++; continue; }
+        add(c); i++;
+      }
+      continue;
+    }
+
+    if (ch === '`') { const r = readBacktick(src, i); subs.push(r.body); mark(); i = r.next; continue; }
+    if (ch === '$' && src[i + 1] === '(' && src[i + 2] === '(') { mark(); i = readArith(src, i).next; continue; }
+    if (ch === '$' && src[i + 1] === '(') { const r = readParen(src, i + 2); subs.push(r.body); mark(); i = r.next; continue; }
+    if (ch === '$') { mark(); add('$'); i++; continue; }
+
+    if ((ch === '<' || ch === '>') && src[i + 1] === '(') {   // process substitution — a real command
+      const r = readParen(src, i + 2);
+      subs.push(r.body); endWord(); i = r.next; continue;
+    }
+
+    if (ch === '<' && src[i + 1] === '<' && src[i + 2] === '<') { endWord(); i += 3; continue; } // herestring: DATA
+
+    if (ch === '<' && src[i + 1] === '<') {                   // heredoc: body is DATA, skipped whole
+      let j = i + 2;
+      let strip = false;
+      if (src[j] === '-') { strip = true; j++; }
+      while (j < n && (src[j] === ' ' || src[j] === '\t')) j++;
+      let delim = '';
+      while (j < n && !' \t\n;&|<>()'.includes(src[j])) {
+        const c = src[j];
+        if (c === "'" || c === '"') {
+          const e = src.indexOf(c, j + 1);
+          const end = e === -1 ? n : e;
+          delim += src.slice(j + 1, end); j = end + 1; continue;
+        }
+        if (c === '\\' && j + 1 < n) { delim += src[j + 1]; j += 2; continue; }
+        delim += c; j++;
+      }
+      endWord();
+      if (delim) heredocQ.push({ delim, strip });
+      i = j; continue;
+    }
+
+    if (ch === '<' || ch === '>') {                           // redirection: a word boundary
+      endWord(); i++;
+      if (src[i] === '>') i++;
+      if (src[i] === '&') i++;
+      continue;
+    }
+
+    if (ch === '#' && !cur && (i === 0 || ' \t\n;&|('.includes(src[i - 1]))) {  // comment: DATA
+      const eol = src.indexOf('\n', i);
+      i = eol === -1 ? n : eol; continue;
+    }
+
+    if (ch === ';') { endNode(); i++; continue; }
+    if (ch === '&') { endNode(); i++; if (src[i] === '&') i++; continue; }
+    if (ch === '|') { endNode(); i++; if (src[i] === '|') i++; continue; }
+    if (ch === '(' || ch === ')' || ch === '{' || ch === '}') { endNode(); i++; continue; }
+    if (ch === ' ' || ch === '\t') { endWord(); i++; continue; }
+
+    if (ch === '\n') {
+      endNode(); i++;
+      while (heredocQ.length && i < n) i = skipHeredocBody(src, i, heredocQ.shift());
+      continue;
+    }
+
+    add(ch); i++;
+  }
+  endNode();
+  return { nodes, subs };
+}
+
+const ASSIGN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * Every EXECUTABLE command node in `cmd`, recursively — the one question this module answers.
+ *
+ * Each node: { exe, argv, assigns, dynamic }. `argv[0]` is the executable as written; an argument
+ * whose text is not fully known (it contained an expansion) is reported as `''`, never as a
+ * half-word that could be mistaken for a literal token. `dynamic: true` means the EXECUTABLE itself
+ * is unknown — the caller must fail open.
+ */
+export function commandNodes(cmd, depth = 0, acc = []) {
+  if (typeof cmd !== 'string' || !cmd || depth > MAX_DEPTH || acc.length >= MAX_NODES) return acc;
+  const { nodes, subs } = parseLevel(cmd);
+  const payloads = [];
+
+  for (const words of nodes) {
+    if (acc.length >= MAX_NODES) break;
+    let k = 0;
+    const assigns = [];
+    while (k < words.length && ASSIGN_RE.test(words[k].text)) { assigns.push(words[k].text); k++; }
+    const rest = words.slice(k);
+    if (!rest.length) continue;
+    const node = {
+      assigns,
+      dynamic: rest[0].dynamic,
+      exe: rest[0].dynamic ? '' : rest[0].text,
+      argv: rest.map((w) => (w.dynamic ? '' : w.text)),
+    };
+    acc.push(node);
+
+    // `sh -c '…'` / `bash -lc '…'`: the argument after a short-flag cluster ending in `c` is a
+    // command string BY DEFINITION. If it is not literal it comes through as '' and is skipped —
+    // `bash -c "$cmd"` has nothing to classify, so the gate fails open.
+    if (!node.dynamic && SHELL_EXES.has(baseName(node.exe))) {
+      for (let a = 1; a < node.argv.length; a++) {
+        const w = node.argv[a];
+        if (!w.startsWith('-')) break;
+        if (/^-[A-Za-z]*c$/.test(w)) { if (node.argv[a + 1]) payloads.push(node.argv[a + 1]); break; }
+      }
+    }
+  }
+
+  for (const s of subs) commandNodes(s, depth + 1, acc);
+  for (const p of payloads) commandNodes(p, depth + 1, acc);
+  return acc;
+}
+
+/**
+ * Does `cmd` invoke any of `tools` AS AN EXECUTABLE, anywhere — nested shells, substitutions and
+ * all? Returns one entry per invocation: { tool, args }, where `args` is that node's own argument
+ * list. Prose, comments, heredoc text, quoted arguments and dynamic executables return nothing.
+ *
+ * `npx`/`bunx`/`pnpx` wrappers are transparent, and a `@version` suffix is stripped — but ONLY at an
+ * explicit `@`, so `ruflo-source-patch` is a different binary and not `ruflo` (issue #12).
+ */
+export function findInvocations(cmd, tools) {
+  const want = new Set((Array.isArray(tools) ? tools : String(tools || '').split(',')).map((t) => t.trim()).filter(Boolean));
+  const out = [];
+  if (!want.size) return out;
+  for (const node of commandNodes(cmd)) {
+    if (node.dynamic || !node.argv.length) continue;
+    let idx = 0;
+    if (NPX_WRAPPERS.has(baseName(node.argv[0]))) {
+      idx = 1;
+      while (idx < node.argv.length && node.argv[idx].startsWith('-')) idx++;
+      if (idx >= node.argv.length) continue;
+    }
+    let name = baseName(node.argv[idx]);
+    const at = name.indexOf('@');
+    if (at > 0) name = name.slice(0, at);
+    if (!want.has(name)) continue;
+    out.push({ tool: name, args: node.argv.slice(idx + 1) });
   }
   return out;
+}
+
+/** The findInvocations answer as TAB-separated lines (`tool<TAB>arg…`), one per invocation. */
+export function invocationLines(cmd, tools) {
+  const clean = (s) => String(s).replace(/[\t\r\n]/g, ' ');
+  return findInvocations(cmd, tools)
+    .map((inv) => [inv.tool, ...inv.args].map(clean).join('\t'))
+    .join('\n');
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────────────────────────
@@ -110,7 +425,7 @@ if (isMain()) {
     if (which === 'tool_name') out = toolName(ev);
     else if (which === 'command') out = commandOf(ev);
     else if (which === 'field') out = field(ev, process.argv[3] || '');
-    else if (which === 'skeleton') out = shellSkeleton(commandOf(ev));
+    else if (which === 'invocations') out = invocationLines(commandOf(ev), process.argv[3] || '');
     process.stdout.write(out);
     // ALWAYS exit 0: a parse miss is an empty string, never a crash the gate has to survive.
     process.exit(0);

--- a/plugin/scripts/verify-interface.sh
+++ b/plugin/scripts/verify-interface.sh
@@ -69,14 +69,59 @@
 # awareness of shell quoting: a `|`, `;`, `&`, `(`, or newline INSIDE a quoted string (a grep pattern's
 # regex alternation, an awk program, a `git commit -m` message) reads as a real shell separator, so
 # whatever follows is misread as command position. `grep -E "foo|ruflo init" file.txt` blocked on an
-# ordinary read-only search. Fixed by matching against a quote-masked SKELETON of the command
-# (`shellSkeleton()` in hook-input.mjs, ADR-0021's one shared parser) instead of the raw string:
-# quoted CONTENT is replaced with `_`, quote characters and everything outside quotes survive
-# byte-identical, so a `|` etc. inside quotes is masked away while a real shell separator outside
-# quotes still anchors the match. Capture groups are unaffected because any surviving match lies
-# outside quotes, where the skeleton equals the original. Computed once and reused by both the
-# help-recording branch and the blocking branch, which share MATCH_RE. Fails open (exit 0) if the
-# skeleton verb errors for any reason — same contract as every other step here.
+# ordinary read-only search. That was fixed by matching a quote-masked SKELETON of the command rather
+# than the raw string — and the skeleton is now gone too, replaced by the classifier described below.
+# The invariant it won survives verbatim: a separator inside quotes is CONTENT, and the tool name
+# after it is an ARGUMENT, not command position.
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+#
+# FIX (2026-07-27, issue #44 — github.com/sparkling's FOURTH report on this one file (#12, #13, #41,
+# #44), and the mirror image of #41: that was a false POSITIVE, this is a false NEGATIVE in the very
+# same matcher. Four reports on one gate is the signal ADR-055/#48 acts on, so the count is kept
+# accurate deliberately rather than rounded down.)
+#
+# #41's skeleton was right, and it opened a hole. A DEFINITE invocation nested inside a literal shell
+# payload, a backtick substitution, or a `$( … )` inside double quotes is *inside quotes* — so the
+# skeleton masked it away and the gate never saw it. All three of these were ALLOWED while the
+# identical bare command BLOCKED:
+#     bash -lc 'ruflo memory search -q x'
+#     x=`ruflo memory search -q x`
+#     printf '%s\n' "$(ruflo memory search -q x)"
+# (`x=$(ruflo …)` unquoted blocked only by luck: `$(`'s paren happens to be in the command-position
+# anchor class. Wrap it in double quotes and the same call walked straight through.) A nested
+# invocation is an invocation — `bash -lc 'ruflo memory search -q x'` guesses at exactly the flags
+# this wall exists to stop me guessing at.
+#
+# WHAT ACTUALLY CHANGED, AND WHY IT IS NOT A FIFTH PATCH. Masking-then-matching was still a STRING
+# question asked about a STRUCTURAL fact, and every previous fix was another turn of that screw: a
+# better anchor (#12), a real JSON parse (#13), a better mask (#41). The mask is deleted. This gate no
+# longer looks at the command string to decide what is being invoked at all. hook-input.mjs
+# (ADR-0021's one shared module) now parses the command into EXECUTABLE COMMAND NODES —
+# `commandNodes()` returning `{ exe, argv, assigns, dynamic }` per node — and this gate asks it one
+# question through the `invocations` verb: is any managed tool in EXECUTABLE POSITION anywhere in
+# here? Everything below operates on already-split argv tokens; no pattern is ever applied to $CMD
+# again (the single remaining `=~` is the fail-OPEN opt-out token, and it is labelled where it sits).
+#
+# WHAT THE PARSER TREATS AS A COMMAND, AND WHAT AS DATA — this is the whole discipline, and it is what
+# keeps the fix from re-creating #41:
+#   • Pipelines, `;`, `&&`, `||`, `&`, newlines and group boundaries split simple commands.
+#   • `$( … )` and backticks are commands at top level AND inside double quotes — recursed into.
+#   • …and are inert inside SINGLE quotes and inside heredoc bodies — DATA, never inspected.
+#   • `sh -c` / `bash -lc` / `bash -ic` / `/bin/bash -c` payloads are commands by definition —
+#     recursed into, and recursively so, bounded by MAX_DEPTH/MAX_NODES.
+#   • Process substitutions `<( … )` are commands; herestrings, `#` comments and every quoted
+#     ARGUMENT are DATA.
+#   • A DYNAMIC executable (`$TOOL memory search`, `eval "$cmd"`, `bash -c "$cmd"`) is reported with
+#     `dynamic: true` and an empty `exe`: the name is not in the text, so there is nothing to
+#     classify and this gate never sees it — fail open, #12's lesson kept.
+# Heredoc bodies being DATA also retires a pre-existing false positive that #44's recursion would
+# otherwise have made worse, and which bit the maintainer live on 2026-07-27: a doc heredoc whose
+# line begins with a tool name ("agentic-qe integration plan"), or that quotes a `$(ruflo …)`
+# example, blocked an ordinary `cat <<'EOF'`.
+#
+# Both branches below — help-recording and blocking — read the SAME classifier output. "Two regexes
+# for one concept is how you get a gate that never opens" was written into this file's tests in blood;
+# there is now one answer and no second path to it, by construction.
 # ─────────────────────────────────────────────────────────────────────────────────────────────────
 
 set -uo pipefail
@@ -104,64 +149,100 @@ TOOL_NAME=$(printf '%s' "$INPUT" | "$NODE_BIN" "$HOOK_INPUT" tool_name 2>/dev/nu
 CMD=$(printf '%s' "$INPUT" | "$NODE_BIN" "$HOOK_INPUT" command 2>/dev/null) || exit 0
 [ -n "$CMD" ] || exit 0
 
-# Quote-masked skeleton of CMD (issue #41, residual of #12): quoted CONTENT is replaced with `_`;
-# quote characters and everything outside quotes survive byte-identical. MATCH_RE below is matched
-# against SKEL, not CMD, so a `|`/`;`/`&`/`(`/newline INSIDE a quoted string (a grep pattern's regex
-# alternation, a commit message, an awk program) is no longer mistaken for a real shell separator.
-# Capture-group offsets for any surviving match are unaffected — a match can only survive outside
-# quotes, where SKEL equals CMD exactly. Computed once, used by both branches below.
-SKEL=$(printf '%s' "$INPUT" | "$NODE_BIN" "$HOOK_INPUT" skeleton 2>/dev/null) || exit 0
+# EVERY invocation of a managed CLI in this command, from the shared CLASSIFIER (hook-input.mjs).
+#
+# This is the whole fix for the four-issue streak. The gate no longer asks a STRING question about a
+# structural fact. It asks the parser one question — "is any of these tools in EXECUTABLE position
+# anywhere in this command?" — and the parser answers it from real shell structure: pipelines, `$( )`
+# and backticks (live at top level and inside double quotes), literal `sh -c`/`bash -lc`/`-ic`
+# payloads recursively, process substitutions, leading assignments. Quoted arguments, heredoc bodies,
+# herestrings, `#` comments and single-quoted `$( )` are DATA and never appear. A dynamic executable
+# (`$TOOL …`, `eval "$cmd"`, `bash -c "$cmd"`) is UNKNOWN and never appears either — fail open.
+#
+# There is deliberately NO regex fallback. MATCH_RE is gone, not demoted: a second path is precisely
+# how this defect class survived #12, #13, #41 and #44.
+#
+# Output: one TAB-separated line per invocation — `tool<TAB>arg<TAB>arg…`. Empty = nothing to check.
+# The tool LIST is policy and stays here; the STRUCTURE is the parser's. Only the ecosystem CLIs whose
+# interfaces I keep guessing at — NOT git/ls/grep. This must not become a tax on ordinary work, or it
+# gets switched off and protects nothing.
+TOOLS='ruflo,claude-flow,agentic-flow,agentic-qe,ruvector,agent-browser,ruv-swarm'
+INV=$(printf '%s' "$INPUT" | "$NODE_BIN" "$HOOK_INPUT" invocations "$TOOLS" 2>/dev/null) || exit 0
+[ -n "$INV" ] || exit 0
 
 # Per-command override (issue #12, defect 2). The block message tells the caller to set this ON THE
 # COMMAND — so check the command STRING, not this process's environment (which the caller never
 # touches: a PreToolUse hook only ever sees the proposed command as text on stdin).
+#
+# This one flat-string test is deliberate and is NOT the pattern the classifier replaced. It is an
+# opt-OUT: its worst failure is that the token appearing in prose lets a command through, which is
+# fail-open — the contract this gate already grants on every parse it cannot make. The banned pattern
+# is deciding an INVOCATION from a flat string, where the failures are a missed block and a blocked
+# innocent. Keeping it flat also preserves the `export RUVNET_SKIP_INTERFACE_CHECK=1; …` form.
 [[ $CMD =~ (^|[[:space:]])RUVNET_SKIP_INTERFACE_CHECK=1([[:space:]]|$) ]] && exit 0
 
-# Only the ecosystem CLIs whose interfaces I keep guessing at. NOT git/ls/grep — this must not become
-# a tax on ordinary work, or it gets switched off and protects nothing.
-TOOLS='ruflo|claude-flow|agentic-flow|agentic-qe|ruvector|agent-browser|ruv-swarm'
+# Granularity is policy, and it has to match the mistake it prevents: TWO levels (`memory search`,
+# not just `memory`), because `ruflo memory --help` lists subcommands but never shows `search`'s
+# `-q` — and `-q` is the exact flag I guessed wrong. Pure bash builtins over already-parsed argv
+# tokens: no pattern is ever applied to the command STRING again.
+#   $1 = the invocation's TAB-separated arg list, already split by the caller into $F
+# Sets: SUB1 SUB2 (subcommand levels, possibly empty) and IS_HELP.
+subcommand_of() {
+  SUB1=""; SUB2=""; IS_HELP=0
+  local k w
+  for ((k = 1; k < ${#F[@]}; k++)); do
+    w="${F[k]}"
+    [ "$w" = "--help" ] || [ "$w" = "-h" ] && IS_HELP=1
+  done
+  for ((k = 1; k < ${#F[@]}; k++)); do
+    w="${F[k]}"
+    [ -n "$w" ] || break                       # a dynamic arg: its value is unknown, so stop here
+    case "$w" in
+      [a-z]*) ;;                               # a subcommand looks like a lowercase word …
+      *) break ;;
+    esac
+    case "$w" in *[!a-z-]*) break ;; esac      # … of [a-z-] only (this also rejects -flags)
+    if [ -z "$SUB1" ]; then SUB1="$w"; else SUB2="$w"; break; fi
+  done
+}
 
-# ONE regex, used by BOTH paths. My first version used a DIFFERENT (weaker) regex on the help-recording
-# path — it lacked the `@[A-Za-z0-9._-]+` that absorbs `@latest`, so reading `ruflo@latest memory search
-# --help` recorded NOTHING and the very next call was still blocked. The break-test caught it before it
-# shipped. Two regexes for one concept is how you get a gate that never opens.
-#
-# Capture TWO levels (`memory search`, not just `memory`): `ruflo memory --help` lists subcommands but
-# does NOT show `search`'s `-q` flag — and `-q` is the exact thing I guessed wrong. Granularity has to
-# match the mistake it prevents.
-#
-# ANCHORED to command position (issue #12, defect 1): the version suffix now requires a leading `@`
-# (it no longer absorbs an arbitrary hyphenated tail, which used to misread `ruflo-source-patch` as
-# `ruflo` with subcommand `source-patch`), and the whole match must start at the beginning of the
-# command, or right after a shell separator (`;`, `&`, `|`, `(`, newline) — optionally through a
-# leading `npx ` — instead of anywhere the tool's name happens to appear. This is what keeps
-# `npx ruflo@latest memory search` recognized as a real invocation while a sentence that merely
-# *mentions* `ruflo memory search` inside a quoted string, echo argument, or commit message is not.
-NL=$'\n'
-MATCH_RE="(^|[;&|(${NL}])[[:space:]]*(npx[[:space:]]+)?($TOOLS)(@[A-Za-z0-9._-]+)?[[:space:]]+([a-z][a-z-]*)([[:space:]]+([a-z][a-z-]*))?"
+# PASS 1 — record every help read FIRST. Reading help is always allowed, and doing this before any
+# blocking decision means `ruflo x --help && ruflo x -q y` works in one command: the read satisfies
+# the call. (The old flat test asked whether `--help` appeared ANYWHERE in the command string, which
+# both missed `bash -lc 'ruflo … --help'` — the quote after `--help` is not whitespace — and let an
+# unrelated `grep -h` unlock a completely different tool's unread invocation.)
+SAW_HELP=0
+while IFS=$'\t' read -r -a F; do
+  [ ${#F[@]} -gt 0 ] || continue
+  subcommand_of
+  [ "$IS_HELP" = "1" ] || continue
+  [ -n "$SUB1" ] || continue
+  SAW_HELP=1
+  mkdir -p "$HOME/.cache/ruvnet-brain/help-read" 2>/dev/null || true
+  : > "$HOME/.cache/ruvnet-brain/help-read/${F[0]}.$SUB1${SUB2:+.$SUB2}" 2>/dev/null || true
+  # `ruflo memory search --help` also satisfies the parent `ruflo memory` — the child is strictly more.
+  : > "$HOME/.cache/ruvnet-brain/help-read/${F[0]}.$SUB1" 2>/dev/null || true
+done <<< "$INV"
 
-if [[ $CMD =~ (--help|-h)([[:space:]]|$) ]]; then   # reading help is ALWAYS allowed — and recorded
-  if [[ $SKEL =~ $MATCH_RE ]]; then
-    KEY="${BASH_REMATCH[3]}.${BASH_REMATCH[5]}${BASH_REMATCH[7]:+.${BASH_REMATCH[7]}}"
-    mkdir -p "$HOME/.cache/ruvnet-brain/help-read" 2>/dev/null || true
-    : > "$HOME/.cache/ruvnet-brain/help-read/$KEY" 2>/dev/null || true
-    # `ruflo memory search --help` also satisfies the parent `ruflo memory` — the child is strictly more.
-    : > "$HOME/.cache/ruvnet-brain/help-read/${BASH_REMATCH[3]}.${BASH_REMATCH[5]}" 2>/dev/null || true
+# PASS 2 — block the first invocation whose interface has not been read in the last 24h.
+TOOL=""; SUB=""; KEY=""
+while IFS=$'\t' read -r -a F; do
+  [ ${#F[@]} -gt 0 ] || continue
+  subcommand_of
+  [ "$IS_HELP" = "1" ] && continue
+  [ -n "$SUB1" ] || continue                   # `ruflo` with no subcommand: nothing to ground
+  K="${F[0]}.$SUB1${SUB2:+.$SUB2}"
+  S="$HOME/.cache/ruvnet-brain/help-read/$K"
+  if [ -f "$S" ]; then
+    NOW=$(date +%s 2>/dev/null) || exit 0
+    THEN=$(date -r "$S" +%s 2>/dev/null) || exit 0
+    [ $((NOW - THEN)) -lt 86400 ] && continue  # read within the last 24h (these are @latest packages)
   fi
-  exit 0
-fi
+  TOOL="${F[0]}"; SUB="$SUB1${SUB2:+ $SUB2}"; KEY="$K"
+  break
+done <<< "$INV"
 
-[[ $SKEL =~ $MATCH_RE ]] || exit 0
-TOOL="${BASH_REMATCH[3]}"; SUB="${BASH_REMATCH[5]}${BASH_REMATCH[7]:+ ${BASH_REMATCH[7]}}"
-KEY="${BASH_REMATCH[3]}.${BASH_REMATCH[5]}${BASH_REMATCH[7]:+.${BASH_REMATCH[7]}}"
-
-STAMP="$HOME/.cache/ruvnet-brain/help-read/$KEY"
-# Read within the last 24h? (interfaces move — these are @latest/@alpha packages)
-if [ -f "$STAMP" ]; then
-  NOW=$(date +%s 2>/dev/null) || exit 0
-  THEN=$(date -r "$STAMP" +%s 2>/dev/null) || exit 0
-  [ $((NOW - THEN)) -lt 86400 ] && exit 0
-fi
+[ -n "$TOOL" ] || exit 0
 
 read -r -d '' MSG <<EOF || true
 ⛔ BLOCKED — you have not read the interface for: ${TOOL} ${SUB}

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v3.9.98-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v3.9.100-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/tests/unit/hook-input.test.mjs
+++ b/tests/unit/hook-input.test.mjs
@@ -4,7 +4,7 @@
 // parser returns the whole string; the old regex returned everything up to the first `"` and the gate
 // failed open on it.
 import { describe, it, expect } from 'vitest';
-import { parseHookEvent, toolName, commandOf, field, shellSkeleton } from '../../plugin/scripts/hook-input.mjs';
+import { parseHookEvent, toolName, commandOf, field, commandNodes, findInvocations } from '../../plugin/scripts/hook-input.mjs';
 
 describe('hook-input — the shared PreToolUse payload parser (ADR-0021)', () => {
   it('KNOWN-BAD (the #13 fail-open): a command with embedded quotes is returned WHOLE, not truncated', () => {
@@ -52,63 +52,208 @@ describe('hook-input — the shared PreToolUse payload parser (ADR-0021)', () =>
   });
 });
 
-describe('shellSkeleton — quote-masked command, for command-position matching (issue #41)', () => {
-  it('empty string in, empty string out', () => {
-    expect(shellSkeleton('')).toBe('');
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// commandNodes / findInvocations — the CLASSIFIER that replaced shellSkeleton + shellScanUnits.
+//
+// Those two helpers answered a STRING question ("mask the quoted bytes, then regex the result for
+// command position"). Every invariant they protected is real; each one is re-expressed below against
+// the question the gate now actually asks — WHICH EXECUTABLES DOES THIS COMMAND RUN? — and each test
+// names the assertion it carries forward, so nothing the old suite guarded is now unguarded.
+//
+// Two old assertions were about the MASK, not about an invariant, and are stated structurally here
+// instead: "quote characters survive, content is masked" is really "a quoted region is exactly ONE
+// argument whose bytes are preserved as data", and every `skel.length === cmd.length` offset check is
+// really "the surrounding script is unaffected". Byte offsets were a property of the mask; there is no
+// mask any more, and asserting them would be pinning an implementation again — which is precisely
+// what made these tests die when the implementation was replaced.
+
+const exes = (cmd) => commandNodes(cmd).map((n) => (n.dynamic ? '<dynamic>' : n.exe));
+const invoked = (cmd, tools = 'ruflo') => findInvocations(cmd, tools).map((i) => [i.tool, ...i.args].join(' '));
+
+describe('commandNodes — quoted DATA never becomes a command (was: shellSkeleton, issue #41)', () => {
+  it('(was: empty in, empty out) nothing to run yields no nodes, and never a throw', () => {
+    expect(commandNodes('')).toEqual([]);
+    expect(commandNodes(null)).toEqual([]);
+    expect(commandNodes(undefined)).toEqual([]);
+    expect(commandNodes(42)).toEqual([]);
   });
 
-  it('no quotes at all: passes through byte-identical', () => {
-    const cmd = 'ruflo memory search -q x';
-    expect(shellSkeleton(cmd)).toBe(cmd);
+  it('(was: no quotes passes through byte-identical) a plain command is ONE node, argv word-for-word', () => {
+    expect(commandNodes('ruflo memory search -q x')).toEqual([
+      { assigns: [], dynamic: false, exe: 'ruflo', argv: ['ruflo', 'memory', 'search', '-q', 'x'] },
+    ]);
   });
 
-  it('THE BUG (issue #41): a separator char INSIDE a double-quoted grep pattern is masked, not exposed', () => {
-    // `grep -E "foo|ruflo init" file.txt` — the `|` sits inside the pattern argument. The old raw-CMD
-    // anchor read it as a real shell separator and misread `ruflo init` as command position. The
-    // skeleton must remove that `|` from view while keeping the quote characters and everything
-    // outside the quotes untouched.
-    const skel = shellSkeleton('grep -E "foo|ruflo init" file.txt');
-    expect(skel).not.toContain('|'); // the separator character is gone — it was inside quotes
-    expect(skel).not.toContain('ruflo'); // so is the tool name that used to leak through
-    expect(skel.startsWith('grep -E "')).toBe(true);
-    expect(skel.endsWith('" file.txt')).toBe(true);
-    expect(skel.length).toBe('grep -E "foo|ruflo init" file.txt'.length); // offsets preserved
+  it('THE BUG (issue #41): a `|` inside a quoted grep pattern is an ARGUMENT, not a command boundary', () => {
+    // `grep -E "foo|ruflo init" file.txt` — the reporter's case. The old raw-CMD anchor read that `|`
+    // as a real shell separator and misread `ruflo init` as command position, blocking an ordinary
+    // read-only search. The masking fix hid the `|`; the parser never sees a separator there at all,
+    // because the whole quoted region is ONE WORD. Both halves of the invariant, structurally:
+    const cmd = 'grep -E "foo|ruflo init" file.txt';
+    expect(commandNodes(cmd)).toHaveLength(1);                     // ONE command node — no boundary
+    expect(commandNodes(cmd)[0].exe).toBe('grep');                 // …and it is grep
+    expect(commandNodes(cmd)[0].argv).toEqual(['grep', '-E', 'foo|ruflo init', 'file.txt']);
+    expect(invoked(cmd)).toEqual([]);                              // ruflo is NOT an invoked executable
   });
 
-  it('quote characters themselves survive; only the CONTENT between them is masked', () => {
-    const skel = shellSkeleton('echo "a|b" \'c;d\'');
-    expect(skel).toBe('echo "___" \'___\'');
+  it('(was: quote chars survive, content masked) a quoted region is ONE argument, bytes preserved', () => {
+    // Old form asserted `echo "___" '___'`. The invariant underneath is that quoted text is a single
+    // opaque DATA argument — separators inside it are content, and the content is not mangled.
+    expect(commandNodes(`echo "a|b" 'c;d'`)).toEqual([
+      { assigns: [], dynamic: false, exe: 'echo', argv: ['echo', 'a|b', 'c;d'] },
+    ]);
   });
 
-  it('a real, unquoted separator still survives the mask (command position is still detectable)', () => {
-    const skel = shellSkeleton('echo hi | ruflo memory search');
-    expect(skel).toContain('| ruflo memory search'); // outside any quotes — byte-identical to input
+  it('(was: a real unquoted separator survives the mask) a real separator DOES split commands', () => {
+    // The other side of #41: masking must not blind the gate to genuine command position.
+    expect(exes('echo hi | ruflo memory search')).toEqual(['echo', 'ruflo']);
+    expect(invoked('echo hi | ruflo memory search')).toEqual(['ruflo memory search']);
+    for (const sep of [';', '&&', '||', '|', '&', '\n']) {
+      expect(exes(`echo hi ${sep} ruflo init`), `separator ${JSON.stringify(sep)}`).toEqual(['echo', 'ruflo']);
+    }
   });
 
-  it('backslash-escaped quote inside a double-quoted string does not prematurely close the quote', () => {
-    // Mirrors the #13 fixture: an escaped `\"` is a literal `"` byte in the raw text but must not end
-    // the quoted region. The escape (backslash + escaped char) masks as two bytes; the real closing
-    // quote at the very end must still be recognized and preserved.
+  it('(was: escaped quote does not close the quote) the #13 fixture is ONE node, content intact', () => {
+    // An escaped `\"` is a literal `"` byte in the raw text but must not end the quoted region. If it
+    // did, the tail would be re-read as shell code and `quoted` / `thing` would surface as commands.
     const cmd = 'git commit -m "fix: \\"quoted\\" thing"';
-    const skel = shellSkeleton(cmd);
-    expect(skel.length).toBe(cmd.length); // offsets preserved through the escape handling
-    expect(skel.startsWith('git commit -m "')).toBe(true);
-    expect(skel.endsWith('"')).toBe(true);
-    expect(skel).not.toContain('quoted'); // masked, including the text between the escaped quotes
+    expect(commandNodes(cmd)).toHaveLength(1);
+    expect(commandNodes(cmd)[0].argv).toEqual(['git', 'commit', '-m', 'fix: "quoted" thing']);
+    expect(exes(cmd)).toEqual(['git']); // nothing after the quote became a command
   });
 
-  it('single quotes take no escapes — a backslash inside them is ordinary masked content', () => {
-    // "a\|b" is 4 literal characters (a, \, |, b) — the backslash has no escaping power inside single
-    // quotes (real shell semantics), so it is masked like any other content byte, not consumed as an
-    // escape the way it would be inside double quotes.
-    const skel = shellSkeleton("echo 'a\\|b'");
-    expect(skel).toBe("echo '____'");
+  it('(was: single quotes take no escapes) a backslash inside single quotes is ordinary content', () => {
+    // `'a\|b'` is 4 literal characters (a, \, |, b) — real shell semantics: single quotes have no
+    // escapes at all, so the backslash must NOT be consumed the way it is inside double quotes.
+    const argv = commandNodes("echo 'a\\|b'")[0].argv;
+    expect(argv).toEqual(['echo', 'a\\|b']);
+    expect(argv[1]).toHaveLength(4);
   });
 
-  it('an unterminated quote masks to the end of the string — never throws, never hangs', () => {
-    expect(() => shellSkeleton('echo "never closes')).not.toThrow();
-    const skel = shellSkeleton('echo "never closes');
-    expect(skel).toBe('echo "____________');
-    expect(skel.length).toBe('echo "never closes'.length);
+  it('(was: unterminated quote masks to end) an unclosed quote terminates and stays DATA', () => {
+    expect(() => commandNodes('echo "never closes')).not.toThrow();
+    expect(commandNodes('echo "never closes')).toEqual([
+      { assigns: [], dynamic: false, exe: 'echo', argv: ['echo', 'never closes'] },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Issue #44: masking alone was not enough. A DEFINITE command node nested inside a literal
+// `bash -lc '…'` payload, a backtick substitution, or a `$( … )` inside double quotes is *inside
+// quotes* — masked out, invisible to any gate matching on the masked text. The parser recurses into
+// exactly those, and into nothing else: a nested node is a command only when its EXECUTABLE is
+// LITERAL, which is the line that keeps this from becoming #41 again.
+describe('commandNodes — nested commands are commands (was: shellScanUnits, issue #44)', () => {
+  it('(was: unit 0 is the top-level skeleton) top-level nodes come first, and simple stays simple', () => {
+    expect(commandNodes('ls -la')).toHaveLength(1);
+    expect(exes("bash -lc 'ruflo memory search -q x'")).toEqual(['bash', 'ruflo']); // top level, then nested
+  });
+
+  it('DEFINITE nested nodes are found: sh -c payloads, backticks, $() — including inside "…"', () => {
+    expect(invoked("bash -lc 'ruflo memory search -q x'")).toEqual(['ruflo memory search -q x']);
+    expect(invoked('sh -c "ruflo memory search -q x"')).toEqual(['ruflo memory search -q x']);
+    expect(invoked("bash -ic 'ruflo init'")).toEqual(['ruflo init']);
+    expect(invoked("/bin/bash -c 'ruflo init'")).toEqual(['ruflo init']);
+    expect(invoked("bash --login -c 'ruflo init'")).toEqual(['ruflo init']);
+    expect(invoked('x=`ruflo memory search -q x`')).toEqual(['ruflo memory search -q x']);
+    expect(invoked('x=$(ruflo memory search -q x)')).toEqual(['ruflo memory search -q x']);
+    expect(invoked(`printf '%s' "$(ruflo memory search -q x)"`)).toEqual(['ruflo memory search -q x']);
+    expect(invoked('echo "out: `ruflo init`"')).toEqual(['ruflo init']);
+    expect(invoked('diff <(ruflo init) f')).toEqual(['ruflo init']); // process substitution
+  });
+
+  it('a leading assignment does not hide the executable behind it', () => {
+    expect(commandNodes('FOO=1 ruflo init')[0]).toMatchObject({ assigns: ['FOO=1'], exe: 'ruflo' });
+    expect(invoked('FOO=1 ruflo init')).toEqual(['ruflo init']);
+  });
+
+  it('recurses: a payload inside a payload is still a definite command', () => {
+    expect(invoked(`bash -c 'sh -c "ruflo init"'`)).toEqual(['ruflo init']);
+    expect(invoked("bash -lc 'echo $(ruflo init)'")).toEqual(['ruflo init']);
+  });
+
+  it('DATA is never promoted: single quotes and heredoc bodies suppress both substitution forms', () => {
+    expect(invoked(`printf '%s' '$(ruflo init)'`)).toEqual([]);
+    expect(invoked(`printf '%s' '\`ruflo init\`'`)).toEqual([]);
+    expect(invoked("cat <<'EOF'\nruflo init is the command\nEOF")).toEqual([]);
+    expect(invoked("cat <<'EOF'\nx=$(ruflo init)\nEOF")).toEqual([]);
+    expect(invoked('cat <<-EOF\n\tx=`ruflo init`\nEOF')).toEqual([]);
+    expect(invoked('echo hi <<< "ruflo init"')).toEqual([]);       // herestring is DATA
+    expect(invoked('ls # ruflo init')).toEqual([]);                // comment is DATA
+  });
+
+  it('LIVE CAPTURE 2026-07-27: PRODUCT PROSE in a heredoc body is DATA, not an invocation', () => {
+    // Not in any issue: the maintainer was blocked mid-session because the words "agentic-qe
+    // integration plan" appeared inside a heredoc body he was writing. Same class as #12/#41 seen
+    // from the false-positive side — a tool NAME at the start of a line looks exactly like command
+    // position to anything line-anchored. The parser never asks: a heredoc body is skipped whole.
+    const cmd = "cat <<'EOF'\nagentic-qe integration plan\nEOF";
+    expect(exes(cmd)).toEqual(['cat']);
+    expect(invoked(cmd, 'agentic-qe')).toEqual([]);
+    expect(invoked('cat <<EOF\nagentic-qe integration plan\nEOF', 'agentic-qe')).toEqual([]); // unquoted delimiter too
+    // …and the identical text as a REAL command is still found. Prose vs invocation is the whole job;
+    // a test that only proved the ALLOW half would pass on a parser that found nothing at all.
+    expect(invoked('agentic-qe integration plan', 'agentic-qe')).toEqual(['agentic-qe integration plan']);
+  });
+
+  it('a heredoc consumes its BODY, not the rest of the script', () => {
+    expect(exes("cat <<'EOF'\nprose\nEOF\nruflo init")).toEqual(['cat', 'ruflo']);
+    expect(invoked("cat <<'EOF'\nprose\nEOF\nruflo init")).toEqual(['ruflo init']);
+  });
+
+  it('a DYNAMIC executable stays opaque — nothing to ground, so the caller fails open', () => {
+    // #12's lesson, kept: a name that is not in the text cannot be classified. `dynamic: true` is the
+    // parser SAYING SO, and `exe` is '' rather than a half-word that could be mistaken for a literal.
+    expect(commandNodes('$TOOL memory search -q x')[0]).toMatchObject({ dynamic: true, exe: '' });
+    expect(invoked('$TOOL memory search -q x')).toEqual([]);
+    expect(invoked('bash -c "$cmd"')).toEqual([]);
+    expect(invoked('eval "$cmd"')).toEqual([]);
+    // An argument whose text is not fully known is reported as '' too — never a partial token.
+    expect(commandNodes('ruflo memory search -q "$Q"')[0].argv).toEqual(['ruflo', 'memory', 'search', '-q', '']);
+  });
+
+  it('$(( … )) is ARITHMETIC, not a command substitution', () => {
+    expect(exes('echo $((1+2))')).toEqual(['echo']);
+    expect(exes('echo $((1<<2))')).toEqual(['echo']);              // and its `<<` is not a heredoc
+    expect(invoked('echo $((1+2)) && ruflo init')).toEqual(['ruflo init']); // the script still parses on
+  });
+
+  it('TERMINATES and stays bounded on hostile input — unclosed quotes, unclosed subs, deep nesting', () => {
+    expect(() => commandNodes('bash -c "ruflo init')).not.toThrow();
+    expect(() => commandNodes('x=$(y=$(z=$(echo')).not.toThrow();
+    expect(() => commandNodes('cat <<EOF\nnever terminated')).not.toThrow();
+    const deep = 'bash -c '.repeat(40) + 'ruflo init';
+    expect(() => commandNodes(deep)).not.toThrow();
+    const bomb = '$('.repeat(300) + 'ruflo init';
+    const t0 = Date.now();
+    expect(() => commandNodes(bomb)).not.toThrow();
+    expect(Date.now() - t0, 'a parser a hostile command can hang is a denial of service on the shell').toBeLessThan(2000);
+    expect(commandNodes(bomb).length).toBeLessThanOrEqual(256);    // MAX_NODES — output stays bounded
+  });
+});
+
+// findInvocations is what every gate actually calls; commandNodes is the structure underneath it.
+// These are #12's invariants — the ones about WHICH BINARY a name refers to — restated on the API
+// that now decides it.
+describe('findInvocations — the name must be the EXECUTABLE, and the right binary (issue #12)', () => {
+  it('npx/bunx/pnpx wrappers are transparent and an explicit @version is stripped', () => {
+    expect(invoked('npx ruflo@latest memory search -q x')).toEqual(['ruflo memory search -q x']);
+    expect(invoked('npx -y ruflo@3.28.0 init')).toEqual(['ruflo init']);
+    expect(invoked('bunx ruflo init')).toEqual(['ruflo init']);
+    expect(invoked('/usr/local/bin/ruflo init')).toEqual(['ruflo init']); // a path still names the binary
+  });
+
+  it('a DIFFERENT binary sharing a prefix or suffix is NOT the managed tool', () => {
+    expect(invoked('ruflo-source-patch adr-index status')).toEqual([]);
+    expect(invoked('my-ruflo memory search -q x')).toEqual([]);
+    expect(invoked('echo ruflowers memory search')).toEqual([]);
+  });
+
+  it('an empty or unknown tool list finds nothing, and never throws', () => {
+    expect(findInvocations('ruflo init', '')).toEqual([]);
+    expect(findInvocations('ruflo init', [])).toEqual([]);
+    expect(findInvocations('ruflo init', 'agentic-qe')).toEqual([]);
+    expect(() => findInvocations(null, 'ruflo')).not.toThrow();
   });
 });

--- a/tests/unit/verify-interface.test.mjs
+++ b/tests/unit/verify-interface.test.mjs
@@ -86,9 +86,27 @@ describe.skipIf(!hasBash || process.platform === 'win32')('verify-interface.sh �
     for (const bin of ['python3', 'jq', '$(cat', '| grep', '| sed']) {
       expect(src, `verify-interface.sh must not depend on ${bin}`).not.toContain(bin);
     }
-    // MATCH_RE (which CLI, which subcommand) is still bash regex — only JSON payload parsing moved
-    // to node (issue #13). BASH_REMATCH must still be how the tool/subcommand are captured.
-    expect(src).toMatch(/BASH_REMATCH/);
+  });
+
+  it('NO REGEX FALLBACK: which tool, which subcommand come from the shared classifier, never a pattern', () => {
+    // This assertion REPLACES the old `expect(src).toMatch(/BASH_REMATCH/)`, which pinned the
+    // opposite design — back then MATCH_RE, a bash regex over the command string, decided which CLI
+    // and which subcommand were being invoked, and only JSON payload parsing had moved to node (#13).
+    // MATCH_RE is what #12, #41 and #44 each patched in turn, so the invariant is now inverted: the
+    // gate must ask hook-input.mjs for EXECUTABLE STRUCTURE and must keep no second, string-shaped
+    // path to the same answer. A second path is exactly how this defect class survived four fixes.
+    const src = fs.readFileSync(GATE, 'utf8').split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+    expect(src, 'the gate must consume the shared classifier').toContain('hook-input.mjs');
+    expect(src, 'via the invocations verb — the structural question').toMatch(/invocations/);
+    expect(src, 'MATCH_RE was the regex fallback; it must not come back').not.toContain('MATCH_RE');
+    expect(src, 'no BASH_REMATCH capture of a tool name from the command string').not.toContain('BASH_REMATCH');
+    // Subcommand levels are derived from already-parsed argv tokens ($F), not re-matched from $CMD.
+    expect(src).toMatch(/\$\{F\[/);
+    // Exactly ONE bash regex may remain, and it is the fail-OPEN opt-out token, whose worst failure
+    // is letting a command through — never deciding that an invocation happened.
+    const rematches = src.split('\n').filter((l) => l.includes('=~'));
+    expect(rematches, `unexpected regex match(es): ${JSON.stringify(rematches)}`).toHaveLength(1);
+    expect(rematches[0]).toContain('RUVNET_SKIP_INTERFACE_CHECK');
   });
 });
 
@@ -229,5 +247,181 @@ describe.skipIf(!hasBash || process.platform === 'win32')('verify-interface.sh �
     run('ruflo init --help', { home });
     expect(fs.existsSync(stamp), 'a REAL help read must still be recorded').toBe(true);
     expect(run('ruflo init --force', { home }).status).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Issue #44 (github.com/sparkling again, fourth precise report on this file — after #41's false
+// POSITIVE, this is a false NEGATIVE in the same matcher). #41 fixed the gate by matching a
+// quote-masked SKELETON instead of the raw command. That was right, and it opened a hole: a
+// DEFINITE invocation nested inside a literal shell payload (`bash -lc '…'`), a backtick
+// substitution, or a `$(…)` inside double quotes is *inside quotes*, so the skeleton masks it away
+// and the gate never sees it. The gate exists to stop me invoking a CLI whose flags I am guessing
+// at — and `bash -lc 'ruflo memory search -q x'` invokes it just as surely as typing it bare.
+//
+// RED-FIRST — verbatim output of THIS block run against the pre-fix gate (3.9.84-dev, commit
+// 3501ef4), captured with both source files checked back out to HEAD. The only edit is that the
+// prefix every FAIL line shares — `tests/unit/verify-interface.test.mjs > verify-interface.sh —
+// issue #44: definite invocations nested in shell payloads and command substitutions > ` — is
+// elided to `…`; nothing else is changed. (The two heredoc FALSE-POSITIVE lines were a
+// PRE-EXISTING false positive, not one this change introduced: a heredoc body line beginning with
+// a tool name already blocked before #44 existed. They are red here because recursing into `$( … )`
+// without teaching the lexer about heredocs would have made that worse, not better.)
+//
+//   ⎯⎯⎯⎯⎯⎯ Failed Tests 13 ⎯⎯⎯⎯⎯⎯⎯
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > literal bash -lc payload (reporter case 1): bash -lc 'ruflo memory search -q x'
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > backtick substitution (reporter case 2): x=`ruflo memory search -q x`
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > $() inside double quotes (reporter case 3): printf '%s\n' "$(ruflo memory search -q x)"
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > sh -c with a double-quoted payload: sh -c "ruflo memory search -q x"
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > bash -ic (interactive flag cluster): bash -ic 'ruflo memory search -q x'
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > absolute path to the shell: /bin/bash -c 'ruflo memory search -q x'
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > $() inside double quotes, mid-sentence: echo "result: $(ruflo memory search -q x) done"
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > backtick inside double quotes: echo "result: `ruflo memory search -q x`"
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > two levels of nesting: bash -c 'sh -c "ruflo memory search -q x"'
+//   FAIL  … > BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK) > $() nested inside a bash -c payload: bash -lc 'echo $(ruflo memory search -q x)'
+//   FAIL  … > FALSE-POSITIVE GUARDS — widening the gate must not cost us #41 back (must stay ALLOWED) > heredoc prose whose line starts with the tool name: cat <<'EOF'
+//   FAIL  … > FALSE-POSITIVE GUARDS — widening the gate must not cost us #41 back (must stay ALLOWED) > heredoc prose containing a literal $() example: cat <<'EOF'
+//   FAIL  … > THE GATE MUST STILL OPEN — a stamped interface unlocks the nested forms too > reading the help INSIDE a nested payload records the stamp (or the gate could never open)
+//
+//   Test Files  1 failed (1)
+//        Tests  13 failed | 44 passed (57)
+//
+//   …and the shared shape of all ten BYPASS failures, verbatim (the gate returned 0 — ALLOWED —
+//   on a definite invocation, so there is no stderr to show; that empty `stderr:` line IS the bug):
+//
+//   AssertionError: expected BLOCKED (2), got 0
+//   stderr: : expected +0 to be 2 // Object.is equality
+//
+describe.skipIf(!hasBash || process.platform === 'win32')('verify-interface.sh — issue #44: definite invocations nested in shell payloads and command substitutions', () => {
+  describe("BYPASSES — the reporter's three, plus the same mechanism's near neighbours (must BLOCK)", () => {
+    it.each([
+      ['literal bash -lc payload (reporter case 1)', "bash -lc 'ruflo memory search -q x'"],
+      ['backtick substitution (reporter case 2)', 'x=`ruflo memory search -q x`'],
+      ['$() inside double quotes (reporter case 3)', 'printf \'%s\\n\' "$(ruflo memory search -q x)"'],
+      ['sh -c with a double-quoted payload', 'sh -c "ruflo memory search -q x"'],
+      ['bash -ic (interactive flag cluster)', "bash -ic 'ruflo memory search -q x'"],
+      ['absolute path to the shell', "/bin/bash -c 'ruflo memory search -q x'"],
+      ['$() inside double quotes, mid-sentence', 'echo "result: $(ruflo memory search -q x) done"'],
+      ['backtick inside double quotes', 'echo "result: `ruflo memory search -q x`"'],
+      ['two levels of nesting', 'bash -c \'sh -c "ruflo memory search -q x"\''],
+      ['$() nested inside a bash -c payload', "bash -lc 'echo $(ruflo memory search -q x)'"],
+    ])('%s: %s', (_label, cmd) => {
+      const r = run(cmd);
+      expect(r.status, `expected BLOCKED (2), got ${r.status}\nstderr: ${r.stderr}`).toBe(2);
+      expect(r.stderr).toMatch(/BLOCKED — you have not read the interface for: ruflo memory search/);
+    });
+  });
+
+  describe('CONTROLS — already correct before the fix; the fix must not regress them (must BLOCK)', () => {
+    it.each([
+      ['direct invocation', 'ruflo memory search -q x'],
+      ['pipeline invocation', 'echo hi | ruflo memory search -q x'],
+      ['unquoted $() assignment', 'x=$(ruflo memory search -q x)'],
+      ['npx-wrapped invocation', 'npx ruflo@latest memory search -q test'],
+    ])('%s: %s', (_label, cmd) => {
+      const r = run(cmd);
+      expect(r.status, `expected BLOCKED (2), got ${r.status}\nstderr: ${r.stderr}`).toBe(2);
+    });
+  });
+
+  describe('FALSE-POSITIVE GUARDS — widening the gate must not cost us #41 back (must stay ALLOWED)', () => {
+    it.each([
+      // #41's family — prose that merely mentions a tool.
+      ['prose in a commit message', 'git commit -m "explained how ruflo memory search returns rows"'],
+      ['prose in an echo', 'echo "run ruflo init to start"'],
+      ['separator inside a quoted regex', 'grep -E "foo|ruflo init" file.txt'],
+      // #12's family — the name as a SUBSTRING of a different word or a different binary.
+      ['tool name as a substring of another word', 'echo ruflowers memory search'],
+      ['a different, hyphen-prefixed binary', 'my-ruflo memory search -q x'],
+      ['a different, hyphen-suffixed binary', 'ruflo-source-patch adr-index status'],
+      // NEW with this fix: the executable is DYNAMIC, so there is nothing definite to ground.
+      ['dynamic executable name', '$TOOL memory search -q x'],
+      ['eval of a variable', 'eval "$cmd"'],
+      ['bash -c of a variable', 'bash -c "$cmd"'],
+      // Single quotes suppress BOTH substitution forms — this is literal text, not a command node.
+      ['$() inside SINGLE quotes is literal text', "printf '%s' '$(ruflo memory search -q x)'"],
+      ['backticks inside SINGLE quotes are literal text', "printf '%s' '`ruflo memory search -q x`'"],
+      // Heredocs. A body line starting with the tool name looks exactly like command position to a
+      // line-anchored regex, and a quoted-delimiter body suppresses substitution entirely — so
+      // recursing into `$(…)` without heredoc awareness would INVENT a false positive here.
+      ['heredoc prose whose line starts with the tool name',
+        "cat <<'EOF'\nruflo memory search is the command you want\nEOF"],
+      ['heredoc prose containing a literal $() example',
+        "cat <<'EOF'\nresult=$(ruflo memory search -q x)\nEOF"],
+      ['heredoc prose containing a literal backtick example',
+        "cat <<'EOF'\nuse `ruflo memory search -q x` here\nEOF"],
+      // LIVE CAPTURE 2026-07-27, in no issue: the maintainer was blocked mid-session writing this
+      // exact text into a heredoc body. A tool name at the START OF A LINE is indistinguishable from
+      // command position to anything line-anchored — the same class as #12/#41 from the false-positive
+      // side, and the fifth instance in 14 days. Both delimiter forms, because an UNQUOTED delimiter
+      // is where a naive "substitution happens here, so recurse" reading would go wrong.
+      ['LIVE 07-27: product prose in a heredoc body (quoted delimiter)',
+        "cat <<'EOF'\nagentic-qe integration plan\nEOF"],
+      ['LIVE 07-27: product prose in a heredoc body (unquoted delimiter)',
+        'cat <<EOF\nagentic-qe integration plan\nEOF'],
+      ['LIVE 07-27: the same prose mid-paragraph, multi-line body',
+        'cat > plan.md <<EOF\n# Plan\nWe should write the agentic-qe integration plan first.\nThen ruflo memory search is worth a look.\nEOF'],
+    ])('%s: %s', (_label, cmd) => {
+      const r = run(cmd);
+      expect(r.status, `expected ALLOWED (0), got ${r.status}\nstderr: ${r.stderr}`).toBe(0);
+    });
+
+    it('LIVE 07-27 control: the SAME words as a real command still BLOCK (the allow must not be blanket)', () => {
+      // A false-positive fix that also stopped finding real invocations would pass every ALLOW case
+      // above and protect nothing. `agentic-qe` is in the managed TOOLS list, so the bare command
+      // must still block — that is what makes the heredoc ALLOW meaningful rather than vacuous.
+      const r = run('agentic-qe integration plan');
+      expect(r.status, `expected BLOCKED (2), got ${r.status}\nstderr: ${r.stderr}`).toBe(2);
+      expect(r.stderr).toMatch(/BLOCKED — you have not read the interface for: agentic-qe integration plan/);
+    });
+
+    it('a real command AFTER a heredoc body still blocks — masking the body must not mask the script', () => {
+      const r = run("cat <<'EOF'\njust prose in here\nEOF\nruflo memory search -q x");
+      expect(r.status, `expected BLOCKED (2), got ${r.status}\nstderr: ${r.stderr}`).toBe(2);
+    });
+  });
+
+  describe('THE GATE MUST STILL OPEN — a stamped interface unlocks the nested forms too', () => {
+    it('a legitimately-stamped invocation passes in every nested form', () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-'));
+      expect(run('ruflo memory search --help', { home }).status).toBe(0);
+      for (const cmd of [
+        'ruflo memory search -q x',
+        "bash -lc 'ruflo memory search -q x'",
+        'x=`ruflo memory search -q x`',
+        'printf \'%s\\n\' "$(ruflo memory search -q x)"',
+      ]) {
+        expect(run(cmd, { home }).status, `${cmd} must be ALLOWED once the help is stamped`).toBe(0);
+      }
+    });
+
+    it('reading the help INSIDE a nested payload records the stamp (or the gate could never open)', () => {
+      // The lesson already written into this file in blood: "Two regexes for one concept is how you
+      // get a gate that never opens." Same shape here — if the blocking branch learns to see nested
+      // invocations but the help-recording branch does not, a user whose whole workflow is
+      // `bash -lc '…'` is walled out permanently with no way through.
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-'));
+      const stamp = path.join(home, '.cache/ruvnet-brain/help-read/ruflo.memory.search');
+      run("bash -lc 'ruflo memory search --help'", { home });
+      expect(fs.existsSync(stamp), 'a help read inside a nested payload must be recorded').toBe(true);
+      expect(run("bash -lc 'ruflo memory search -q x'", { home }).status).toBe(0);
+    });
+
+    it('a stamp is NOT recorded from a tool name that only appears as nested PROSE', () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-'));
+      const stamp = path.join(home, '.cache/ruvnet-brain/help-read/ruflo.memory.search');
+      run('bash -lc \'echo "ruflo memory search is the command" --help\'', { home });
+      expect(fs.existsSync(stamp), 'nested prose must NOT stamp').toBe(false);
+    });
+  });
+
+  it('STILL FAILS OPEN on garbage — recursion must not turn a parse miss into a block', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-'));
+    fs.mkdirSync(path.join(home, '.claude/model-router'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.claude/model-router/profile.json'), '{}');
+    for (const bad of ['not json', '{"tool_name":"Bash","tool_input":{"command":"bash -c \'ruflo memory', '']) {
+      const r = spawnSync('bash', [GATE], { input: bad, env: { ...process.env, HOME: home }, encoding: 'utf8' });
+      expect(r.status, `payload ${JSON.stringify(bad)} must fail open`).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
Closes #44. Merge order step 2 of 4 — before `fix/hook-hardening-d9`, because this **rewrites** `plugin/scripts/hook-input.mjs` while that branch only nudges it. Landing the rewrite first means the small delta reapplies onto it, rather than a rewrite being reapplied onto a small delta, which is where changes get silently dropped.

## What the reporter actually said

`sparkling`, verbatim: *"definite managed-tool invocations bypass the interface gate when nested in literal shell payloads, backticks, or command substitutions inside double quotes."*

They also **refused the tidy generalization** — unquoted `x=$(ruflo …)` **does** block, and they wrote *"the issue should not claim that every unquoted `$()` substitution bypasses the gate."* And they specified the safety property: *"Preserve the current fail-open behavior for dynamic executable names and quoted prose."*

That precision shaped the fix. The mask is **deleted**, not patched: `commandNodes()` parses to executable command nodes and recurses into `sh -c` / `bash -lc` payloads, `$( )`, backticks and process substitutions. `dynamic: true` = executable unknown = **fail open**. No pattern is applied to the command string at all. The tool policy list is unchanged — no silent widening.

## Measured, main vs this branch (isolated HOME so the 24h help-read cache can't mask)

| case | main | this |
|---|---|---|
| `bash -lc 'ruflo memory search -q x'` | exit 0 | **exit 2** |
| `` x=`ruflo memory search -q x` `` | exit 0 | **exit 2** |
| `printf '%s\n' "$(ruflo …)"` | exit 0 | **exit 2** |
| 4 controls (direct / pipeline / unquoted `$()` / prose) | correct | unchanged |
| fail-open (`$TOOL`, `eval "$cmd"`, unterminated quote) | allow | allow |
| heredoc "agentic-qe integration plan" | **exit 2 (live false positive)** | exit 0 |

15/15 probes pass. Parser bounded on hostile input (200-deep nesting, 1000 nested `$()`, 10k backticks, 50k unterminated quote): never throws, worst case 419 ms.

## Mutation proof

Disabling **payload recursion** only: `expected [] to deeply equal [ 'ruflo memory search -q x' ]`, and all six gate-level bypass cases `expected BLOCKED (2), got 0` — the reporter's exact symptom. Disabling **substitution recursion** instead moves the red to the backtick case. Two independent mechanisms, each separately proved able to fail.

## Two things corrected because they were untrue

1. A shipped comment claimed a finding was "recorded in ADR-055's conflict matrix". #48 is real and open; that ADR row does not exist. Rewritten.
2. Three places called this "sparkling's **third** report on this gate". It is their **fourth** (#12, #13, #41, #44).

## Also found

`package-lock.json` root version was **7 versions stale** (3.9.85-dev while package.json read 3.9.92-dev) and `version:check` passes anyway, because `sync-version.mjs` has no lockfile target. Recommend adding one — not done here.