### PR TITLE
fix(release): close Windows cold-start and empty-bundle gates

### DIFF
--- a/docs/adr/0050-issue-pipeline-cannot-silence-itself.md
+++ b/docs/adr/0050-issue-pipeline-cannot-silence-itself.md
@@ -3,7 +3,7 @@ id: ADR-050
 title: The issue pipeline may never manufacture its own acknowledgment — awareness, escalation, and a fixer that knows when to stop
 status: Accepted
 date: 2026-07-24
-updated: 2026-07-30
+updated: 2026-07-31
 impl: wired
 authors: [Stuart Kerr, Claude Code]
 tags: [issues, automation, alerting, sla, security, circuit-breaker]
@@ -178,6 +178,7 @@ The four parallel agents working tonight support this distinction. They show tha
 
 | Date | What changed | Why (with referents) |
 |---|---|---|
+| 2026-07-31 | Re-read the issue surfacer after first-session seed and update maintenance were serialized into one detached worker; I1-I3 are unchanged. | Commit `0f68737` changes only the Stable-Spine seed/heartbeat block in `plugin/scripts/session-start.sh` and adds `plugin/scripts/first-session-worker.mjs`. The open-issue count, human-acknowledgment predicate, SLA escalation, and fixer circuit breaker are untouched. |
 | 2026-07-30 | Removed the default-off project-preference Node launch from SessionStart without changing the issue surfacer. | `plugin/scripts/session-start.sh` now calls the authoritative seed helper only when the settings file explicitly opts into new-project defaults. Issue counting, acknowledgment, escalation, and repair logic are untouched. |
 | 2026-07-30 | Re-read the issue pipeline after project-default seeding and host-convergence messaging landed in SessionStart; I1–I3 are unchanged. | `plugin/scripts/session-start.sh` adds one-time nonsecret preference seeding and restart guidance. The open-count, acknowledgment, escalation, and fixer circuit-breaker logic in `scripts/issue-watch.mjs` and `scripts/issue-fix.mjs` is unchanged; GitHub App follow-up remains open. |
 | 2026-07-29 | Re-read the issue surfacer after opt-in cold-start tracing was added around unrelated spine, heartbeat, and metering stages. The issue block and its acknowledgment/escalation semantics are unchanged. | Commit `66589f4`; governed path `plugin/scripts/session-start.sh`; PR #58 Windows job `90484507774`. |

--- a/docs/adr/0055-proactivity-that-meshes.md
+++ b/docs/adr/0055-proactivity-that-meshes.md
@@ -3,7 +3,7 @@ id: ADR-055
 title: Proactivity that meshes — one decision law, four planes, substance-bound enforcement, learning bound to outcomes
 status: Accepted
 date: 2026-07-27
-updated: 2026-07-30
+updated: 2026-07-31
 impl: wired
 authors: [Stuart Kerr, Claude Fable 5, GPT-5.6 (codex, read-only)]
 tags: [proactivity, hooks, mesh, fourth-wall, learning, grounding, qa]
@@ -684,6 +684,7 @@ delegation drift goes to the interrupt tier (§3.7.9).
 
 | Date | What changed | Why (with referents) |
 |---|---|---|
+| 2026-07-31 | First-session Stable-Spine seeding and update detection now run sequentially in one detached worker; the four-plane decision law, hook output, and outcome receipts are unchanged. | Main stranger run `30603476401` measured two cold detachers at 4597ms. PR #71 core job `91073195901` then rejected simply deferring maintenance because ADR-054 requires updates while Brain OFF. Commit `0f68737` adds `plugin/scripts/first-session-worker.mjs`; focused acceptance passed 70/70 and the real registered SessionStart measured cold 249ms, p95 182ms, max 192ms. |
 | 2026-07-30 | The Windows detached supervisor now severs stdout and stderr explicitly at PowerShell's native `Start-Process` boundary. The process lifetime, TTL, receipt, and four-plane decision law are unchanged. | PR #68 job `91056188408` showed the packed PowerShell SessionStart body completed but the checker did not receive `close` before its five-second watchdog, consistent with a descendant retaining a capture handle; the job did not instrument exact handle ownership. `plugin/scripts/detach.mjs` now prevents supervisor stream inheritance with distinct files; `tests/unit/hook-battery.test.mjs` pins both redirects, and the unchanged packed Windows stranger gate remains the acceptance authority. |
 | 2026-07-30 | Re-read the governed mesh after the default-off SessionStart seed guard and strict cross-platform UX oracle correction. The four-plane decision law, grounding receipts, hook registrations, and outcome-bound learning paths are unchanged. | `plugin/scripts/session-start.sh` skips a Node launch unless `newProjectDefaults` is explicitly true, while `tests/ux/render-probe.mjs` changes only the external acceptance oracle. `npm run qe:ux` passed at candidate `ba53fc9`: cold 334ms, p95 195ms, max 195ms, Fix All 1588ms. |
 | 2026-07-29 | Re-read the full governed hook, mesh, retrieval, and experience surface after the 4.0.0 hardening commit. The decision law is unchanged; dual-host updating, worker retirement, and stored Agentic-QE tests strengthen its enforcement and proof. | Commit `e20cdf2`; governed paths include `plugin/scripts/host-update.mjs`, `plugin/scripts/detach.mjs`, `kb/forge-mcp-all.mjs`, `tests/mesh/coexistence.test.mjs`, and `tests/experience/scenarios.json`. The mesh suite, live Ruflo learning replay, and Agentic-QE gates recorded in `docs/qe/AGENTIC-QE-4.0-MASTER-PLAN.md` pass. |

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -72,6 +72,12 @@ and makes bundle assembly refuse zero RVFs, missing required files, or a stale Z
 candidate repair—not a release verdict—until exact-SHA cross-platform CI, rebuilt artifact,
 clean-install, installed-MCP latency, and publication checks pass.
 
+The first PR #71 core run then rejected the initial implementation because it deferred maintenance
+on a Brain-OFF machine. Commit `0f68737` preserves both contracts without restoring the latency
+race: one detached first-session worker seeds the Stable Spine and then performs the heartbeat
+sequentially. A seed failure prevents the check; a network-check failure cannot undo a successful
+seed and the normal 15-minute retry remains armed.
+
 Extends ADR-057's build order. ADR-057's diagnosis — the three concealment mechanisms, the five
 converged classes — is the incident record and is not restated.
 
@@ -323,6 +329,7 @@ correct: **the strong claim was the defect.**
 
 | Date | What changed | Why (with referents) |
 |---|---|---|
+| 2026-07-31 | Replaced the first cold-start fix's deferred heartbeat with one composite seed-then-heartbeat worker, and refreshed the self-knowledge RVF to the exact code commit. | PR #71 core job `91073195901` correctly failed `tests/unit/brain-off.test.mjs`: the heartbeat stamp stayed at `1`, violating ADR-054's rule that Brain OFF still receives fixes. Commit `0f68737` introduces `plugin/scripts/first-session-worker.mjs`, which serializes seed and heartbeat behind one detacher. Focused acceptance passed 70/70 and the real registered gate measured cold 249ms, p95 182ms, max 192ms. The refreshed `ruvnet-brain.big.rvf` contains 2157 passages, passed 3/3 round trips, and `kb/RVF-GENERATIONS.json` binds it to `0f68737`. |
 | 2026-07-31 | Closed the cold-start oracle gap exposed by the exact post-merge Windows stranger run and made release bundle assembly fail closed. | Main run `30603476401`, Windows job `91070872621`, measured the valid SessionStart at 4597ms while `scripts/qe/session-start-gate.mjs` rejected only a full timeout. Commit `cd28e28` applies `absoluteFailMs=4000` to the cold sample, makes `plugin/scripts/session-start.sh` avoid launching both seed and heartbeat workers in one virgin session, emits `SESSION_TRACE` in the stranger path, and makes `scripts/build-bundle.mjs` refuse zero public RVFs or missing required files before creating a ZIP. Focused verification passed 141/141 tests; the real registered command measured cold 244ms, p95 190ms, max 242ms. |
 | 2026-07-30 | Removed the isolated unit-test module from `governs:`; the executable release authority and its live-QE caller remain governed. | `tests/unit/release-proof.test.mjs` is an acceptance observer, not a production caller. Treating an intentionally test-only module as an unwired runtime surface capped the implemented authority at `built` and made D7 fail for the wrong reason. The runtime path remains `scripts/release-vector.mjs` → `tests/qe/gpt56/live-brain-search.test.mjs` plus `scripts/release-proof.mjs`. |
 | 2026-07-29 | Re-read the complete governed set after the prompt-hook timeout repair; the vector-minimum contract is unchanged, and D6 now states the real 5s pre-tool / 10s prompt-host envelope rather than the obsolete uniform-5s claim. | PR #65 / commit `6734597` changes only the two UserPromptSubmit declarations in `plugin/hooks/hooks.json` and `plugin/hooks/codex-hooks.json`; their inner runtime remains bounded at 4s and the new regression caps the host declaration at 10s. The exact candidate's release vector and cross-platform CI passed before merge; this is release evidence, not a two-grader 95 claim. |

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -3,7 +3,7 @@ id: ADR-058
 title: The 95 contract — one observable per dimension, one mutant per observable, and the external-signal watch plane
 status: Proposed
 date: 2026-07-27
-updated: 2026-07-30
+updated: 2026-07-31
 impl: wired
 authors: [Stuart Kerr, Claude Fable 5, GPT-5.6-Sol (codex)]
 tags: [qa, gen2-qe, grading, external-signals, ci-watch, release-gate, mutation]
@@ -37,7 +37,7 @@ governs:
 # ADR-058: The 95 contract
 
 **Status**: Proposed
-**Date**: 2026-07-27 · **Last updated**: 2026-07-30 · **Why**: the public 4.0.1 artifact exposed
+**Date**: 2026-07-27 · **Last updated**: 2026-07-31 · **Why**: the public 4.0.1 artifact exposed
 that QE-BRN-001 existed in the written master plan but was absent from the executable critical-risk
 map and release vector; the live `search_ruvnet` worker consequently timed out without blocking
 publication.
@@ -62,6 +62,15 @@ remote main, five issues remain open, remote CI/Windows UX are red, the installe
 lacks the Brain self-store, WSL2 and the published artifact remain unproven, Agentic QE currently
 reports a vacuous 0-test pass through its CLI, and both external graders have not re-run on one clean
 published candidate.
+
+The post-merge run of PR #70 then caught another oracle defect before publication: the Windows
+PowerShell stranger path measured a real cold SessionStart at 4597ms, but D6's dedicated gate only
+rejected the cold sample at the full five-second watchdog. Commit `cd28e28` makes the checked-in
+4000ms absolute limit apply to the cold sample too, defers the redundant heartbeat when the same
+first session already dispatched Stable-Spine seeding, preserves stage traces in stranger receipts,
+and makes bundle assembly refuse zero RVFs, missing required files, or a stale ZIP. This is still a
+candidate repair—not a release verdict—until exact-SHA cross-platform CI, rebuilt artifact,
+clean-install, installed-MCP latency, and publication checks pass.
 
 Extends ADR-057's build order. ADR-057's diagnosis — the three concealment mechanisms, the five
 converged classes — is the incident record and is not restated.
@@ -314,6 +323,7 @@ correct: **the strong claim was the defect.**
 
 | Date | What changed | Why (with referents) |
 |---|---|---|
+| 2026-07-31 | Closed the cold-start oracle gap exposed by the exact post-merge Windows stranger run and made release bundle assembly fail closed. | Main run `30603476401`, Windows job `91070872621`, measured the valid SessionStart at 4597ms while `scripts/qe/session-start-gate.mjs` rejected only a full timeout. Commit `cd28e28` applies `absoluteFailMs=4000` to the cold sample, makes `plugin/scripts/session-start.sh` avoid launching both seed and heartbeat workers in one virgin session, emits `SESSION_TRACE` in the stranger path, and makes `scripts/build-bundle.mjs` refuse zero public RVFs or missing required files before creating a ZIP. Focused verification passed 141/141 tests; the real registered command measured cold 244ms, p95 190ms, max 242ms. |
 | 2026-07-30 | Removed the isolated unit-test module from `governs:`; the executable release authority and its live-QE caller remain governed. | `tests/unit/release-proof.test.mjs` is an acceptance observer, not a production caller. Treating an intentionally test-only module as an unwired runtime surface capped the implemented authority at `built` and made D7 fail for the wrong reason. The runtime path remains `scripts/release-vector.mjs` → `tests/qe/gpt56/live-brain-search.test.mjs` plus `scripts/release-proof.mjs`. |
 | 2026-07-29 | Re-read the complete governed set after the prompt-hook timeout repair; the vector-minimum contract is unchanged, and D6 now states the real 5s pre-tool / 10s prompt-host envelope rather than the obsolete uniform-5s claim. | PR #65 / commit `6734597` changes only the two UserPromptSubmit declarations in `plugin/hooks/hooks.json` and `plugin/hooks/codex-hooks.json`; their inner runtime remains bounded at 4s and the new regression caps the host declaration at 10s. The exact candidate's release vector and cross-platform CI passed before merge; this is release evidence, not a two-grader 95 claim. |
 | 2026-07-29 | Reviewed the complete governed-path history since `7709c67` and re-read the only changed governed path; both post-document installer fixes strengthen D8 and leave the 95 contract unchanged. | Commit `c2d5ef0` makes `bin/install.mjs` count canonical `*.big.rvf` stores; commit `ebe51a5` makes Codex status honor `CODEX_HOME` and decode Windows TOML paths. Focused installer smoke passed 22 tests (1 skipped, 3 todo), and Codex wiring passed 42/42. Neither commit proves a published candidate or both external grades. |

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -626,12 +626,12 @@
     },
     "ruvnet-brain": {
       "file": "ruvnet-brain.big.rvf",
-      "sha256": "2d1e8db1ea63ac4b593cc0917ad84bfc1b3a64bb73f7a37f2e2d2b477b68a7bd",
-      "bytes": 4661410,
+      "sha256": "ca290ed69d9c2046f288c7fe0d0b37ada24e9e23449e07bd0f55649b0b3f7d2a",
+      "bytes": 7352789,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": "cd0ed16ab3dc7199d0bb2e8c65b6c37887606192",
-      "builtUtc": "2026-07-30T17:24:56.436Z"
+      "sourceCommit": "0f68737ae8521a5ad56b33b591b8f757c7029d2d",
+      "builtUtc": "2026-07-31T04:39:28.487Z"
     }
   }
 }

--- a/kb/SOURCE.json
+++ b/kb/SOURCE.json
@@ -1,6 +1,6 @@
 {
   "builder": "rvf-kb-forge",
-  "builtUtc": "2026-07-31T03:23:58.243Z",
+  "builtUtc": "2026-07-31T04:39:28.414Z",
   "canonicalManifestUrl": "https://api.github.com/repos/stuinfla/ruvnet-brain/releases/latest",
   "selfUpdate": "node forge-update.mjs",
   "stores": {
@@ -149,10 +149,10 @@
     },
     "ruvnet-brain": {
       "kbName": "ruvnet-brain",
-      "sourceRepo": "/Users/stuartkerr/Code/ruvnet-brain/.",
-      "sourceCommit": "cd0ed16ab3dc7199d0bb2e8c65b6c37887606192",
-      "sourceDescribe": "v4.0.1",
-      "builtUtc": "2026-07-30T12:00:41.900Z",
+      "sourceRepo": "https://github.com/stuinfla/ruvnet-brain.git",
+      "sourceCommit": "0f68737ae8521a5ad56b33b591b8f757c7029d2d",
+      "sourceDescribe": "v4.0.1-16-g0f68737",
+      "builtUtc": "2026-07-31T04:39:28.414Z",
       "builder": "rvf-kb-forge",
       "canonicalManifestUrl": "https://api.github.com/repos/stuinfla/ruvnet-brain/releases/latest",
       "canonicalBundleUrl": "https://raw.githubusercontent.com/stuinfla/ruvnet-brain/main/kb/ruvnet-brain-kb-bundle.zip",

--- a/plugin/scripts/first-session-worker.mjs
+++ b/plugin/scripts/first-session-worker.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// One detached first-session lifecycle worker: seed the Stable Spine, then perform the update
+// heartbeat the seed used to race. Keeping both operations in one worker preserves ADR-054's
+// "Brain OFF still receives fixes" contract without making SessionStart launch two detachers.
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const [updateApply, hostUpdate, versionLog] = process.argv.slice(2);
+if (![updateApply, hostUpdate, versionLog].every((value) => typeof value === 'string' && value)) {
+  process.stderr.write('usage: first-session-worker.mjs <update-apply.mjs> <host-update.mjs> <version-log>\n');
+  process.exit(2);
+}
+
+const seed = spawnSync(process.execPath, [updateApply, '--seed'], {
+  env: process.env,
+  stdio: 'inherit',
+});
+if (seed.error || seed.status !== 0) {
+  process.stderr.write(`[ruvnet-brain] first-session seed failed: ${seed.error?.message || `exit ${seed.status}`}\n`);
+  process.exit(1);
+}
+
+const check = spawnSync(process.execPath, [hostUpdate, '--check'], {
+  env: process.env,
+  encoding: 'utf8',
+});
+const version = String(check.stdout || '').trim();
+if (!check.error && check.status === 0 && /^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$/.test(version)) {
+  fs.mkdirSync(path.dirname(versionLog), { recursive: true });
+  const temporary = `${versionLog}.tmp-${process.pid}`;
+  fs.writeFileSync(temporary, `${version}\n`);
+  fs.renameSync(temporary, versionLog);
+}
+
+// Network failure must not undo a successful seed. The 15-minute heartbeat stamp lets the normal
+// SessionStart path retry later, while the current runtime remains valid and usable.
+process.exit(0);

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -527,9 +527,15 @@ if command -v node >/dev/null 2>&1 && [ -f "$HOOK_DIR/update-apply.mjs" ]; then
       if [ "$SEED_NOW" -gt 0 ] && [ $((SEED_NOW - SEED_LAST)) -gt 300 ]; then
         mkdir -p "$SPINE_HOME" 2>/dev/null
         echo "$SEED_NOW" > "$SEED_STAMP" 2>/dev/null
-        if [ -f "$DETACH" ] && node "$DETACH" 120 "$SPINE_HOME/.seed.log" \
-          node "$HOOK_DIR/update-apply.mjs" --seed; then
+        FIRST_SESSION_WORKER="$HOOK_DIR/first-session-worker.mjs"
+        VERSION_LOG="$STATE_DIR/.last-version-check.log"
+        if [ -f "$DETACH" ] && [ -f "$FIRST_SESSION_WORKER" ] && [ -f "$HOOK_DIR/host-update.mjs" ] \
+          && node "$DETACH" 120 "$SPINE_HOME/.seed.log" node "$FIRST_SESSION_WORKER" \
+            "$HOOK_DIR/update-apply.mjs" "$HOOK_DIR/host-update.mjs" "$VERSION_LOG"; then
           SEED_DISPATCHED=1
+          # The detached worker now owns BOTH seed and heartbeat. Stamp the heartbeat here so a
+          # burst of virgin sessions cannot launch duplicate checks while that worker is active.
+          echo "$SEED_NOW" > "$STAMP" 2>/dev/null
         fi
         trace_stage "seed-dispatch-returned"
       fi
@@ -582,10 +588,9 @@ LAST=0
 [ -f "$STAMP" ] && IFS= read -r LAST < "$STAMP"
 [ -n "$LAST" ] || LAST=0
 # A virgin install must not launch two independent lifecycle workers in the same SessionStart.
-# Seeding copies the exact running payload into the Stable Spine; an immediate version heartbeat
-# cannot improve that result, but on Git-for-Windows its second Node + detached-child startup pushed
-# the real hook to 4597ms and failed the hard <4s margin. Defer the heartbeat to the next session;
-# the stamp remains untouched, so it is guaranteed to run then rather than being silently consumed.
+# Seeding and the immediate version heartbeat run sequentially inside first-session-worker.mjs.
+# On Git-for-Windows, launching them as TWO detached workers pushed the real hook to 4597ms. The
+# composite worker preserves ADR-054 maintenance while keeping the foreground to one detacher.
 if [ "$SEED_DISPATCHED" != "1" ] && [ "$NOW" -gt 0 ] && [ $((NOW - LAST)) -gt 900 ]; then
   trace_stage "heartbeat-block-start"
   echo "$NOW" > "$STAMP" 2>/dev/null

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -488,6 +488,7 @@ fi
 
 # ── STABLE SPINE (ADR-023): seed on first run; honest restart notice only when the SHELL changed ──
 SPINE_HOME="$HOME/.cache/ruvnet-brain"
+SEED_DISPATCHED=0
 trace_stage "spine-block-start"
 if command -v node >/dev/null 2>&1 && [ -f "$HOOK_DIR/update-apply.mjs" ]; then
   if [ ! -f "$SPINE_HOME/active.json" ]; then
@@ -526,8 +527,10 @@ if command -v node >/dev/null 2>&1 && [ -f "$HOOK_DIR/update-apply.mjs" ]; then
       if [ "$SEED_NOW" -gt 0 ] && [ $((SEED_NOW - SEED_LAST)) -gt 300 ]; then
         mkdir -p "$SPINE_HOME" 2>/dev/null
         echo "$SEED_NOW" > "$SEED_STAMP" 2>/dev/null
-        [ -f "$DETACH" ] && node "$DETACH" 120 "$SPINE_HOME/.seed.log" \
-          node "$HOOK_DIR/update-apply.mjs" --seed
+        if [ -f "$DETACH" ] && node "$DETACH" 120 "$SPINE_HOME/.seed.log" \
+          node "$HOOK_DIR/update-apply.mjs" --seed; then
+          SEED_DISPATCHED=1
+        fi
         trace_stage "seed-dispatch-returned"
       fi
     fi
@@ -578,7 +581,12 @@ NOW=$(date +%s 2>/dev/null || echo 0)
 LAST=0
 [ -f "$STAMP" ] && IFS= read -r LAST < "$STAMP"
 [ -n "$LAST" ] || LAST=0
-if [ "$NOW" -gt 0 ] && [ $((NOW - LAST)) -gt 900 ]; then
+# A virgin install must not launch two independent lifecycle workers in the same SessionStart.
+# Seeding copies the exact running payload into the Stable Spine; an immediate version heartbeat
+# cannot improve that result, but on Git-for-Windows its second Node + detached-child startup pushed
+# the real hook to 4597ms and failed the hard <4s margin. Defer the heartbeat to the next session;
+# the stamp remains untouched, so it is guaranteed to run then rather than being silently consumed.
+if [ "$SEED_DISPATCHED" != "1" ] && [ "$NOW" -gt 0 ] && [ $((NOW - LAST)) -gt 900 ]; then
   trace_stage "heartbeat-block-start"
   echo "$NOW" > "$STAMP" 2>/dev/null
 

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -141,10 +141,17 @@ function cpDir(srcDir, destDir, skipNames) {
 }
 
 // ---- assemble ----------------------------------------------------------------------------------
+const ZIP = path.join(path.dirname(OUT), `${path.basename(OUT)}.zip`);
 fs.rmSync(OUT, { recursive: true, force: true });
+// A failed rebuild must not leave an older archive looking like this invocation's output.
+fs.rmSync(ZIP, { force: true });
 fs.mkdirSync(OUT, { recursive: true });
 
 const built = discoverBuilt();
+if (built.length === 0) {
+  console.error('[build-bundle] FATAL: zero public RVF stores are eligible for release. Refusing to publish an empty brain bundle.');
+  process.exit(1);
+}
 const rvfIndexAudit = await auditRvfIndexes(
   built.map((name) => path.join(KB, `${name}.big.rvf`)),
 );
@@ -446,12 +453,17 @@ node forge-ask.mjs --dir . --name ruvector --variant big --q "what is the RVF co
 - See \`manifest.json\` for per-repo chunk counts, variants, grades, and pinned source SHAs.
 `);
 
+if (missing.length) {
+  const requiredMissing = [...new Set(missing)];
+  console.error(`[build-bundle] FATAL: missing required bundle files:\n  ${requiredMissing.join('\n  ')}`);
+  process.exit(1);
+}
+
 // ---- exact release artifact -------------------------------------------------------------------
 // The release signer signs dist/ruvnet-brain.zip, not this assembly directory. Rebuilding only the
 // directory can therefore sign stale bytes left by an older run—the source tree is green while
 // users receive an old brain. Build the exact ZIP here, then extract it through the same safe
 // extractor users run and audit the RVF indexes in those extracted bytes before signing is allowed.
-const ZIP = path.join(path.dirname(OUT), `${path.basename(OUT)}.zip`);
 const archiveFiles = [];
 function collectArchiveFiles(dir, prefix = '') {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -462,7 +474,6 @@ function collectArchiveFiles(dir, prefix = '') {
 }
 collectArchiveFiles(OUT);
 archiveFiles.sort();
-fs.rmSync(ZIP, { force: true });
 const zipped = process.platform === 'win32'
   ? spawnSync('powershell.exe', [
     '-NoProfile',

--- a/scripts/ci/stranger-scenario.mjs
+++ b/scripts/ci/stranger-scenario.mjs
@@ -132,6 +132,10 @@ function runInstaller(args, extraEnv = {}) {
       HOME: HOME_DIR,
       USERPROFILE: HOME_DIR,
       RUVNET_BRAIN_TEST: '1',
+      // Preserve stage timing in the exact stranger path. The Windows cold-start miss that
+      // escaped PR #70 was visible only as one aggregate 4597ms number; future failures must
+      // identify the slow lifecycle stage in the same CI receipt.
+      RUVNET_SESSION_TRACE: '1',
       ...extraEnv,
     },
     input: '',

--- a/scripts/qe/session-start-gate.mjs
+++ b/scripts/qe/session-start-gate.mjs
@@ -37,8 +37,8 @@
 //      real first-run offers.
 //   3. COLD + STEADY — ONE cold fire before the steady-state window. The first-ever fire in a virgin
 //      HOME emits once-per-machine offers, but it is still a real user wait: it must finish inside
-//      the hook's declared timeout and a timeout hard-fails the gate. The following samples measure
-//      the common steady state without allowing a failed cold start to disappear into a percentile.
+//      both absoluteFailMs and the hook's declared timeout. The following samples measure the common
+//      steady state without allowing a failed cold start to disappear into a percentile.
 //   4. SEQUENTIAL — never concurrent. Concurrency would measure the runner's core count.
 //
 // THE THRESHOLDS ARE NOT HARDCODED HERE. They live in kb/card-lane-budget.json under `sessionStart`,
@@ -166,6 +166,9 @@ export async function runSessionStartGate(opts = {}) {
   const reasons = [];
   if (warmupTimedOut) {
     reasons.push(`COLD-START FAIL — the first SessionStart fire exceeded its declared ${timeoutSec}s timeout (${warmupMs.toFixed(0)}ms); first-run latency is user-felt and may not be hidden as an untimed warm-up`);
+  }
+  if (warmupMs > budget.absoluteFailMs) {
+    reasons.push(`COLD-START ABSOLUTE FAIL — the first SessionStart fire took ${warmupMs.toFixed(0)}ms > absoluteFailMs=${budget.absoluteFailMs}ms, even though the command timeout is ${timeoutSec}s; first-run latency may not bypass the absolute limit as an untimed warm-up`);
   }
   if (p95 > budget.absoluteFailMs || max > budget.absoluteFailMs) {
     reasons.push(`ABSOLUTE FAIL — the hook has no margin left inside its own declared ${timeoutSec}s timeout: max=${max.toFixed(0)}ms p95=${p95.toFixed(0)}ms > absoluteFailMs=${budget.absoluteFailMs}ms (= TIMEOUT_MARGIN 0.8 x ${timeoutSec}s, the same wall scripts/selfcheck.mjs already enforces on a stranger's machine)`);

--- a/scripts/selfcheck.mjs
+++ b/scripts/selfcheck.mjs
@@ -424,7 +424,13 @@ export function assertContract({ rec, measurement, mode, timeoutSec }) {
   if (measurement.timedOut) {
     v.push({ kind: 'hang', where, regime: measurement.regime, detail: `${tag} did not exit within its declared timeout of ${timeoutSec}s — the watchdog had to kill the process group` });
   } else if (measurement.elapsedMs > budgetMs * TIMEOUT_MARGIN) {
-    v.push({ kind: 'slow', where, regime: measurement.regime, detail: `${tag} took ${measurement.elapsedMs}ms — over ${Math.round(TIMEOUT_MARGIN * 100)}% of its ${timeoutSec}s timeout (no margin left)` });
+    const stageTrace = String(measurement.stderr || '')
+      .split('\n')
+      .filter((line) => line.includes('SESSION_TRACE'))
+      .map((line) => line.trim())
+      .join(' | ');
+    const traceDetail = stageTrace ? `; stage trace: ${stageTrace}` : '';
+    v.push({ kind: 'slow', where, regime: measurement.regime, detail: `${tag} took ${measurement.elapsedMs}ms — over ${Math.round(TIMEOUT_MARGIN * 100)}% of its ${timeoutSec}s timeout (no margin left)${traceDetail}` });
   }
 
   // 2. EXIT CODE within the declared contract for this mode.

--- a/tests/integration/build-bundle-fence.test.mjs
+++ b/tests/integration/build-bundle-fence.test.mjs
@@ -67,10 +67,11 @@ describe('build-bundle.mjs — private-store fence (fail-closed)', () => {
     expect(r.stderr).toMatch(/FATAL.*private-store fence missing/i);
   });
 
-  it('proceeds with an empty fence ONLY when ALLOW_NO_PRIVATE_FENCE=1 is explicit', () => {
+  it('accepts an empty fence ONLY when ALLOW_NO_PRIVATE_FENCE=1 is explicit, then applies the independent RVF gate', () => {
     const r = runBuildBundle({ ALLOW_NO_PRIVATE_FENCE: '1' });
-    expect(r.code).toBe(0);
+    expect(r.code).toBe(1);
     expect(r.stderr).toMatch(/ALLOW_NO_PRIVATE_FENCE=1.*proceeding with NO fence/i);
+    expect(r.stderr).toMatch(/FATAL.*zero public RVF/i);
   });
 
   it('FATALs (exit 1) when PRIVATE-STORES.json is present but corrupt JSON', () => {
@@ -100,5 +101,30 @@ describe('build-bundle.mjs — private-store fence (fail-closed)', () => {
     expect(names).toContain('public-repo');
     const readme = fs.readFileSync(path.join(tmp, 'dist/ruvnet-brain/README.md'), 'utf8');
     expect(readme).not.toMatch(/cognitum-seed/i);
+  });
+});
+
+describe('build-bundle.mjs — publishable artifact gate (fail-closed)', () => {
+  it('FATALs when discovery yields zero public RVFs, including a private-only KB', () => {
+    fs.writeFileSync(path.join(tmp, 'kb/PRIVATE-STORES.json'), JSON.stringify({ privateStores: ['private-repo'] }));
+    fs.writeFileSync(path.join(tmp, 'kb/private-repo.big.rvf'), '');
+
+    const r = runBuildBundle();
+
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/FATAL.*zero public RVF/i);
+    expect(fs.existsSync(path.join(tmp, 'dist/ruvnet-brain.zip'))).toBe(false);
+  });
+
+  it('FATALs instead of publishing a ZIP when any required bundle file is missing', () => {
+    fs.writeFileSync(path.join(tmp, 'kb/PRIVATE-STORES.json'), JSON.stringify({ privateStores: [] }));
+    fs.writeFileSync(path.join(tmp, 'kb/public-repo.big.rvf'), '');
+
+    const r = runBuildBundle();
+
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/FATAL.*missing required bundle files/i);
+    expect(r.stderr).toContain('public-repo.big.rvf.idmap.json');
+    expect(fs.existsSync(path.join(tmp, 'dist/ruvnet-brain.zip'))).toBe(false);
   });
 });

--- a/tests/qe/release/issue-64-host-convergence.test.mjs
+++ b/tests/qe/release/issue-64-host-convergence.test.mjs
@@ -136,6 +136,7 @@ describe('issue #64 — exact dual-host convergence', () => {
     const source = fs.readFileSync(SESSION, 'utf8');
     expect(source).toContain('SEED_DISPATCHED=0');
     expect(source).toContain('SEED_DISPATCHED=1');
+    expect(source).toContain('first-session-worker.mjs');
     expect(source).toContain('if [ "$SEED_DISPATCHED" != "1" ] && [ "$NOW" -gt 0 ]');
   });
 

--- a/tests/qe/release/issue-64-host-convergence.test.mjs
+++ b/tests/qe/release/issue-64-host-convergence.test.mjs
@@ -132,6 +132,13 @@ describe('issue #64 — exact dual-host convergence', () => {
     expect(source).toContain('do not restart for this update yet');
   });
 
+  it('does not launch the update heartbeat in the same SessionStart that seeds the Stable Spine', () => {
+    const source = fs.readFileSync(SESSION, 'utf8');
+    expect(source).toContain('SEED_DISPATCHED=0');
+    expect(source).toContain('SEED_DISPATCHED=1');
+    expect(source).toContain('if [ "$SEED_DISPATCHED" != "1" ] && [ "$NOW" -gt 0 ]');
+  });
+
   it('the installer binds host sync and Spine activation to one exact package version', () => {
     const source = fs.readFileSync(path.join(ROOT, 'bin/install.mjs'), 'utf8');
     expect(source).toContain('wirePlugin({ expectedVersion: PACKAGE_VERSION, requireManaged: true })');

--- a/tests/unit/first-session-worker.test.mjs
+++ b/tests/unit/first-session-worker.test.mjs
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 const WORKER = path.resolve('plugin/scripts/first-session-worker.mjs');
 const roots = [];
 
-function fixture({ seedExit = 0, checkExit = 0, version = '4.0.2' } = {}) {
+function fixture({ seedExit = 0, checkExit = 0, version = '9.8.7' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'first-session-worker-'));
   roots.push(root);
   const seed = path.join(root, 'seed.mjs');
@@ -29,7 +29,7 @@ describe('first-session lifecycle worker', () => {
     const run = spawnSync(process.execPath, [WORKER, f.seed, f.check, f.versionLog], { encoding: 'utf8' });
     expect(run.status).toBe(0);
     expect(fs.readFileSync(f.order, 'utf8')).toBe('seed\ncheck\n');
-    expect(fs.readFileSync(f.versionLog, 'utf8')).toBe('4.0.2\n');
+    expect(fs.readFileSync(f.versionLog, 'utf8')).toBe('9.8.7\n');
   });
 
   it('does not run the heartbeat when seeding failed', () => {

--- a/tests/unit/first-session-worker.test.mjs
+++ b/tests/unit/first-session-worker.test.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const WORKER = path.resolve('plugin/scripts/first-session-worker.mjs');
+const roots = [];
+
+function fixture({ seedExit = 0, checkExit = 0, version = '4.0.2' } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'first-session-worker-'));
+  roots.push(root);
+  const seed = path.join(root, 'seed.mjs');
+  const check = path.join(root, 'check.mjs');
+  const order = path.join(root, 'order.txt');
+  const versionLog = path.join(root, 'state', 'version.log');
+  fs.writeFileSync(seed, `import fs from 'node:fs'; fs.appendFileSync(${JSON.stringify(order)}, 'seed\\n'); process.exit(${seedExit});\n`);
+  fs.writeFileSync(check, `import fs from 'node:fs'; fs.appendFileSync(${JSON.stringify(order)}, 'check\\n'); process.stdout.write(${JSON.stringify(`${version}\n`)}); process.exit(${checkExit});\n`);
+  return { root, seed, check, order, versionLog };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('first-session lifecycle worker', () => {
+  it('seeds first, then records a valid update heartbeat in the same worker', () => {
+    const f = fixture();
+    const run = spawnSync(process.execPath, [WORKER, f.seed, f.check, f.versionLog], { encoding: 'utf8' });
+    expect(run.status).toBe(0);
+    expect(fs.readFileSync(f.order, 'utf8')).toBe('seed\ncheck\n');
+    expect(fs.readFileSync(f.versionLog, 'utf8')).toBe('4.0.2\n');
+  });
+
+  it('does not run the heartbeat when seeding failed', () => {
+    const f = fixture({ seedExit: 1 });
+    const run = spawnSync(process.execPath, [WORKER, f.seed, f.check, f.versionLog], { encoding: 'utf8' });
+    expect(run.status).toBe(1);
+    expect(fs.readFileSync(f.order, 'utf8')).toBe('seed\n');
+    expect(fs.existsSync(f.versionLog)).toBe(false);
+  });
+
+  it('keeps a successful seed usable when the network heartbeat fails', () => {
+    const f = fixture({ checkExit: 1 });
+    const run = spawnSync(process.execPath, [WORKER, f.seed, f.check, f.versionLog], { encoding: 'utf8' });
+    expect(run.status).toBe(0);
+    expect(fs.readFileSync(f.order, 'utf8')).toBe('seed\ncheck\n');
+    expect(fs.existsSync(f.versionLog)).toBe(false);
+  });
+});

--- a/tests/unit/selfcheck-battery.test.mjs
+++ b/tests/unit/selfcheck-battery.test.mjs
@@ -630,8 +630,10 @@ describe('mutation proof — every assertion is load-bearing', () => {
   });
 
   it('MUTANT: disable the latency-margin check → a hook at 95% of its timeout goes GREEN', async () => {
-    const m = { regime: 'valid', timedOut: false, status: 0, elapsedMs: 4750, stdoutBytes: 10, stdout: '', stderr: '', survivors: false };
+    const m = { regime: 'valid', timedOut: false, status: 0, elapsedMs: 4750, stdoutBytes: 10, stdout: '', stderr: 'SESSION_TRACE stage=spine-block elapsed_ms=4600\n', survivors: false };
     expect(assertContract({ rec: REC, measurement: m, mode: 'advisory', timeoutSec: 5 }).map((v) => v.kind)).toContain('slow');
+    expect(assertContract({ rec: REC, measurement: m, mode: 'advisory', timeoutSec: 5 }).find((v) => v.kind === 'slow').detail)
+      .toContain('SESSION_TRACE stage=spine-block elapsed_ms=4600');
     const { mod, file } = await mutant("} else if (measurement.elapsedMs > budgetMs * TIMEOUT_MARGIN) {", "} else if (false) {");
     try {
       expect(mod.assertContract({ rec: REC, measurement: m, mode: 'advisory', timeoutSec: 5 }).map((v) => v.kind)).not.toContain('slow');

--- a/tests/unit/session-start-gate.test.mjs
+++ b/tests/unit/session-start-gate.test.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { measureFirings, runSessionStartGate } from '../../scripts/qe/session-start-gate.mjs';
+import { loadBudget, measureFirings, runSessionStartGate } from '../../scripts/qe/session-start-gate.mjs';
 
 const resolved = {
   surface: { source: 'checkout', root: path.resolve('plugin') },
@@ -51,5 +51,26 @@ describe('session-start hard gate', () => {
     expect(result.p95).toBe(10);
     expect(result.pass).toBe(false);
     expect(result.reasons.join('\n')).toMatch(/COLD-START FAIL/);
+  });
+
+  it('fails when the cold first fire exceeds absoluteFailMs without timing out', async () => {
+    const budget = loadBudget();
+    const coldMs = budget.absoluteFailMs + 1;
+    expect(coldMs).toBeLessThan(resolved.reg.timeout * 1000);
+
+    let calls = 0;
+    const result = await runSessionStartGate({
+      resolved,
+      fireFn: async () => {
+        calls += 1;
+        return measurement(calls === 1 ? coldMs : 10);
+      },
+    });
+
+    expect(result.warmupTimedOut).toBe(false);
+    expect(result.warmupMs).toBe(coldMs);
+    expect(result.p95).toBe(10);
+    expect(result.pass).toBe(false);
+    expect(result.reasons.join('\n')).toMatch(/COLD-START ABSOLUTE FAIL/);
   });
 });


### PR DESCRIPTION
## Release blockers closed

- defer the version heartbeat when the virgin SessionStart already dispatched Stable-Spine seeding
- hard-fail a cold first fire above the checked-in 4000ms absolute limit, even before the 5s watchdog
- preserve SessionStart stage traces in stranger-matrix failures
- refuse release assembly with zero public RVFs, missing required files, or a stale ZIP

## Local evidence

- focused/adjacent: 141 passed, 1 platform skip
- real registered SessionStart: cold 244ms, p95 190ms, max 242ms
- bundle/release regression: 33/33 passed
- document currency: 0 blocking findings
- pre-push release gate: passed

## Incident

Post-merge main run 30603476401 measured Windows PowerShell cold SessionStart at 4597ms. Publication remains vetoed until this exact PR SHA and the subsequent main SHA pass all required checks.