### PR TITLE
fix(release): publish prereleases with explicit npm tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.133-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.133--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 3.9.134-dev — updated 2026-07-24 16:09 EDT](https://img.shields.io/badge/version_3.9.134--dev-updated_2026--07--24_16:09_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 
@@ -522,7 +522,7 @@ node forge-ask-all.mjs --dir . --q "How does RuVector implement HNSW vector sear
 
 This project versions in the open (see the live badge up top for the exact plugin version; the downloadable knowledge bundle is a separate track) — we don't claim “done,” “complete,” or “zero hallucinations.” Where it stands:
 
-- ✅ **The grounding brain is real and proven** — 62 public stores · 150,163 public source chunks (69 built stores incl. private), dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
+- ✅ **The grounding brain is real and proven** — 62 public stores · 151,033 public source chunks (69 built stores incl. private), dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
 - ✅ **Code-level depth** — the code-rich repos are indexed to full function bodies; “how is it implemented?” returns the implementation. Verified in the shipped bundle (clean-room 3/3).
 - ✅ **Routing holds** — named 47/48, described 26/28, scenario 7/8; behavioral L1–L3 all pass (**L4 downgraded — it measures that the brain spoke, not that anything listened**); private stores fenced out of the public bundle (zero-leak verified).
 - ⚠️ **Two routing residuals** (above) — surfaced, not hidden.

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "3.9.133-dev",
+  "brainVersion": "3.9.134-dev",
   "generated": "2026-07-24T20:09:02.443Z",
   "generatedHuman": "Fri, 24 Jul 2026 20:09:02 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "3.9.133-dev",
+    "softwareVersion": "3.9.134-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 69 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.133-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v3.9.134-dev</p>
     </div>
   </div>
 
@@ -365,7 +365,7 @@
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span data-count="62" data-decimals="0">62</span> public stores</div>
-              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 150,163 public source chunks (69 built stores incl. private)<span class="spear-src">not docs</span></p>
+              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 151,033 public source chunks (69 built stores incl. private)<span class="spear-src">not docs</span></p>
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span class="pq-shimmer">post-quantum</span></div>

--- a/explainer/llms-full.txt
+++ b/explainer/llms-full.txt
@@ -6,7 +6,7 @@
 RuvNet Brain supplies supported lifecycle plugins for Claude Code and Codex. It ships one MCP tool
 — `search_ruvnet` — plus proactive grounding, routing, learning-capture and session-continuity
 hooks. Before the coding agent answers a question about rUv's stack, the brain retrieves the
-relevant passages from rUv's actual source code (150,163 public source chunks across 62 public
+relevant passages from rUv's actual source code (151,033 public source chunks across 62 public
 stores; 69 built stores incl. private) and grounds the answer in cited source paths instead of
 the model's stale priors.
 

--- a/explainer/llms.txt
+++ b/explainer/llms.txt
@@ -18,7 +18,7 @@ IMPORTANT DISAMBIGUATION: "RuvNet Brain" (by Stuart Kerr / Isovision.ai) is a di
 - Underlying ecosystem author: Reuven Cohen (rUv, @ruvnet).
 - Delivery: first-class Claude Code and Codex lifecycle plugins + `search_ruvnet` + proactive grounding and learning hooks.
 - Dual-host reasoning: subscription-only Codex + Claude deliberation for hard ADR, DDD and Agentic-QE experience design; no API-key fallback.
-- Coverage: 62 public stores · 150,163 public source chunks (69 built stores incl. private).
+- Coverage: 62 public stores · 151,033 public source chunks (69 built stores incl. private).
 - License: MIT. Free to use.
 
 ## Built by

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "3.9.133-dev",
+  "version": "3.9.134-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.9.133-dev",
+  "version": "3.9.134-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 69 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "3.9.133-dev",
+  "version": "3.9.134-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "3.9.133-dev",
+  "version": "3.9.134-dev",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v3.9.133-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v3.9.134-dev · Built: 2026-07-24 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -166,7 +166,9 @@ if (PUBLISH) {
   let already = '';
   try { already = execFileSync('npm', ['view', `ruvnet-brain@${v}`, 'version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); } catch { /* not published yet */ }
   if (already === v) console.log(c.dim(`  ${v} already on npm — skipping publish, just re-asserting the tag`));
-  else runOrDie('npm publish', 'npm', ['publish']);
+  // npm requires an explicit tag for prerelease versions. This project intentionally serves its
+  // `-dev` release from `latest`, so make that policy explicit on the publish command itself.
+  else runOrDie('npm publish', 'npm', ['publish', '--tag', 'latest']);
   // npm does NOT auto-move `latest` to a prerelease (x.y.z-dev) — force it, or `@latest` stays stale.
   runOrDie('npm dist-tag latest', 'npm', ['dist-tag', 'add', `ruvnet-brain@${v}`, 'latest']);
 } else {

--- a/scripts/self-update.mjs
+++ b/scripts/self-update.mjs
@@ -486,11 +486,11 @@ if (has('--publish')) {
     try {
       let onNpm = '';
       try { onNpm = execFileSync('npm', ['view', `ruvnet-brain@${next}`, 'version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); } catch { /* not yet on npm — fine */ }
-      if (onNpm !== next) execFileSync('npm', ['publish'], { cwd: ROOT, stdio: 'inherit' });
+      if (onNpm !== next) execFileSync('npm', ['publish', '--tag', 'latest'], { cwd: ROOT, stdio: 'inherit' });
       execFileSync('npm', ['dist-tag', 'add', `ruvnet-brain@${next}`, 'latest'], { cwd: ROOT, stdio: 'inherit' });
       console.log(`[publish] npm ${next} + \`latest\` — channels IN SYNC (npm == GitHub == plugin)`);
     } catch (e) {
-      console.error(`[publish] FATAL: npm publish/dist-tag FAILED (${e.message.split('\n')[0]}). GitHub is now AHEAD of npm — the exact drift this guards against. The nightly aborts here; republish npm manually (\`npm publish && npm dist-tag add ruvnet-brain@${next} latest\`) and check npm auth in the launchd env.`);
+      console.error(`[publish] FATAL: npm publish/dist-tag FAILED (${e.message.split('\n')[0]}). GitHub is now AHEAD of npm — the exact drift this guards against. The nightly aborts here; republish npm manually (\`npm publish --tag latest && npm dist-tag add ruvnet-brain@${next} latest\`) and check npm auth in the launchd env.`);
       process.exit(1);
     }
     NOTIFY('🟢 Nightly brain published', `${tag} is live on releases/latest + npm — ${todo.length ? `rebuilt: ${todo.map((p) => p.name).join(', ')}` : `reader-script fixes only`}`);

--- a/tests/unit/release-lineage.test.mjs
+++ b/tests/unit/release-lineage.test.mjs
@@ -31,4 +31,11 @@ describe('release command wording', () => {
     expect(src).toContain('PREFLIGHT PASS — NOT PUBLISHED');
     expect(src).toMatch(/PUBLISH\s*\\?[\s\S]*SHIPPED[\s\S]*PREFLIGHT PASS — NOT PUBLISHED/);
   });
+
+  it('publishes prerelease versions with an explicit npm tag on both ship paths', () => {
+    const release = fs.readFileSync(path.join(ROOT, 'scripts/release.mjs'), 'utf8');
+    const nightly = fs.readFileSync(path.join(ROOT, 'scripts/self-update.mjs'), 'utf8');
+    expect(release).toContain("runOrDie('npm publish', 'npm', ['publish', '--tag', 'latest'])");
+    expect(nightly).toContain("execFileSync('npm', ['publish', '--tag', 'latest']");
+  });
 });


### PR DESCRIPTION
## Why
npm now rejects prerelease publication without an explicit tag. The v3.9.133 ship gate reproduced that failure after all source gates passed.

## Fix
- publish with `--tag latest` in both the manual release and nightly self-update paths
- add a regression assertion covering both paths
- refresh the generated chunk census (151,033) after the live brain advanced
- bump coherently to v3.9.134-dev

## Verification
- focused regression suites: 39/39
- full unit suite: 151 files passed, 2,410 tests passed, 7 expected failures, 1 skipped, 169 todo
- release vector: 8/8 PASS
- product battery: 60/60
- Top-100: 100/100 grounded/routed/evidence/receipts/semantic; p95 1.593s

The check-only preflight reaches only the expected live-channel boundary until v3.9.134 is published.