### PR TITLE
fix: recognize canonical big RVF installs

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -1084,7 +1084,7 @@ function gatherInstallState(cacheDir) {
   try {
     repos = fs
       .readdirSync(cacheDir)
-      .filter((f) => f.endsWith('.rvf') && !f.endsWith('.big.rvf')).length;
+      .filter((f) => f.endsWith('.rvf')).length;
   } catch {
     /* ignore */
   }

--- a/tests/integration/install-smoke.mjs
+++ b/tests/integration/install-smoke.mjs
@@ -147,7 +147,9 @@ test('`--doctor` on a COMPLETE brain dir returns the healthy verdict (exit 0) �
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvb-doctor-healthy-cache-'));
   try {
     fs.writeFileSync(path.join(brainDir, 'forge-mcp-all.mjs'), '// stub for install-smoke — never executed\n');
-    fs.writeFileSync(path.join(brainDir, 'ruvector.rvf'), 'not a real store — presence is what gatherInstallState counts\n');
+    // Current release bundles contain canonical *.big.rvf stores only. The older checker excluded
+    // that suffix and falsely failed a real 60-store v3.9.131 install as "zero stores".
+    fs.writeFileSync(path.join(brainDir, 'ruvector.big.rvf'), 'not a real store — presence is what gatherInstallState counts\n');
     const xen = path.join(brainDir, 'node_modules', '@xenova', 'transformers');
     fs.mkdirSync(xen, { recursive: true });
     fs.writeFileSync(path.join(xen, 'package.json'), '{"name":"@xenova/transformers","version":"0.0.0-fixture"}\n');


### PR DESCRIPTION
## Summary
- count canonical `.big.rvf` stores during installer and doctor verification
- regression-test the exact store-only layout shipped in v3.9.131-dev

## Proof
- clean-home v3.9.131 install unpacked 60 `.big.rvf` stores but the old checker reported zero
- `node --test tests/integration/install-smoke.mjs`: 22 pass, 0 fail (1 skipped, 3 todo)
- pre-push release gate passed

## Release requirement
Keep #52 and #56 open until this fix is published and the exact npm artifact passes the clean-home install boundary.