### PR TITLE
fix: honor isolated Codex homes

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -734,8 +734,9 @@ export function codexStatus({ configPath = codexConfigPath(), codexDir = codexHo
   if (!host) return { host: false, wired: false, serverPath: null, serverExists: false };
   let text = '';
   try { text = fs.readFileSync(configPath, 'utf8'); } catch { /* no config yet */ }
-  const m = /^[ \t]*\[mcp_servers\.(?:ruvnet-brain|"ruvnet-brain"|'ruvnet-brain')\][^[]*?args\s*=\s*\[\s*"([^"]+)"/m.exec(text);
-  const serverPath = m ? m[1] : null;
+  const m = /^[ \t]*\[mcp_servers\.(?:ruvnet-brain|"ruvnet-brain"|'ruvnet-brain')\][^[]*?args\s*=\s*\[\s*("(?:\\.|[^"\\])*")/m.exec(text);
+  let serverPath = null;
+  try { serverPath = m ? JSON.parse(m[1]) : null; } catch { /* malformed entry — treat as absent */ }
   let serverExists = false;
   try { serverExists = serverPath ? fs.existsSync(serverPath) : false; } catch { /* unreadable */ }
   return { host: true, wired: Boolean(serverPath) && serverExists, serverPath, serverExists };

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -687,7 +687,7 @@ function wirePlugin() {
 // THAT absolute server path is registered. Registering the npx dir would rot when the temp dir vanished.
 const CODEX_BLOCK_START = '# --- ruvnet-brain (managed block, installer-rewritten) ---';
 const CODEX_BLOCK_END = '# --- end ruvnet-brain ---';
-const codexHomeDir = () => path.join(os.homedir(), '.codex');
+const codexHomeDir = () => process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
 const codexConfigPath = () => path.join(codexHomeDir(), 'config.toml');
 const codexServerDir = () => path.join(os.homedir(), '.claude', 'ruvnet-brain', 'mcp');
 const codexHookWrapperPath = (codexDir = codexHomeDir()) =>

--- a/tests/unit/codex-wiring.test.mjs
+++ b/tests/unit/codex-wiring.test.mjs
@@ -118,6 +118,32 @@ describe('mergeCodexConfig — the three outcomes, and only three', () => {
   });
 });
 
+describe('Codex home selection', () => {
+  it('honors CODEX_HOME instead of silently wiring the login-home Codex', () => {
+    const home = tmpdir();
+    const codexDir = path.join(home, 'isolated-codex');
+    const server = path.join(home, 'server.mjs');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(server, '// fixture\n');
+    fs.writeFileSync(
+      path.join(codexDir, 'config.toml'),
+      `${START}\n[mcp_servers.ruvnet-brain]\ncommand = "node"\nargs = [${JSON.stringify(server)}]\n${END}\n`,
+    );
+    const before = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexDir;
+    try {
+      expect(codexStatus()).toMatchObject({
+        host: true,
+        wired: true,
+        serverPath: server,
+      });
+    } finally {
+      if (before === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = before;
+    }
+  });
+});
+
 // ── high: byte preservation + idempotency, the two things a reinstall can destroy ────────────────
 describe('a reinstall is safe — every other section survives, and the result is stable', () => {
   it('preserves the pre-existing sections byte for byte', () => {


### PR DESCRIPTION
## Summary
- honor `CODEX_HOME` for installer, MCP, plugin, hook-wrapper, and doctor paths
- add a regression proving the default Codex status probe reads the isolated home, not the login home

## Reproduction
The exact `3.9.132-dev` npm installer was run with an isolated `CODEX_HOME`. Bare Codex persisted the marketplace/plugin correctly, but the installer derived `~/.codex` from `HOME` and could target a different host.

## Proof
- `npx vitest run tests/unit/codex-wiring.test.mjs`: 42/42 pass
- pre-push release gate passed

Keep #52 open until the merged fix is published and a clean isolated-Codex-home reinstall is idempotent.