### PR TITLE
fix(release): isolate installer import and sync claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ node forge-ask-all.mjs --dir . --q "How does RuVector implement HNSW vector sear
 
 This project versions in the open (see the live badge up top for the exact plugin version; the downloadable knowledge bundle is a separate track) — we don't claim “done,” “complete,” or “zero hallucinations.” Where it stands:
 
-- ✅ **The grounding brain is real and proven** — 63 public stores · 152,678 public source chunks (70 built stores incl. private), dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
+- ✅ **The grounding brain is real and proven** — 63 public stores · 153,369 public source chunks (70 built stores incl. private), dual embeddings, cross-encoder rerank, plugin (MCP tool + enforcement hook + skill), all re-runnable.
 - ✅ **Code-level depth** — the code-rich repos are indexed to full function bodies; “how is it implemented?” returns the implementation. Verified in the shipped bundle (clean-room 3/3).
 - ✅ **Routing holds** — named 47/48, described 26/28, scenario 7/8; behavioral L1–L3 all pass (**L4 downgraded — it measures that the brain spoke, not that anything listened**); private stores fenced out of the public bundle (zero-leak verified).
 - ⚠️ **Two routing residuals** (above) — surfaced, not hidden.

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -365,7 +365,7 @@
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span data-count="63" data-decimals="0">63</span> public stores</div>
-              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 152,678 public source chunks (70 built stores incl. private)<span class="spear-src">not docs</span></p>
+              <p class="spear-lab">rUv&rsquo;s real source code, indexed &mdash; 153,369 public source chunks (70 built stores incl. private)<span class="spear-src">not docs</span></p>
             </div>
             <div class="spear-card reveal-stagger">
               <div class="spear-num grad"><span class="pq-shimmer">post-quantum</span></div>

--- a/explainer/llms-full.txt
+++ b/explainer/llms-full.txt
@@ -6,7 +6,7 @@
 RuvNet Brain supplies supported lifecycle plugins for Claude Code and Codex. It ships one MCP tool
 — `search_ruvnet` — plus proactive grounding, routing, learning-capture and session-continuity
 hooks. Before the coding agent answers a question about rUv's stack, the brain retrieves the
-relevant passages from rUv's actual source code (152,678 public source chunks across 63 public
+relevant passages from rUv's actual source code (153,369 public source chunks across 63 public
 stores; 70 built stores incl. private) and grounds the answer in cited source paths instead of
 the model's stale priors.
 

--- a/explainer/llms.txt
+++ b/explainer/llms.txt
@@ -18,7 +18,7 @@ IMPORTANT DISAMBIGUATION: "RuvNet Brain" (by Stuart Kerr / Isovision.ai) is a di
 - Underlying ecosystem author: Reuven Cohen (rUv, @ruvnet).
 - Delivery: first-class Claude Code and Codex lifecycle plugins + `search_ruvnet` + proactive grounding and learning hooks.
 - Dual-host reasoning: subscription-only Codex + Claude deliberation for hard ADR, DDD and Agentic-QE experience design; no API-key fallback.
-- Coverage: 63 public stores · 152,678 public source chunks (70 built stores incl. private).
+- Coverage: 63 public stores · 153,369 public source chunks (70 built stores incl. private).
 - License: MIT. Free to use.
 
 ## Built by

--- a/tests/unit/install-telemetry-consent.test.mjs
+++ b/tests/unit/install-telemetry-consent.test.mjs
@@ -1,6 +1,6 @@
 // tests/unit/install-telemetry-consent.test.mjs — the installer half of the telemetry contract.
 //
-// bin/install.mjs exports (under RUVNET_BRAIN_IMPORT_ONLY=1, same pattern as offerNightly):
+// bin/install.mjs exports through its side-effect-free import boundary:
 //   parseTelemetryAnswer — default-YES parser (ENTER/y accept; only explicit n/no declines)
 //   offerTelemetry       — the decision matrix (suppressed in test mode; asked once ever;
 //                          fail-PRIVATE when there is no TTY to ask on)
@@ -31,9 +31,10 @@ afterEach(() => {
 
 let seq = 0;
 async function freshInstaller({ testMode = false, argv = [] } = {}) {
-  process.env.RUVNET_BRAIN_IMPORT_ONLY = '1';
   if (testMode) process.env.RUVNET_BRAIN_TEST = '1'; else delete process.env.RUVNET_BRAIN_TEST;
-  process.argv = [process.execPath, INSTALLER, ...argv];
+  // The installer now authorizes main() by direct argv identity. Give flag parsing the requested
+  // arguments without claiming this dynamic import is a direct CLI invocation.
+  process.argv = [process.execPath, `${INSTALLER}.import-test`, ...argv];
   // unique query → unique module instance → module-level flags re-read the env we just set
   return import(pathToFileURL(INSTALLER).href + `?telemetry-case=${++seq}`);
 }


### PR DESCRIPTION
## Summary\n- isolate telemetry installer dynamic imports from the direct-CLI main boundary\n- synchronize public corpus claims with the rebuilt 153,369-chunk bundle\n\n## Verification\n- full unit suite: 167 files passed, 2,600 tests passed, 0 unexpected failures\n- focused claims + telemetry suite stress replayed 10x: 38/38 each run\n- pre-push version, channel, secrets, and doc-currency gates passed\n\nRelease remains unpublished until this PR, exact-main gates, and clean registry-install proof pass.