### PR TITLE
fix(hooks): preserve newline-terminated router profiles

### DIFF
--- a/plugin/scripts/route-dispatch.sh
+++ b/plugin/scripts/route-dispatch.sh
@@ -62,6 +62,7 @@ PROFILE_INPUT=""
 while IFS= read -r _profile_line; do
   PROFILE_INPUT+="$_profile_line"
   [ ${#PROFILE_INPUT} -ge 65536 ] && break
+  true
 done < "$PROFILE" 2>/dev/null || exit 0
 [ -n "$_profile_line" ] && PROFILE_INPUT+="$_profile_line"
 case "$PROFILE_INPUT" in *'"basis"'*'"assumed:'*) exit 0 ;; esac

--- a/plugin/scripts/verify-interface.sh
+++ b/plugin/scripts/verify-interface.sh
@@ -31,6 +31,7 @@ PROFILE_INPUT=""
 while IFS= read -r _profile_line; do
   PROFILE_INPUT+="$_profile_line"
   [ ${#PROFILE_INPUT} -ge 65536 ] && break
+  true
 done < "$PROFILE" 2>/dev/null || exit 0
 [ -n "${_profile_line:-}" ] && PROFILE_INPUT+="$_profile_line"
 case "$PROFILE_INPUT" in *'"basis"'*'"assumed:'*) exit 0 ;; esac

--- a/tests/unit/route-dispatch.test.mjs
+++ b/tests/unit/route-dispatch.test.mjs
@@ -79,8 +79,17 @@ describe.skipIf(!hasBash || process.platform === 'win32')('route-dispatch.sh —
     expect(r.stderr).toBe('');
   });
 
-  it('BLOCKS a dispatch with no model — the leak becomes a hard error, not a habit', () => {
-    const r = dispatch({ description: 'sweep tests', subagent_type: 'general-purpose' });
+  it.each([
+    ['newline-terminated profile', '{"harnesses":{}}\n'],
+    ['profile without a final newline', '{"harnesses":{}}'],
+  ])('BLOCKS a dispatch with no model for a %s', (_label, profileContent) => {
+    const r = dispatch(
+      { description: 'sweep tests', subagent_type: 'general-purpose' },
+      'Task',
+      {},
+      true,
+      profileContent,
+    );
     expect(r.status).toBe(2); // exit 2 = block, and stderr is fed back to the model as the reason
     expect(r.stderr).toMatch(/SUBAGENT DISPATCH BLOCKED/);
     expect(r.stderr).toMatch(/INHERITS this session's model/);

--- a/tests/unit/verify-interface.test.mjs
+++ b/tests/unit/verify-interface.test.mjs
@@ -41,8 +41,11 @@ describe.skipIf(!hasBash || process.platform === 'win32')(
       expect(result.stderr).not.toMatch(/BLOCKED/);
     });
 
-    it('emits migration guidance for an obvious managed-CLI string', () => {
-      const result = run('ruflo memory search -q test');
+    it.each([
+      ['newline-terminated profile', '{}\n'],
+      ['profile without a final newline', '{}'],
+    ])('emits migration guidance with a %s', (_label, profileContent) => {
+      const result = run('ruflo memory search -q test', { profileContent });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('ruvnet_cli_help');
       expect(result.stdout).toContain('ruvnet_cli_run');


### PR DESCRIPTION
## Outcome

Fixes the production-shaped silent no-op behind #80. The shim already forwarded the original PreToolUse envelope; the actual failure was that newline-terminated profile reads left the `while` loop with status 1, activating `|| exit 0` before either blocking hook evaluated the payload.

## Changes

- keep successful profile reads successful in `route-dispatch.sh` and `verify-interface.sh`
- exercise both newline-terminated and no-final-newline profiles
- preserve the existing fail-open behavior for genuine profile read failures

## Verification

- focused route/verify tests: 30/30
- relevant hook suite: 195 passed, 4 deliberate expected failures
- core plugin suite: 60/60
- real shim probe: both newline variants return blocking status 2
- `git diff --check`: clean

#84 remains independent: this change makes the hook compute and emit the correct decision, but does not claim that Claude Code waits for the PreToolUse result before dispatch.

Fixes #80