### PR TITLE
fix(qe): expose novice 50 benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "node plugin/test/run-tests.mjs",
     "release:proof": "node scripts/release-proof.mjs",
     "benchmark:brain50": "node scripts/brain-latency-50.mjs",
+    "benchmark:novice50": "node scripts/brain-novice-50.mjs",
     "version:check": "node scripts/sync-version.mjs --check",
     "claims:verify": "node scripts/claims-verify.mjs",
     "claims:fix": "node scripts/claims-verify.mjs --fix",


### PR DESCRIPTION
Release-gate follow-up for v4.0.2. The definition-of-done correctly rejected an orphaned novice 50-question harness. This exposes the existing harness as npm run benchmark:novice50 so it is a reachable, truthfully manual QE surface.\n\nFocused proof: wired-check 0 UNWIRED; 37/37 wiring + novice benchmark unit tests.