### PR TITLE
test(release): recognize current fast-lane receipts

### DIFF
--- a/plugin/test/run-tests.mjs
+++ b/plugin/test/run-tests.mjs
@@ -257,7 +257,7 @@ if (!fs.existsSync(path.join(KB, 'forge-mcp-all.mjs'))) {
       // The permanent zero-ML card lane is a real grounded answer too. It deliberately does not
       // impersonate the heavy lane's `#1 ... relevance` format, so the QE oracle must recognize
       // both response contracts or every fast answer is mislabeled "(no hit)".
-      const fast = text.match(/FAST LANE[^\n]*\brepo="([^"]+)"/);
+      const fast = text.match(/FAST LANE[\s\S]*?#1\s+repo=(\S+)\s+evidence=/);
       const repo = m?.[1] || fast?.[1];
       const rel = m && m[2] !== 'n/a' ? parseFloat(m[2]) : null;
       const exp = q.expectRepo;


### PR DESCRIPTION
## What changed

The release battery now recognizes the current grounded card-lane receipt format: FAST LANE followed by #1 repo=... evidence=.... The prior oracle only recognized an obsolete quoted inline format and mislabeled nine valid grounded answers as no hit.

## Evidence

- Exact candidate Top-100: 100/100 grounded, 100/100 semantic, 0 errors; p50 23ms, p95 2.67s, max 3.83s.
- Exact candidate npm test: 60/60.
- Pre-push gate passed.

No production retrieval behavior changed; this repairs the release oracle that blocked the valid artifact.