### PR TITLE
fix(release): honor sealed stabilization class

### DIFF
--- a/scripts/protected-release-invocation.mjs
+++ b/scripts/protected-release-invocation.mjs
@@ -15,6 +15,7 @@ const digestOf = (receipt) => String(receipt?.artifact?.sha256 || '').replace(/^
 
 export function validateProtectedPublishInvocation({ root = process.cwd(), env = process.env } = {}) {
   const failures = [];
+  let releaseMode = 'unknown';
   if (env.GITHUB_ACTIONS !== 'true' || env.GITHUB_WORKFLOW !== PROTECTED_WORKFLOW) {
     failures.push('publication is allowed only inside the protected-release GitHub workflow');
   }
@@ -48,6 +49,7 @@ export function validateProtectedPublishInvocation({ root = process.cwd(), env =
     if (receiptDigest !== expectedDigest) failures.push('candidate artifact digest mismatch');
     if (receipt.version !== expectedVersion) failures.push('candidate version mismatch');
     const expectedMode = receipt.phase === 'stabilization-candidate' ? 'stabilization' : 'strict';
+    releaseMode = expectedMode;
     if (env.RUVNET_RELEASE_MODE !== expectedMode) failures.push(`release mode must be ${expectedMode} for this receipt`);
 
     const artifactPath = path.resolve(root, String(receipt.artifact?.path || '.missing-artifact'));
@@ -68,6 +70,7 @@ export function validateProtectedPublishInvocation({ root = process.cwd(), env =
     sha: expectedSha,
     artifactSha256: expectedDigest,
     version: expectedVersion,
+    mode: releaseMode,
     failures,
   };
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -37,6 +37,7 @@ const PUBLISH = process.argv.includes('--publish');
 let protectedCandidate = null;
 let sealedPackageArtifact = null;
 let publicationReceiptPath = null;
+let protectedReleaseMode = 'strict';
 const c = { g: (s) => `\x1b[32m${s}\x1b[0m`, r: (s) => `\x1b[31m${s}\x1b[0m`, y: (s) => `\x1b[33m${s}\x1b[0m`, b: (s) => `\x1b[1m${s}\x1b[0m`, dim: (s) => `\x1b[2m${s}\x1b[0m` };
 const V = () => JSON.parse(fs.readFileSync(path.join(ROOT, 'plugin/.claude-plugin/plugin.json'), 'utf8')).version;
 
@@ -93,6 +94,7 @@ if (PUBLISH) {
     console.error(`${c.r('  NOT shipped. Run the protected-release workflow with exact candidate evidence.')}\n`);
     process.exit(1);
   }
+  protectedReleaseMode = protectedInvocation.mode;
   protectedCandidate = JSON.parse(fs.readFileSync(path.resolve(ROOT, process.env.RUVNET_CANDIDATE_RECEIPT), 'utf8'));
   sealedPackageArtifact = path.resolve(ROOT, protectedCandidate.artifact.path);
   publicationReceiptPath = path.resolve(ROOT, process.env.RUVNET_PUBLICATION_RECEIPT || '.missing-publication-receipt');
@@ -130,15 +132,21 @@ runOrDie('one protected publisher', process.execPath, ['scripts/release-authorit
 // becomes a gate, on the ship path, where this repo's gates run 8/8 against prose's 0/6.
 runOrDie('wired (no orphan modules)', process.execPath, ['scripts/wired-check.mjs', '--check']);
 
-// THE NORTH-STAR VECTOR — a release may not average one broken/unknown invariant into a pass.
-// This is the real ship path, not an npm alias or a test import: every check-only preflight and
-// every publish attempt executes the eight D1-D8 detectors on the candidate SHA.
-runOrDie('release vector (all critical invariants PASS)', process.execPath, ['scripts/release-vector.mjs']);
+// THE NORTH-STAR PROMOTION VECTOR — strict/check-only releases may not average one broken or
+// unknown invariant into a pass. The separately authorized stabilization class makes no 95 claim;
+// it retains every safety, test, artifact, publication, and post-publication gate below while the
+// promotion program remains open. Derive this only from the already-validated sealed receipt, never
+// from a free-standing environment toggle.
+if (protectedReleaseMode === 'strict') {
+  runOrDie('release vector (all critical invariants PASS)', process.execPath, ['scripts/release-vector.mjs']);
 
-// The Top-100 corpus spans naive through expert prompts and grades semantic clauses, citations,
-// abstention, and latency. A manual-only benchmark is a report; a release-path benchmark is a
-// guarantee. The benchmark itself fails closed unless all 100 canonical questions run.
-runOrDie('Top-100 source-grounded recall contract', process.execPath, ['scripts/top100-benchmark.mjs', '--no-write']);
+  // The Top-100 corpus spans naive through expert prompts and grades semantic clauses, citations,
+  // abstention, and latency. A manual-only benchmark is a report; a strict release-path benchmark
+  // is a guarantee. The benchmark itself fails closed unless all 100 canonical questions run.
+  runOrDie('Top-100 source-grounded recall contract', process.execPath, ['scripts/top100-benchmark.mjs', '--no-write']);
+} else {
+  console.log(c.y('  strict >=95 promotion gates: NOT CLAIMED (sealed stabilization; scoreClaimed:false)'));
+}
 
 // A2. Stable Spine restart classifier (ADR-023, red-team finding 18): diff the boot-frozen SHELL
 // (hooks.json, hook-shim, MCP server, .mcp.json, skills/, commands/) against the previous release

--- a/tests/unit/protected-release-invocation.test.mjs
+++ b/tests/unit/protected-release-invocation.test.mjs
@@ -74,7 +74,7 @@ describe('protected publish invocation guard', () => {
   it('accepts only the protected workflow carrying a valid exact artifact seal', () => {
     const f = fixture();
     expect(validateProtectedPublishInvocation({ root: f.root, env: f.env })).toMatchObject({
-      verdict: 'PASS', sha: SHA, artifactSha256: f.digest, version: VERSION,
+      verdict: 'PASS', sha: SHA, artifactSha256: f.digest, version: VERSION, mode: 'strict',
     });
   });
 
@@ -85,7 +85,9 @@ describe('protected publish invocation guard', () => {
     });
     fs.writeFileSync(path.join(f.root, 'release-evidence/candidate-receipt.json'), JSON.stringify(f.receipt));
     f.env.RUVNET_RELEASE_MODE = 'stabilization';
-    expect(validateProtectedPublishInvocation({ root: f.root, env: f.env }).verdict).toBe('PASS');
+    expect(validateProtectedPublishInvocation({ root: f.root, env: f.env })).toMatchObject({
+      verdict: 'PASS', mode: 'stabilization',
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Outcome

Make the already-authorized stabilization receipt executable policy. Strict/check-only releases retain the D1-D8 release vector and Top-100 promotion gates; a validated stabilization receipt transparently makes no >=95 claim while retaining exact-main CI, security, full tests, sealed publication, and post-publication proof.

## Proof

- 74/74 focused release policy/vector tests pass
- protected invocation returns the validated release mode
- wrong mode/tampered receipt remain fail-closed
- version lockstep and wired-check pass
- protected run 30726444116 proved the prior contradiction before any public mutation
