### PR TITLE
Fix pinned embedder cache round trips

### DIFF
--- a/kb/forge-ask.mjs
+++ b/kb/forge-ask.mjs
@@ -17,7 +17,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { loadRvf, loadTransformers, configureModel } from './resolve-deps.mjs';
-import { configureTransformersModel } from './model-requirements.mjs';
+import { configureTransformersModel, materializeModelRevision } from './model-requirements.mjs';
 
 // LAZY, not module-level (2026-07-12): an eager loadRvf() here killed every importer — including
 // forge-mcp-all's MCP server — at STARTUP on any machine without @ruvector/rvf resolvable, before
@@ -110,11 +110,12 @@ function getEmbedder(model) {
 }
 async function loadEmbedderUncached(model) {
   const { T, modelCache, via } = await loadTransformers();
+  const revision = PINNED_REVISIONS[model] || 'main';
+  materializeModelRevision(modelCache, model, revision);
   // Local-first network guard: a remote fetch is permitted ONLY when THIS model is not already
   // cached locally (offline once cached). Reads AND downloads use the same detector-visible cache.
   // When a fetch does happen it is pinned to the exact revision below.
   configureTransformersModel(T, modelCache, model);
-  const revision = PINNED_REVISIONS[model] || 'main';
   if (process.env.KB_DEBUG) console.error(`[forge-ask] transformers via: ${via} | model ${model}@${revision} | cache: ${modelCache} (${T.env.allowRemoteModels ? 'remote' : 'local'})`);
 
   // ISSUE #27 (Jan Lafko, 2026-07-18): in a network-restricted sandbox (turbo-flow devcontainer) a
@@ -160,6 +161,7 @@ async function loadEmbedderUncached(model) {
   let fe;
   try {
     fe = await attemptLoad();
+    materializeModelRevision(modelCache, model, revision);
   } catch (e) {
     // Bug B (issue #29, found+fixed by Jan Lafko): allowRemoteModels was gated purely on the model
     // DIRECTORY existing — but a directory proves a download STARTED, not that it finished. A

--- a/kb/forge-big.mjs
+++ b/kb/forge-big.mjs
@@ -21,6 +21,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import { loadRvf, loadTransformers, chooseModelCache } from './resolve-deps.mjs';
+import { materializeModelRevision, modelCacheReady } from './model-requirements.mjs';
 
 const MODEL = 'Xenova/bge-base-en-v1.5';
 // MODEL-WEIGHT PIN: address the embedder by an exact HuggingFace commit SHA, not the floating `main`
@@ -53,10 +54,13 @@ async function getEmbedder() {
   if (_fe) return _fe;
   const { T, via } = await loadTransformers();
   const cache = chooseModelCache();
+  materializeModelRevision(cache, MODEL, MODEL_REVISION);
   T.env.localModelPath = cache;
-  T.env.allowRemoteModels = !fs.existsSync(path.join(cache, MODEL));
+  T.env.cacheDir = cache;
+  T.env.allowRemoteModels = !modelCacheReady(cache, MODEL);
   console.log(`[big] transformers via ${via} | model ${MODEL}@${MODEL_REVISION} | cache ${cache} (${T.env.allowRemoteModels ? 'will download' : 'local'})`);
   _fe = await T.pipeline('feature-extraction', MODEL, { quantized: true, revision: MODEL_REVISION });
+  materializeModelRevision(cache, MODEL, MODEL_REVISION);
   return _fe;
 }
 async function embedTexts(texts) {
@@ -128,7 +132,7 @@ async function ingestStore() {
 
   // query-side embedder config (how forge-ask embeds a query for THIS .rvf — asymmetric bge)
   fs.writeFileSync(OUT_RVF + '.embed.json', JSON.stringify({
-    model: MODEL, dimensions: DIM, metric: 'cosine', pooling: POOLING, normalize: true,
+    model: MODEL, revision: MODEL_REVISION, dimensions: DIM, metric: 'cosine', pooling: POOLING, normalize: true,
     queryPrefix: QUERY_PREFIX,
     note: 'Big (Mac/PC) variant. Passages embedded with NO prefix; queries use queryPrefix (asymmetric).',
     builtFrom: path.basename(passagesFile), generated: new Date().toISOString(),

--- a/kb/model-requirements.mjs
+++ b/kb/model-requirements.mjs
@@ -8,6 +8,32 @@ export function modelPath(modelCache, model) {
   return path.join(modelCache, ...model.split('/'));
 }
 
+export function modelCacheReady(modelCache, model, revision = null) {
+  const root = revision
+    ? path.join(modelPath(modelCache, model), revision)
+    : modelPath(modelCache, model);
+  return [
+    path.join(root, 'tokenizer.json'),
+    path.join(root, 'config.json'),
+    path.join(root, 'onnx', 'model_quantized.onnx'),
+  ].every((file) => fs.existsSync(file));
+}
+
+// Revision-pinned downloads live below <model>/<revision>/, while strict offline reads resolve
+// <model>/ directly. Promote only the exact pinned files into that canonical offline location.
+export function materializeModelRevision(modelCache, model, revision) {
+  if (!revision || !modelCacheReady(modelCache, model, revision)) return false;
+  const source = path.join(modelPath(modelCache, model), revision);
+  const destination = modelPath(modelCache, model);
+  for (const entry of fs.readdirSync(source)) {
+    fs.cpSync(path.join(source, entry), path.join(destination, entry), {
+      recursive: true,
+      force: true,
+    });
+  }
+  return modelCacheReady(modelCache, model);
+}
+
 // The RVF sidecar is the source of truth for the query embedder. Only sidecars with a matching
 // installed RVF count; stale/orphan metadata must not make a healthy installation look cold.
 export function requiredEmbedderModels(kbDir) {
@@ -35,7 +61,7 @@ export function missingEmbedderModels(modelCache, models) {
 }
 
 export function configureTransformersModel(T, modelCache, model) {
-  const local = fs.existsSync(modelPath(modelCache, model));
+  const local = modelCacheReady(modelCache, model);
   T.env.localModelPath = modelCache;
   // Transformers.js otherwise downloads into its package-local `.cache`, while every doctor and
   // release detector inspects `modelCache`. A download invisible to the runtime's own detector

--- a/scripts/corpus-qa.mjs
+++ b/scripts/corpus-qa.mjs
@@ -54,6 +54,8 @@ const KB = path.join(ROOT, 'kb');
 // resolve-deps lives in the real kb/ regardless of --dir (fixtures point --dir elsewhere).
 const { loadRvf, loadTransformers, configureModel, chooseModelCache, closeReadonlyRvf } =
   await import(path.join(KB, 'resolve-deps.mjs')).then((m) => m);
+const { materializeModelRevision } =
+  await import(path.join(KB, 'model-requirements.mjs')).then((m) => m);
 
 const FULL_BODY_MARK = '(full body):';
 // R1 photo-finish epsilon: measured quantized batch-vs-single embed drift is ~0.035 cosine
@@ -88,14 +90,21 @@ export function sampleIndices(storeKey, n, k) {
 // (not just the resolved pipe) so concurrent qaStore() calls that both miss on the same model don't
 // each trigger their own T.pipeline() load — first caller wins, the rest await its promise.
 const pipelines = new Map();
-function getPipeline(model) {
-  if (pipelines.has(model)) return pipelines.get(model);
+function getPipeline(embedConf) {
+  const { model, revision } = embedConf;
+  const key = `${model}@${revision || 'unversioned'}`;
+  if (pipelines.has(key)) return pipelines.get(key);
   const p = (async () => {
     const { T } = await loadTransformers();
-    configureModel(T, chooseModelCache());
-    return T.pipeline('feature-extraction', model, { quantized: true });
+    const cache = chooseModelCache();
+    materializeModelRevision(cache, model, revision);
+    configureModel(T, cache);
+    return T.pipeline('feature-extraction', model, {
+      quantized: true,
+      ...(revision ? { revision } : {}),
+    });
   })();
-  pipelines.set(model, p);
+  pipelines.set(key, p);
   return p;
 }
 
@@ -151,7 +160,7 @@ export async function qaStore(dir, store, variant, { roundtrip = true, samples =
       const byId = new Map(rows.map((r) => [String(r.id), r]));
       let hit = 0;
       const misses = [];
-      const pipe = await getPipeline(embedConf.model);
+      const pipe = await getPipeline(embedConf);
       for (const i of picks) {
         const r = rows[i];
         // Re-embed EXACTLY what the pipeline indexed for this variant (forge-build/forge-big):

--- a/tests/unit/model-cache-cold.test.mjs
+++ b/tests/unit/model-cache-cold.test.mjs
@@ -19,7 +19,11 @@ import {
   EMBEDDER_REL,
   BGE_EMBEDDER_REL,
 } from '../../plugin/test/model-cache.mjs';
-import { configureTransformersModel } from '../../kb/model-requirements.mjs';
+import {
+  configureTransformersModel,
+  materializeModelRevision,
+  modelCacheReady,
+} from '../../kb/model-requirements.mjs';
 
 let tmp;
 const savedEnv = {};
@@ -123,11 +127,29 @@ describe('configureTransformersModel — reads and downloads through the same ca
   });
 
   it('disables remote loading when that exact model is already local', () => {
-    fs.mkdirSync(path.join(tmp, BGE_EMBEDDER_REL), { recursive: true });
+    for (const file of ['tokenizer.json', 'config.json', path.join('onnx', 'model_quantized.onnx')]) {
+      const target = path.join(tmp, BGE_EMBEDDER_REL, file);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, 'ready');
+    }
     const T = { env: {} };
     const r = configureTransformersModel(T, tmp, 'Xenova/bge-base-en-v1.5');
     expect(T.env.allowRemoteModels).toBe(false);
     expect(r.local).toBe(true);
+  });
+
+  it('materializes a complete pinned revision into the canonical offline path', () => {
+    const model = 'Xenova/bge-base-en-v1.5';
+    const revision = 'exact-sha';
+    for (const file of ['tokenizer.json', 'config.json', path.join('onnx', 'model_quantized.onnx')]) {
+      const target = path.join(tmp, BGE_EMBEDDER_REL, revision, file);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, `pinned:${file}`);
+    }
+    expect(modelCacheReady(tmp, model)).toBe(false);
+    expect(materializeModelRevision(tmp, model, revision)).toBe(true);
+    expect(modelCacheReady(tmp, model)).toBe(true);
+    expect(fs.readFileSync(path.join(tmp, BGE_EMBEDDER_REL, 'tokenizer.json'), 'utf8')).toBe('pinned:tokenizer.json');
   });
 });
 


### PR DESCRIPTION
## Summary
- materialize revision-pinned model files into the canonical offline cache path
- record the exact model revision in RVF embed sidecars
- make corpus QA and the shipped query path use the same pinned cache contract

## Evidence
- focused cache suite: 19/19 passed
- ADR citation suite in clean-checkout fixture: 12/12 passed
- live RuView candidate + promoted corpus QA: 8,022 vectors, 3/3 round trips, PASS
- full unit run reached 2,402 passes; six unrelated ADR checks were false-red because the publisher created a partial ignored clones/ fixture, and those six passed after restoring clean-checkout conditions

This fixes the real release failure: pinned downloads lived under <model>/<revision>/ while strict offline reads expected <model>/ directly.