### PR TITLE
fix(hooks): resolve AgentDB memory state newest-wins across every candidate store

### DIFF
--- a/plugin/scripts/ground-ruvnet.sh
+++ b/plugin/scripts/ground-ruvnet.sh
@@ -108,20 +108,36 @@ MEM_STATE="off"; MEM_IDLE=0
 # repository identity with the primary checkout but not its ignored `.swarm/` directory. If the
 # local worktree has no store, inspect the primary worktree resolved from git's absolute common dir
 # before declaring memory absent.
+# NEWEST-WINS, and it has to be newest-wins rather than first-match-wins: the store is resolved
+# relative to the hook's cwd, which is whatever directory the session happens to be working in
+# rather than the ruflo root, so the FIRST candidate found is not necessarily the one being
+# written. A stale local `.swarm/` used to end the search and fire the "hooks look miswired" nag
+# while every write was landing in another store.
+#
+# Taking the newest needs no mtime arithmetic, because over a candidate set the two questions the
+# states depend on distribute: "the newest is fresh" is equivalent to "ANY is fresh", and "the
+# newest exists" to "ANY exists". So accumulate two flags across every candidate instead of
+# mutating MEM_STATE per candidate, then resolve once at the end.
+MEM_FOUND=0; MEM_FRESH=0
 check_memory_db() {
   _db=$1
   [ -f "$_db" ] || return 1
-  MEM_STATE="idle"; MEM_IDLE=1
+  MEM_FOUND=1
   if find "$_db" "$_db-wal" -mmin -90 2>/dev/null | grep -q .; then
-    MEM_STATE="on"; MEM_IDLE=0
+    MEM_FRESH=1
     return 0
   fi
   return 1
 }
+# 1. cwd — the ruflo root when the session is working at the top of a project.
 for _db in .swarm/agentdb-memory.db .swarm/memory.db .claude/memory.db; do
   check_memory_db "$_db" && break
 done
-if [ "$MEM_STATE" = "off" ]; then
+# 2. Primary worktree. Once MEM_FRESH is set the answer is already final ("on" is terminal, no
+#    later candidate can beat it), so short-circuiting on FRESH is sound where short-circuiting
+#    on FOUND was not — and it keeps the healthy common case at its original cost: one stat, one
+#    find, and no git fork.
+if [ "$MEM_FRESH" = 0 ]; then
   _common_git=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
   case "$_common_git" in
     */.git)
@@ -136,8 +152,29 @@ if [ "$MEM_STATE" = "off" ]; then
       ;;
   esac
 fi
+# 3. $HOME. ruflo's own default store lives here, and a project subdir without a `.swarm/` of its
+#    own is the common case that read as "memory absent" — RUFLO_STATE above trips on
+#    `.claude-flow/` alone, which such a subdir often has, so the gate and the miss combined into
+#    a confident false negative. Skipped when cwd IS $HOME: pass 1 already covered it.
+if [ "$MEM_FRESH" = 0 ] && [ -n "$HOME" ] && [ "$PWD" != "$HOME" ]; then
+  for _db in \
+    "$HOME/.swarm/agentdb-memory.db" \
+    "$HOME/.swarm/memory.db" \
+    "$HOME/.claude/memory.db"
+  do
+    check_memory_db "$_db" && break
+  done
+fi
+# Resolve once, from the whole candidate set.
+if [ "$MEM_FRESH" = 1 ]; then
+  MEM_STATE="on";   MEM_IDLE=0
+elif [ "$MEM_FOUND" = 1 ]; then
+  MEM_STATE="idle"; MEM_IDLE=1
+else
+  MEM_STATE="off";  MEM_IDLE=0
+fi
 unset _db
-unset _common_git _primary_root
+unset _common_git _primary_root MEM_FOUND MEM_FRESH
 # RUNNING version (this session's loaded plugin) vs STAGED version (marketplace copy on disk).
 GV0="?"
 [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json" ] && \


### PR DESCRIPTION
Fixes #66.

Two false positives in the memory-detection block of `plugin/scripts/ground-ruvnet.sh`, both of
which fire on a healthy install, and both traceable to the store being resolved relative to the
hook's cwd — which is whatever directory the session happens to be working in, not the ruflo root.

### 1. A store under `$HOME/.swarm/` was never consulted

Candidates at L121 are relative, and the only fallback was the primary git worktree. So any
project subdirectory without its own `.swarm/` reported:

> AgentDB persistent project memory is NOT set up (.swarm/memory.db does not exist) — decisions
> made here are being lost between sessions

…and instructed the model to offer to turn on memory that was already on and actively being
written. `RUFLO_STATE` (L93–94) trips on the presence of `.claude-flow/` alone, which such
directories often have, so the gate and the miss combine into a confident false negative. Acting
on the advice risks initialising a redundant second store.

### 2. A stale local store ended the search

`check_memory_db()` mutated `MEM_STATE` to `idle` on mere existence, and the fallback was gated on
`MEM_STATE = "off"` — so a stale local `.swarm/` shadowed a fresher store elsewhere and the "your
memory isn't capturing this session — the hooks look miswired" text fired while writes were landing
fine.

## Approach: newest-wins

Rather than patch the gate, this does what the comment above the block already promises (L107):

```
# So: consider every store, and each one's -wal, and take the newest.
```

- Accumulate `MEM_FOUND` / `MEM_FRESH` across the **whole** candidate set instead of mutating
  `MEM_STATE` per candidate, then resolve state once at the end.
- Add `$HOME` as a third candidate location.
- Keep a short-circuit on **FRESH**, which is sound because `on` is terminal — no later candidate
  can beat it — where short-circuiting on **FOUND** was not. The healthy common case therefore
  costs exactly what it did before: one stat, one `find`, and no `git` fork. That matters on a hook
  that runs every prompt inside a 5s budget.

Taking the newest needs no mtime arithmetic, because over a candidate set the two questions the
states depend on distribute: *"the newest is fresh"* ≡ *"any is fresh"*, and *"the newest exists"* ≡
*"any exists"*.

No change to the warning text, the 90-minute threshold, the WAL handling, or the relative
precedence of the pre-existing candidates.

## Verification

Synthetic `$HOME` fixtures, plus a real install whose store lives at `$HOME/.swarm/`:

| scenario | expected | result |
|---|---|---|
| stale local `.swarm/` **+ fresh `$HOME` store** | silent — newest wins | silent ✅ |
| fresh local + stale `$HOME` | silent | silent ✅ |
| both stale | "over 90 minutes" | fires ✅ |
| no store anywhere, ruflo stack present | "NOT set up" | fires ✅ |
| no local store, fresh `$HOME` | silent | silent ✅ (previously "NOT set up") |
| cwd `$HOME`, store present locally | silent | silent ✅ |
| cwd a project with its own stale `.swarm/` | silent | silent ✅ (previously "miswired") |
| cwd `/tmp` | silent | silent ✅ |

`sh -n` and `bash -n` clean; the added code is POSIX with no bashisms, consistent with the rest of
the script.

**Honest note on scope:** measured outcomes are *identical* to simply gating the old first-match
structure on `!= "on"` (I verified both against the table above). The gain here is not different
behaviour — it is that the code now expresses newest-wins directly, so a future change to
`check_memory_db()`'s early return cannot silently reintroduce shadowing, and the state machine is
readable in one place. If you'd rather have the three-line gate fix instead, I'm happy to reduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
