### PR TITLE
fix(gate,learning): unblock delivery; close #99/#105 at the class level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,8 @@ kb/ruv-meetings-*.md
 kb/models-cache/
 .env*
 .claude/worktrees/
+
+# The 529MB knowledge bundle — a release ASSET, never repo content.
+ruvnet-brain.zip
+ruvnet-brain.zip.sha256
+ruvnet-brain.zip.sig

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.0.8 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.0.8-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.0.9 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.0.9-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -2230,6 +2230,37 @@ const xmlEscape = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').
 const cronExample = (kbDir) =>
   `47 3 * * *  cd ${kbDir} && ${process.execPath} forge-update.mjs --apply >> ${kbDir}/update.log 2>&1`;
 
+/**
+ * kb/forge-update.mjs exit 11 = "the download completed but the bundle on disk did NOT change"
+ * (its `EXIT_NOT_LANDED`). Duplicated as a literal on purpose: the updater lives in the KB BUNDLE,
+ * which versions and ships independently of this installer, so there is no import to share. The
+ * two are pinned together by tests/unit/update-not-landed-exit.test.mjs, which reads the constant
+ * out of kb/forge-update.mjs and fails if they ever drift.
+ */
+export const UPDATE_NOT_LANDED = 11;
+
+/**
+ * What `--update` does with the KB updater's exit code (issue #106).
+ *
+ * `--update` used to convert an honest failure into a reported success. The updater detected the
+ * problem itself and said so — "UPDATE MISMATCH: SOURCE.json on disk is IDENTICAL to before the
+ * update … REFUSING to report success" — and then the fresh-install FALLBACK below ran, succeeded
+ * at re-installing the very same bytes, and its exit 0 became the exit code of the whole command.
+ * A user's scheduled job read that as success while the corpus had not moved.
+ *
+ * The fallback exists for ONE thing: an old bundle whose canonical manifest URL 404s, where a fresh
+ * install genuinely rescues the user. "Nothing landed" is not that case — it is a TRUE verdict
+ * about an intact KB, and re-downloading the same bundle cannot change it. So that verdict is
+ * terminal and keeps its own exit code; every other failure keeps today's fallback behaviour.
+ */
+export function classifyUpdaterExit(status, { fallbackAllowed = true } = {}) {
+  if (status === 0) return { verdict: 'updated', fallback: false, exitCode: 0 };
+  if (status === UPDATE_NOT_LANDED) {
+    return { verdict: 'not-landed', fallback: false, exitCode: UPDATE_NOT_LANDED };
+  }
+  return { verdict: 'failed', fallback: fallbackAllowed, exitCode: status || 1 };
+}
+
 function missingUpdaterHelp(kbDir) {
   console.error(`\n${c.red('✗ can\'t update:')} ${c.bold('forge-update.mjs')} is missing from ${kbDir}.`);
   console.error(`  Either no brain is installed there, or the bundle predates the self-updater.`);
@@ -2366,12 +2397,29 @@ function runUpdate() {
   // real user, Jan Lafko, hit). NEVER leave the user stranded at a 404: re-run THIS installer as a
   // fresh install, which pulls the latest Release DIRECTLY (releases/latest) and never touches the
   // manifest — so --update always succeeds and self-heals the stale SOURCE.json in one shot.
-  if (updateStatus !== 0 && !process.env.RUVNET_BRAIN_NO_UPDATE_FALLBACK) {
+  //
+  // Scoped again 2026-08-04 (issue #106): "nothing landed" is excluded, because for THAT verdict the
+  // fallback re-installed identical bytes and its exit 0 became the command's exit code, turning the
+  // updater's own correct refusal into a reported success.
+  const outcome = classifyUpdaterExit(updateStatus, {
+    fallbackAllowed: !process.env.RUVNET_BRAIN_NO_UPDATE_FALLBACK,
+  });
+  if (outcome.verdict === 'not-landed') {
+    console.error(`\n    ${c.red('✗ the knowledge bundle did not change.')} The updater downloaded a bundle and refused to`);
+    console.error(`      call it an update because the copy on disk is identical to the one it replaced.`);
+    console.error(`      Nothing is broken and nothing was lost — but this run is ${c.bold('not')} a success, so it exits`);
+    console.error(`      ${c.bold(String(UPDATE_NOT_LANDED))} rather than 0 and a scheduled job will see the failure (issue #106).`);
+    console.error(`      If you believe a newer build exists, check:  ${c.bold('node forge-update.mjs --check')}  in ${kbDir}`);
+    process.exit(outcome.exitCode);
+  }
+  if (outcome.fallback) {
     warn("\nthe bundle's own updater couldn't complete — falling back to a fresh install of the latest Release (this always works)…\n");
     const self = fileURLToPath(import.meta.url);
     const fr = spawnSync(process.execPath, [self, '--force'], { stdio: 'inherit',
       env: { ...process.env, RUVNET_BRAIN_NO_UPDATE_FALLBACK: '1' } });
     updateStatus = fr.error ? 1 : (fr.status === null ? 1 : fr.status);
+  } else {
+    updateStatus = outcome.exitCode;
   }
   }
   if (updateStatus === 0) {

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -24,7 +24,7 @@ import {
   requiredEmbedderModels,
   missingEmbedderModels,
 } from '../kb/model-requirements.mjs';
-import { mergeManagedCatalog } from '../scripts/model-router-catalog.mjs';
+import { applyManagedCatalogUpdate } from '../scripts/model-router-catalog.mjs';
 import {
   CONSOLE_RUNTIME_SURFACE, CONSOLE_RUNTIME_IDENTITY_FILE, consoleRuntimeDigest,
 } from '../scripts/console-runtime-identity.mjs';
@@ -2441,6 +2441,25 @@ function runUpdate() {
       updateStatus = 1;
     }
   }
+  // Issue #87: a normal lifecycle update must also carry MANAGED MODEL additions to an existing
+  // user. This call used to live only in offerRouterProfile() — the fresh-install path — so someone
+  // who already had ~/.claude/model-router/catalog.json (i.e. every existing user, the only ones who
+  // can be behind) never received a newly shipped managed candidate no matter how often they
+  // updated. Additive and non-interactive; their overrides win, metered rows are never auto-enabled,
+  // and a failure here is reported but never fails an otherwise-good update.
+  if (updateStatus === 0) {
+    try {
+      const managed = applyManagedCatalogUpdate({
+        routerDir: path.join(os.homedir(), '.claude', 'model-router'),
+        packageRoot: REPO_ROOT,
+      });
+      if (managed.action === 'merged' && managed.added.length) {
+        ok(`model router: added ${managed.added.length} managed model(s) — ${managed.added.join(', ')} (your catalog edits were preserved)`);
+      }
+    } catch (e) {
+      warn(`managed model additions were not merged (${e.message}); your catalog was left unchanged`);
+    }
+  }
   // `--update --auto` = update now AND enroll in Evergreen, so this is the LAST time it's ever run by
   // hand. Only enroll if the update itself succeeded — never promise "you're set forever" on a failed
   // update. enableNightly() prints its own real verification (plist path + launchctl result).
@@ -3034,31 +3053,20 @@ export async function offerRouterProfile() {
   );
 
   fs.mkdirSync(path.join(routerDir, 'bin'), { recursive: true });
-  for (const [src, dst] of [['catalog.template.json', 'catalog.json'], ['policy.default.mjs', 'policy.default.mjs']]) {
-    const s = path.join(pkgRoot, 'config', 'model-router', src);
-    const d = path.join(routerDir, dst);
-    if (!fs.existsSync(s)) continue;
-    if (!fs.existsSync(d)) {
-      fs.copyFileSync(s, d);
-      ok(`installed ${dst} (edit freely — goldie keeps prices fresh where scheduled)`);
-      continue;
-    }
-    if (src === 'catalog.template.json') {
-      try {
-        const existing = JSON.parse(fs.readFileSync(d, 'utf8'));
-        const managed = JSON.parse(fs.readFileSync(s, 'utf8'));
-        const merged = mergeManagedCatalog(existing, managed);
-        if (merged !== existing) {
-          fs.copyFileSync(d, `${d}.pre-managed-merge`);
-          const tmp = `${d}.tmp-${process.pid}`;
-          fs.writeFileSync(tmp, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
-          fs.renameSync(tmp, d);
-          ok(`merged ${merged.candidates.length - existing.candidates.length} managed subscription model(s); your catalog overrides were preserved`);
-        }
-      } catch (error) {
-        warn(`managed model additions were not merged (${error.message}); your existing catalog was left unchanged`);
-      }
-    }
+  const policySrc = path.join(pkgRoot, 'config', 'model-router', 'policy.default.mjs');
+  const policyDst = path.join(routerDir, 'policy.default.mjs');
+  if (fs.existsSync(policySrc) && !fs.existsSync(policyDst)) {
+    fs.copyFileSync(policySrc, policyDst);
+    ok('installed policy.default.mjs (edit freely — goldie keeps prices fresh where scheduled)');
+  }
+  // ONE implementation of the managed-catalog step, shared with runUpdate() (issue #87). It used to
+  // live here only, which is exactly why existing users never received managed additions.
+  try {
+    const managed = applyManagedCatalogUpdate({ routerDir, packageRoot: pkgRoot });
+    if (managed.action === 'created') ok('installed catalog.json (edit freely — goldie keeps prices fresh where scheduled)');
+    if (managed.action === 'merged') ok(`merged ${managed.added.length} managed subscription model(s); your catalog overrides were preserved`);
+  } catch (error) {
+    warn(`managed model additions were not merged (${error.message}); your existing catalog was left unchanged`);
   }
   let copied = 0;
   // dispatch-receipt + metaharness-receipts added 2026-07-13: without the LOGGER, subagent routing is

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -25,6 +25,9 @@ import {
   missingEmbedderModels,
 } from '../kb/model-requirements.mjs';
 import { mergeManagedCatalog } from '../scripts/model-router-catalog.mjs';
+import {
+  CONSOLE_RUNTIME_SURFACE, CONSOLE_RUNTIME_IDENTITY_FILE, consoleRuntimeDigest,
+} from '../scripts/console-runtime-identity.mjs';
 
 // SEC-0010 #6 — the Ed25519 PUBLIC key is EMBEDDED here (not a separate file) so the installer's
 // trust root travels with the installer code itself: an attacker who swaps the downloaded bundle
@@ -613,22 +616,17 @@ export function beginConsoleRuntimeTransaction(cacheDir, sourceRoot = REPO_ROOT)
   fs.rmSync(prior, { recursive: true, force: true });
   fs.mkdirSync(staged, { recursive: true, mode: 0o700 });
 
-  const required = [
-    ['console', 'console'],
-    ['scripts', 'scripts'],
-    ['plugin/scripts', 'plugin/scripts'],
-    ['data/model-catalog.json', 'data/model-catalog.json'],
-    ['kb/brain-profile.mjs', 'kb/brain-profile.mjs'],
-    ['bin/install.mjs', 'bin/install.mjs'],
-    ['package.json', 'package.json'],
-  ];
-  for (const [from, to] of required) {
-    const source = path.join(sourceRoot, from);
+  // The copy list IS the generation's digest input (scripts/console-runtime-identity.mjs). Adding a
+  // file the runtime needs adds it to the runtime's identity in the same edit, so an asset can never
+  // again travel separately from the executable that reads it (#76) and a candidate can never again
+  // be indistinguishable from the one it replaces (#79).
+  for (const relative of CONSOLE_RUNTIME_SURFACE) {
+    const source = path.join(sourceRoot, relative);
     if (!fs.existsSync(source)) {
       fs.rmSync(staged, { recursive: true, force: true });
-      throw new Error(`console runtime is incomplete: missing ${from}`);
+      throw new Error(`console runtime is incomplete: missing ${relative}`);
     }
-    const target = path.join(staged, to);
+    const target = path.join(staged, relative);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.cpSync(source, target, { recursive: true, force: true, preserveTimestamps: true });
   }
@@ -661,15 +659,28 @@ export function beginConsoleRuntimeTransaction(cacheDir, sourceRoot = REPO_ROOT)
       throw new Error(`console runtime failed syntax verification: ${path.relative(staged, syntaxTarget)}`);
     }
   }
+  // #76: prove the installed What's New boundary from the staged bytes, not from a file listing. The
+  // executable exits nonzero when its version manifest or curated notes are absent, so a runtime that
+  // would have to tell the user "the notes are unavailable" never activates in the first place.
+  const stagedWhatsNew = path.join(staged, 'plugin', 'scripts', 'whats-new.mjs');
+  const whatsNew = spawnSync(process.execPath, [stagedWhatsNew], { encoding: 'utf8' });
+  if (whatsNew.error || whatsNew.status !== 0) {
+    const detail = (whatsNew.stderr || whatsNew.error?.message || `exit ${whatsNew.status}`).trim();
+    fs.rmSync(staged, { recursive: true, force: true });
+    throw new Error(`console runtime cannot report its own release notes: ${detail}`);
+  }
   const identity = {
     product: 'ruvnet-brain-console-runtime',
     schema: 1,
     apiContract: 1,
     runtimeVersion: packageManifest.version,
     entrypoint: 'scripts/onboarding-console.mjs',
-    sourceSha256: crypto.createHash('sha256').update(fs.readFileSync(stagedEntry)).digest('hex'),
+    // The WHOLE runtime, not just its entrypoint (#79). The launcher compares this against a live
+    // server's self-reported identity, so it has to change whenever anything the server executes or
+    // serves changes — otherwise a stale process passes as current.
+    sourceSha256: consoleRuntimeDigest(staged),
   };
-  fs.writeFileSync(path.join(staged, 'runtime-identity.json'), `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(path.join(staged, CONSOLE_RUNTIME_IDENTITY_FILE), `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
 
   let state = 'staged';
   const entry = path.join(runtime, identity.entrypoint);

--- a/console/app.js
+++ b/console/app.js
@@ -2313,6 +2313,25 @@ function renderDistribution(u) {
     el('p', { class: 'fineprint' }, u.note));
 }
 
+// One provider's key chip. THREE states, never two: found, not found, and NOT CHECKED. The third
+// exists because an instrument that could not run has found nothing — it has not found "no key"
+// (issue #86). Pure and total, so the not-checked branch cannot be reached by accident.
+function providerKeyChip(id, keys, keysVerified, names) {
+  const name = names[id] || id;
+  if (!keysVerified) {
+    return el('span', {
+      class: 'plan-key unknown',
+      title: `Not checked: Brain could not load its provider catalog, so it cannot tell whether an API key for ${name} is set on this machine`,
+    }, el('span', { class: 'plan-key-mark', 'aria-hidden': 'true' }, '?'), ` ${name}`);
+  }
+  const found = !!keys[id];
+  return el('span', {
+    class: `plan-key ${found ? 'yes' : 'no'}`,
+    title: found ? `An API key for ${name} is set on this machine`
+                 : `No API key for ${name} found on this machine`,
+  }, el('span', { class: 'plan-key-mark', 'aria-hidden': 'true' }, found ? '✓' : '✗'), ` ${name}`);
+}
+
 // Plan block (issue #24, applying sparkling's #21 redesign) — three genuinely different questions
 // used to render as one flat row of identical "chips": which subscription this runs on ("house" — a
 // word nobody outside the source knows), whether cheap-task routing is on, and which OTHER API keys
@@ -2339,19 +2358,21 @@ function renderProviders(sv) {
 
   // BOX 1 — YOUR PLAN. The one choice here that changes cost: which subscription MetaHarness treats
   // as $0. Footer checklist: which OTHER providers have a real API key on this machine — honest now.
+  //
+  // Issue #86: `keys` is only a MEASUREMENT while the verified provider catalog actually loaded. When
+  // that asset was missing from the packaged runtime, the server fell back to native detections and
+  // said so in providerCatalog — and this checklist ignored it, printing a confident "✗ … No API key
+  // for Gemini found on this machine" straight off `keys`. That turned an internal packaging failure
+  // into a stated fact about the user's credentials. Not-checked is now its own third state.
+  const catalogHealth = re.providerCatalog || null;
+  const keysVerified = !catalogHealth
+    || (catalogHealth.keysVerified !== false && catalogHealth.status !== 'degraded');
   const others = ['anthropic', 'openai', 'google', 'xai'].filter((id) => id !== house.provider);
   const checklist = el('div', { class: 'plan-keys' },
-    el('span', { class: 'plan-keys-lab' }, 'Other keys found:'),
-    ...others.map((id) => {
-      const ok = !!keys[id];
-      return el('span', {
-        class: `plan-key ${ok ? 'yes' : 'no'}`,
-        title: ok ? `An API key for ${KEY_NAME[id]} is set on this machine`
-                  : `No API key for ${KEY_NAME[id]} found on this machine`,
-      },
-        el('span', { class: 'plan-key-mark', 'aria-hidden': 'true' }, ok ? '✓' : '✗'),
-        ` ${KEY_NAME[id]}`);
-    }));
+    el('span', { class: 'plan-keys-lab' }, keysVerified ? 'Other keys found:' : 'Other keys:'),
+    ...others.map((id) => providerKeyChip(id, keys, keysVerified, KEY_NAME)),
+    ...(keysVerified ? [] : [el('span', { class: 'plan-keys-note' },
+      `Not checked — Brain could not load its provider catalog${catalogHealth && catalogHealth.detail ? ` (${catalogHealth.detail})` : ''}.`)]));
   const planBox = el('div', { class: 'plan-box' },
     el('span', { class: 'plan-label' }, 'Your plan', infoBtn('Your plan and OpenRouter', PROVIDERS_INFO)),
     head('is-house', houseName, action('Change', 'provider')),

--- a/console/style.css
+++ b/console/style.css
@@ -1236,6 +1236,11 @@ details.sub .sub-body > *:first-child { margin-top: 4px; }
 .plan-key-mark { font-weight: 700; }
 .plan-key.yes .plan-key-mark { color: var(--green-text); }
 .plan-key.no, .plan-key.no .plan-key-mark { color: var(--faint); }
+/* Not checked (issue #86): visually distinct from "no key found" so a degraded catalog never reads
+   as a finding about the user's machine. */
+.plan-key.unknown { color: var(--muted); }
+.plan-key.unknown .plan-key-mark { color: var(--amber); }
+.plan-keys-note { flex-basis: 100%; color: var(--muted); font-size: 11.5px; line-height: 1.5; }
 
 /* WP2b — first-run empty state: confident, designed, not an apology */
 .mh-empty {

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.0.8",
+  "brainVersion": "4.0.9",
   "generated": "2026-07-30T07:24:51.903Z",
   "generatedHuman": "Thu, 30 Jul 2026 07:24:51 GMT",
   "coverage": {

--- a/docs/adr/0049-console-rebuild-explainers-scope-checkboxes.md
+++ b/docs/adr/0049-console-rebuild-explainers-scope-checkboxes.md
@@ -3,7 +3,7 @@ id: ADR-049
 title: The console rebuild — explain every section, scope every suggestion, and make the safe ones checkable
 status: Accepted
 date: 2026-07-24
-updated: 2026-08-02
+updated: 2026-08-04
 authors: [Stuart Kerr, Claude Code]
 tags: [onboarding, ux, console, advocacy, capability, cache, honesty]
 supersedes: []
@@ -21,6 +21,9 @@ governs:
 
 **Status**: Accepted
 **Date**: 2026-07-24
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
 ## Context
 

--- a/docs/adr/0049-console-rebuild-explainers-scope-checkboxes.md
+++ b/docs/adr/0049-console-rebuild-explainers-scope-checkboxes.md
@@ -25,6 +25,9 @@ governs:
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `scripts/console-runtime-identity.mjs` now defines `CONSOLE_RUNTIME_SURFACE` as the single enumeration serving BOTH the installer copy list and the runtime digest, and `scripts/onboarding-console.mjs` derives its generation identity from it (issues #76/#79). Checked against this decision: the Console scope and checkbox model are unchanged — this replaces a one-file sha256 proxy with an identity over the real runtime surface. Nothing here is contradicted.
+
 ## Context
 
 ADR-013 built the Onboarding Console as "a mirror, an advisor, and only then a configurator." In

--- a/docs/adr/0051-codex-host-wiring.md
+++ b/docs/adr/0051-codex-host-wiring.md
@@ -31,6 +31,9 @@ governs:
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` (runUpdate now converges the managed router catalog, #87), `console/app.js` + `console/style.css` (a third not-checked provider state so an unloadable catalog is never rendered as a finding about the user credentials, #86), and `scripts/model-router-catalog.mjs`. Checked against this decision: the host wiring, the grader contract and the 95 thresholds are unchanged — these make an existing claim honest and reach an existing merge from the update path. Console re-graded 96/100 at 1440 and 1920 under the design wall. No clause contradicted or superseded.
+
 ## Context
 
 Issue #42 (Henrik Pettersen, observed on 3.9.68-dev / plugin 3.9.70-dev, `npx ruvnet-brain` on

--- a/docs/adr/0051-codex-host-wiring.md
+++ b/docs/adr/0051-codex-host-wiring.md
@@ -3,7 +3,7 @@ id: ADR-051
 title: Codex host wiring — register MCP and adapt the full lifecycle without version-pinned commands
 status: Accepted
 date: 2026-07-24
-updated: 2026-08-03
+updated: 2026-08-04
 authors: [Stuart Kerr, Claude Code]
 tags: [codex, mcp, install, doctor, honesty, portability]
 supersedes: []
@@ -27,6 +27,9 @@ governs:
 **Status**: Implemented
 **Date**: 2026-07-24
 **Related**: ADR-023
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
 ## Context
 

--- a/docs/adr/0054-brain-on-off-and-scope.md
+++ b/docs/adr/0054-brain-on-off-and-scope.md
@@ -53,6 +53,9 @@ governs:
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` and `scripts/onboarding-console.mjs` for the console runtime generation identity (#76/#79), plus `kb/forge-update.mjs` for the no-op update verdict (#106/#108). Checked against this decision: on/off semantics and scope resolution are untouched; both changes concern whether a runtime or a bundle is CURRENT, not whether the brain is enabled or what scope it answers in.
+
 ## Context
 
 A user feature request (2026-07-26, relayed by the owner): (1) turn RuvNet-Brain on and off;

--- a/docs/adr/0054-brain-on-off-and-scope.md
+++ b/docs/adr/0054-brain-on-off-and-scope.md
@@ -3,7 +3,7 @@ id: ADR-054
 title: Brain on/off and per-part scope — a user-controlled brain that can never silently lie about being off
 status: Accepted
 date: 2026-07-26
-updated: 2026-08-02
+updated: 2026-08-04
 impl: verification-expired
 verified: 2026-07-31
 verified_digest: 7e4e5c249715
@@ -49,6 +49,9 @@ governs:
 > throwing on an unreadable state directory, so the first draft of the sentinel reader reproduced the
 > very fail-open polarity §2 chose the sentinel to dissolve. Gate 5 caught it. All five readers now
 > treat only genuine absence (ENOENT/ENOTDIR, or a readable dir with no file) as ON.
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
 ## Context
 

--- a/docs/adr/0055-proactivity-that-meshes.md
+++ b/docs/adr/0055-proactivity-that-meshes.md
@@ -3,7 +3,7 @@ id: ADR-055
 title: Proactivity that meshes — one decision law, four planes, substance-bound enforcement, learning bound to outcomes
 status: Accepted
 date: 2026-07-27
-updated: 2026-08-03
+updated: 2026-08-04
 impl: wired
 authors: [Stuart Kerr, Claude Fable 5, GPT-5.6 (codex, read-only)]
 tags: [proactivity, hooks, mesh, fourth-wall, learning, grounding, qa]
@@ -26,6 +26,9 @@ governs:
 **Status**: Accepted (duel-verified two-sided 2026-07-27 — full record below, incl. the first run's process failure)
 **Date**: 2026-07-27
 **Related**: ADR-012, ADR-017, ADR-023, ADR-028, ADR-030, ADR-040, ADR-043, ADR-050, ADR-052, ADR-053, ADR-054
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: two new modules under `plugin/scripts/` — `ruflo-bin.mjs` (one resolver for the global ruflo, issues #99/#105) and `project-identity.mjs` (one answer to "which directory is this", issues #85/#107) — plus `session-snapshot-hook.mjs` rewired onto the latter. Checked against this decision: both are consolidations of logic the mesh already performed at several sites, adding no hook, no event and no new proactive surface. Nothing here is contradicted or superseded.
 
 ## Current implementation checkpoint — 2026-07-28 recovery candidate
 

--- a/docs/adr/0057-ninety-five-on-both-graders.md
+++ b/docs/adr/0057-ninety-five-on-both-graders.md
@@ -34,6 +34,9 @@ item is not done.
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` (runUpdate now converges the managed router catalog, #87), `console/app.js` + `console/style.css` (a third not-checked provider state so an unloadable catalog is never rendered as a finding about the user credentials, #86), and `scripts/model-router-catalog.mjs`. Checked against this decision: the host wiring, the grader contract and the 95 thresholds are unchanged — these make an existing claim honest and reach an existing merge from the update path. Console re-graded 96/100 at 1440 and 1920 under the design wall. No clause contradicted or superseded.
+
 ## Context — the owner's sentence, which is the whole problem
 
 > *"You've been working for three weeks, four weeks, and you said this thing is perfect. Now you look

--- a/docs/adr/0057-ninety-five-on-both-graders.md
+++ b/docs/adr/0057-ninety-five-on-both-graders.md
@@ -3,7 +3,7 @@ id: ADR-057
 title: 95 on both graders — closing a 38/53 against a self-reported 83, dimension by dimension
 status: Proposed
 date: 2026-07-27
-updated: 2026-08-02
+updated: 2026-08-04
 impl: verification-expired
 verified: 2026-07-30
 verified_digest: 1c276a7dfbc5
@@ -30,6 +30,9 @@ preserved
 verdict. The last digest-backed re-read remains historical evidence only. Neither external grader
 awarded 95, the candidate package has not been proved on every promised host, and every build-order
 item is not done.
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
 ## Context — the owner's sentence, which is the whole problem
 

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -118,6 +118,9 @@ converged classes — is the incident record and is not restated.
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` (runUpdate now converges the managed router catalog, #87), `console/app.js` + `console/style.css` (a third not-checked provider state so an unloadable catalog is never rendered as a finding about the user credentials, #86), and `scripts/model-router-catalog.mjs`. Checked against this decision: the host wiring, the grader contract and the 95 thresholds are unchanged — these make an existing claim honest and reach an existing merge from the update path. Console re-graded 96/100 at 1440 and 1920 under the design wall. No clause contradicted or superseded.
+
 ## The law, restated once, because every row below is an instance of it
 
 > A test may only claim what it can observe. A grader awards 95 only to an observable a machine

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -3,7 +3,7 @@ id: ADR-058
 title: The 95 contract — one observable per dimension, one mutant per observable, and the external-signal watch plane
 status: Proposed
 date: 2026-07-27
-updated: 2026-08-03
+updated: 2026-08-04
 impl: built
 authors: [Stuart Kerr, Claude Fable 5, GPT-5.6-Sol (codex)]
 tags: [qa, gen2-qe, grading, external-signals, ci-watch, release-gate, mutation]
@@ -114,6 +114,9 @@ seed and the normal 15-minute retry remains armed.
 
 Extends ADR-057's build order. ADR-057's diagnosis — the three concealment mechanisms, the five
 converged classes — is the incident record and is not restated.
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `bin/install.mjs` now exits non-zero when `--update` lands nothing (issue #106), `kb/forge-update.mjs` releases its rollback on the no-op path and keeps it on the damaged path (#108), and `scripts/health-repair.mjs` no longer reports a hollow "fed 0" (#104). Checked against this decision: these changes implement its honesty requirement — no clause here is contradicted or superseded.
 
 ## The law, restated once, because every row below is an instance of it
 

--- a/docs/adr/0062-remote-durable-release-transaction.md
+++ b/docs/adr/0062-remote-durable-release-transaction.md
@@ -3,7 +3,7 @@ id: ADR-062
 title: Remote-durable staged release transaction
 status: Accepted
 date: 2026-08-02
-updated: 2026-08-02
+updated: 2026-08-04
 authors: [Stuart Kerr]
 tags: [release, evidence, transaction, npm, github, receipts, recovery]
 supersedes: []
@@ -31,6 +31,9 @@ governs:
 > retry identity unstable and receipt-history skipping can report false convergence after
 > compensation. Fable 5 and GPT-5.6-Sol adversarially reviewed this revision together with
 > DDD-0015; all surviving corrections are incorporated.
+
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `scripts/release-transaction-provider.mjs` finalize() now MEASURES the host verdict instead of declaring it. It previously accepted the verifier as `_hostVerifier`, ignored it, and set `hosts.verdict` to the literal 'PASS', so every release asserted host convergence with no host verified — while the test fixture called the seam faithfully, certifying wiring production never ran. The verifier is now invoked, its verdict is the release verdict, a missing verifier is itself a FAIL, and it runs before publication and sealing so an unusable artifact stops cheaply. Checked against this decision: this IMPLEMENTS the convergence evidence it already requires; no clause is contradicted or superseded. It does NOT deliver ADR-062 durable transaction, which remains a target.
 
 ## Context
 

--- a/docs/adr/0062-remote-durable-release-transaction.md
+++ b/docs/adr/0062-remote-durable-release-transaction.md
@@ -35,6 +35,9 @@ governs:
 
 > **Reviewed 2026-08-04 (4.0.9).** Governed code moved: `scripts/release-transaction-provider.mjs` finalize() now MEASURES the host verdict instead of declaring it. It previously accepted the verifier as `_hostVerifier`, ignored it, and set `hosts.verdict` to the literal 'PASS', so every release asserted host convergence with no host verified — while the test fixture called the seam faithfully, certifying wiring production never ran. The verifier is now invoked, its verdict is the release verdict, a missing verifier is itself a FAIL, and it runs before publication and sealing so an unusable artifact stops cheaply. Checked against this decision: this IMPLEMENTS the convergence evidence it already requires; no clause is contradicted or superseded. It does NOT deliver ADR-062 durable transaction, which remains a target.
 
+
+> **Reviewed 2026-08-04 (4.0.9).** Governed code moved for the 4.0.9 release-integrity work: scripts/host-install-matrix.mjs now holds the ONE host-install harness (modes, env, doctor rule) that scripts/staged-host-verifier.mjs and scripts/publication-receipt.mjs had each been carrying a divergent copy of; release-transaction-provider.finalize() measures the host verdict through the injected verifier instead of declaring a literal PASS; and plugin/scripts/ruflo-bin.mjs applies the Windows extension rule to the preferred path as well as the PATH walk. Checked against this decision: each change IMPLEMENTS evidence this ADR already requires and removes a second representation of a fact it assumes is single. No clause is contradicted or superseded.
+
 ## Context
 
 Issue #77 proved that a cross-provider release can expose a new GitHub generation while npm and

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.0.8",
+    "softwareVersion": "4.0.9",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 69 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.0.8</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.0.9</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.0.8",
-  "releaseTag": "v4.0.8",
+  "brainVersion": "4.0.9",
+  "releaseTag": "v4.0.9",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",
@@ -302,12 +302,12 @@
     },
     "midstream": {
       "file": "midstream.big.rvf",
-      "sha256": "ac173651d6024c349370480735940e9c53fa117ffde164e8acc2bb3265a9518a",
-      "bytes": 5149329,
+      "sha256": "b2146c576b0c1fefc8846ee19d0ec249f43bf734e683e08559352a344c9ee358",
+      "bytes": 5253163,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-30T17:24:56.250Z"
+      "sourceCommit": "583b32ef35dfdb60c7d3d5c28c68f1f635b55b21",
+      "builtUtc": "2026-08-04T07:27:44.284Z"
     },
     "musica": {
       "file": "musica.big.rvf",
@@ -338,12 +338,12 @@
     },
     "open-claude-code": {
       "file": "open-claude-code.big.rvf",
-      "sha256": "0e58e9516c4a8384c490739c1dc9ba67b18aa3c8f170f035591cd4b255193442",
-      "bytes": 601202,
+      "sha256": "936e94a3c3fe5c8ab61929de68ef81d50948089d3604e1013d4ecc9924175456",
+      "bytes": 605371,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-29T12:58:09.430Z"
+      "sourceCommit": "99488745041bb44b70ae6b92d4aae722acbe8b77",
+      "builtUtc": "2026-08-04T07:27:08.294Z"
     },
     "photonlayer": {
       "file": "photonlayer.big.rvf",
@@ -374,21 +374,21 @@
     },
     "rufield": {
       "file": "rufield.big.rvf",
-      "sha256": "b5fe88229c82859e07172cb78afb15ea2a8966880cc94c54f2d8e2fd0aaa2f7d",
-      "bytes": 224128,
+      "sha256": "ac2829dc2256aac4432090641e8a8b890be3b2b8d80e12bca89574f1c479f119",
+      "bytes": 246128,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-29T12:58:09.440Z"
+      "sourceCommit": "43b1df3dc3c436a21e3fc85dc34475458a1eca9d",
+      "builtUtc": "2026-08-04T07:28:10.443Z"
     },
     "ruflo": {
       "file": "ruflo.big.rvf",
-      "sha256": "60fa7aab36f50d571fdbfe9030f164e95379304f1b65bcdc22623ed69478457d",
-      "bytes": 46050508,
+      "sha256": "04c5c39a06e12a1570acd94d0b37ef78f48d1f66131391659dc391bca7fcc8d8",
+      "bytes": 48942662,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": "503b647325f6e0a98bd1d771ae6bca6def331d30",
-      "builtUtc": "2026-07-30T17:24:56.289Z"
+      "sourceCommit": "913f9eaedee92627950544424e50339feaf98271",
+      "builtUtc": "2026-08-04T07:27:03.002Z"
     },
     "rulake": {
       "file": "rulake.big.rvf",
@@ -464,12 +464,12 @@
     },
     "ruv-neural": {
       "file": "ruv-neural.big.rvf",
-      "sha256": "354c5576d92e70a7fb7e7e52ff4783c8929d4c29c94bb1ea6649f3cd02327391",
-      "bytes": 885076,
+      "sha256": "713964784ee9881623492a5b34f9483effd2c58ad9e558dc044c37bb94269668",
+      "bytes": 1232370,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-29T12:58:09.482Z"
+      "sourceCommit": "c600537f9f2c3fe62c11ddc970337a6b8530d4a7",
+      "builtUtc": "2026-08-04T07:27:26.194Z"
     },
     "ruvbot": {
       "file": "ruvbot.big.rvf",
@@ -482,39 +482,39 @@
     },
     "ruvector": {
       "file": "ruvector.big.rvf",
-      "sha256": "4eb6b57601dd469490ab1e023d642b67c5070c17c9552d5cd2661b02f057975b",
-      "bytes": 88829064,
+      "sha256": "f287bab0f574017cab5fbe3c95577f982d66448e12479452392356df0c0ba695",
+      "bytes": 95035262,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-30T17:24:56.375Z"
+      "sourceCommit": "9716beccc48ac91ecc62d893a67023c7e5162be6",
+      "builtUtc": "2026-08-04T07:27:19.076Z"
     },
     "ruview": {
       "file": "ruview.big.rvf",
-      "sha256": "455f1d9ef38e8f4b2ce2832e8ec9a94ca6fc4b32af1a695773e08d0289150c46",
-      "bytes": 26289350,
+      "sha256": "c1f105579efb6e5ab8fe05fe70e2af2099a64763b41d29e877dd8fcbf2dc2b9c",
+      "bytes": 27994693,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": "90b29595fbebf5c7b0356fa260332fcc674760ef",
-      "builtUtc": "2026-07-30T17:24:56.423Z"
+      "sourceCommit": "5780c239e4cdcd4389eed37a96d19a98154ebe03",
+      "builtUtc": "2026-08-04T07:26:57.996Z"
     },
     "ruvnet": {
       "file": "ruvnet.big.rvf",
-      "sha256": "7099d94af8888d45e4a5fc0dbb3969c150b54c745a48ec48feccf27afa523ad4",
-      "bytes": 305521,
+      "sha256": "ff345d79a37bb58d2310f3da189a521dfda6535734575cc30d27f2240ade9d9e",
+      "bytes": 322122,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-29T12:58:09.534Z"
+      "sourceCommit": "651c07934a16e1f0ec99e412c09f8dd6f7247260",
+      "builtUtc": "2026-08-04T07:27:50.942Z"
     },
     "rvcsi": {
       "file": "rvcsi.big.rvf",
-      "sha256": "072127f712311cfca826b6ee39759b22c01e09214a13ba4e8d761f1cc2fc07c8",
-      "bytes": 362728,
+      "sha256": "58ee6240c0cd98d4da7c9b2714d1b51c6f4366758517304279b34391a6f43309",
+      "bytes": 370455,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-29T12:58:09.535Z"
+      "sourceCommit": "2ef4fd1e3a30dad68cb7969135a809a0ef230656",
+      "builtUtc": "2026-08-04T07:28:04.971Z"
     },
     "rvdna": {
       "file": "rvdna.big.rvf",
@@ -581,12 +581,12 @@
     },
     "sublinear-time-solver": {
       "file": "sublinear-time-solver.big.rvf",
-      "sha256": "ca291aaaae8ae4a0cd70a4b62ac8ad3fd65264de01ef04ec798fa04f8676f142",
-      "bytes": 12570282,
+      "sha256": "2dbd9cc02d2c882504d2d2ead9e0d6cde74ce3933c5bd436bc8ff35bc8edcb9c",
+      "bytes": 12777599,
       "model": "Xenova/bge-base-en-v1.5",
       "dimensions": 768,
-      "sourceCommit": null,
-      "builtUtc": "2026-07-30T17:24:56.451Z"
+      "sourceCommit": "6ef45761e9a27029cf968322b3967364499e3b5d",
+      "builtUtc": "2026-08-04T07:27:58.061Z"
     },
     "symbolic-scribe": {
       "file": "symbolic-scribe.big.rvf",
@@ -632,6 +632,24 @@
       "dimensions": 768,
       "sourceCommit": "0f68737ae8521a5ad56b33b591b8f757c7029d2d",
       "builtUtc": "2026-07-31T04:39:28.487Z"
+    },
+    "rvqr": {
+      "file": "rvqr.big.rvf",
+      "sha256": "b51734bfd8cd12a25c202554bdf24ee79fb49af73964b931adafba4c1deecb62",
+      "bytes": 1153702,
+      "model": "Xenova/bge-base-en-v1.5",
+      "dimensions": 768,
+      "sourceCommit": "1bdf7da0d39276c3212569696fe9d0dd55cdd21d",
+      "builtUtc": "2026-08-04T07:28:14.891Z"
+    },
+    "rucelium": {
+      "file": "rucelium.big.rvf",
+      "sha256": "4d5015ed34dcefd70a757811b8897c04f925f528e19ee17f0bc4346110321950",
+      "bytes": 664568,
+      "model": "Xenova/bge-base-en-v1.5",
+      "dimensions": 768,
+      "sourceCommit": "813da13eb9a46b6acf78fe7ecc8c220ecf83b386",
+      "builtUtc": "2026-08-04T07:28:21.711Z"
     }
   }
 }

--- a/kb/forge-update.mjs
+++ b/kb/forge-update.mjs
@@ -36,7 +36,60 @@ const APPLY = argv.includes('--apply');
 const RESTORE_COMPLETE = argv.includes('--restore-complete');
 const ONLY = argv.find((a) => !a.startsWith('--'));
 
-function die(msg, code = 1) { console.error(`\n[forge-update] ERROR: ${msg}`); process.exit(code); }
+/**
+ * EXIT CODES — anything scripting this (a cron line, a LaunchAgent, `npx ruvnet-brain --update`)
+ * reads only this number, so each one means exactly one thing:
+ *
+ *    0  --check: current  ·  --apply: the bundle on disk genuinely moved
+ *    1  configuration/verification error; local copy may need the rollback beside it
+ *    2  network / canonical manifest unreachable — nothing was touched
+ *    3  the signature could not be fetched — refused to apply
+ *    4  signature verification FAILED — refused to apply
+ *   10  --check: a newer build exists
+ *   11  --apply: the download completed but the bundle on disk did NOT change (issue #106)
+ *
+ * 11 is deliberately NOT 1: it is a truthful verdict about an intact KB, not a broken updater, so
+ * a caller can tell "nothing landed" apart from "something went wrong" — and must not retry it as
+ * if a fresh install would help.
+ */
+export const EXIT_NOT_LANDED = 11;
+
+// ── ROLLBACK COPIES — ONE settlement point, on EVERY exit path ────────────────────────────────
+// `process.exit()` does NOT run `finally` blocks, so a die() anywhere below the directory swap used
+// to leave a multi-gigabyte rollback copy behind with nothing to release it. Issue #108 measured
+// exactly that: ~1.6 GB stranded per night, ten copies (~16 GB) before the owner noticed — and the
+// run that stranded them had actually SUCCEEDED. Every exit now passes through settleRollback(), so
+// the copy is either RELEASED or deliberately KEPT and named. Never silently stranded.
+const backupsMade = [];
+let rollbackSettled = false;
+function settleRollback({ reclaimable, keepReason = null, intentionallyRemovedStores = [] }) {
+  if (rollbackSettled) return;
+  rollbackSettled = true;
+  if (!reclaimable) {
+    // A rollback copy is only dead weight once the copy in place is known good. When it is NOT,
+    // this directory is the user's recovery — deleting it to "not strand resources" would be the
+    // far worse bug. Keep it, and say where it is and why.
+    for (const b of backupsMade) {
+      console.error(`\n  ROLLBACK COPY KEPT: ${b}`);
+      console.error(`    ${keepReason || 'the copy now in place could not be verified — restore this directory if the KB is broken,'}`);
+      console.error(`    then remove it once you are satisfied (or re-run this updater after fixing the cause).`);
+    }
+    return;
+  }
+  const { removed, kept, freed } = reclaimBackups({ kbDir: KB_DIR, backupsMade, intentionallyRemovedStores });
+  if (removed.length) {
+    console.log(`\nreleased ${removed.length} rollback ${removed.length === 1 ? 'copy' : 'copies'} — ${(freed / 1e9).toFixed(2)} GB reclaimed`);
+    console.log(`  (the copy in place is intact; this exact build is re-downloadable at any time)`);
+  }
+  for (const [b, why] of kept) console.log(`\n  KEPT ${b}\n    ${why}`);
+}
+
+function die(msg, code = 1) {
+  console.error(`\n[forge-update] ERROR: ${msg}`);
+  // Cleanup must never mask the error that caused it.
+  try { settleRollback({ reclaimable: false }); } catch { /* ignore */ }
+  process.exit(code);
+}
 
 if (!fs.existsSync(SOURCE_PATH)) {
   die(`no SOURCE.json next to this script (${SOURCE_PATH}). This bundle predates the evergreen ` +
@@ -46,11 +99,22 @@ let source;
 try { source = JSON.parse(fs.readFileSync(SOURCE_PATH, 'utf8')); }
 catch (e) { die(`SOURCE.json is unreadable/corrupt: ${e.message}`); }
 
-const stores = Array.isArray(source.stores)
+// The RELEASE TAG IS A PROPERTY OF THE BUNDLE, and every store inside it shares that tag (issue
+// #108 bug 2). It is written once, at the top level of SOURCE.json; the per-store entries never
+// carry it. isBehind() short-circuits on `canon.releaseTag && local.releaseTag`, so with the local
+// side always undefined that branch could never fire — every store fell through to a timestamp
+// compare against the RELEASE's publish time, which is always later than the forge time of the KB
+// inside it. Result: all 15 stores read BEHIND on every run, forever, immediately after a
+// successful update. `--check` exited 10 permanently and was useless as a monitoring signal, and
+// `--apply` re-downloaded half a gigabyte every night to change nothing. Inheriting the tag the
+// bundle already records is the whole fix; a store that carries its own still wins.
+const withBundleTag = (s) => (s && s.releaseTag == null && source.releaseTag != null
+  ? { ...s, releaseTag: source.releaseTag } : s);
+const stores = (Array.isArray(source.stores)
   ? source.stores
   : (source.stores && typeof source.stores === 'object')
     ? Object.entries(source.stores).map(([kbName, v]) => ({ kbName, ...v }))
-    : [source];
+    : [source]).map(withBundleTag);
 
 const manifestUrl = source.canonicalManifestUrl || stores.find((s) => s.canonicalManifestUrl)?.canonicalManifestUrl;
 if (!manifestUrl) {
@@ -266,6 +330,21 @@ export function resolveBundleUrl({ canon, local, source }) {
 }
 
 /**
+ * The identity of a WHOLE bundle, as recorded at the top level of its SOURCE.json.
+ *
+ * This is what advances when a new bundle is published, regardless of which individual stores were
+ * re-forged into it — which is precisely why the "did anything land" question belongs here and not
+ * on a single store (issue #108). Returns null when a SOURCE.json carries no such identity at all
+ * (bundles predating `releaseTag`/`brainVersion`, or a plain forge manifest), so callers can tell
+ * "identical" apart from "no signal to compare".
+ */
+export function bundleIdentity(src) {
+  if (!src || typeof src !== 'object') return null;
+  const parts = [src.releaseTag, src.brainVersion, src.builtUtc].map((v) => (v == null ? '' : String(v)));
+  return parts.some(Boolean) ? parts.join('|') : null;
+}
+
+/**
  * Confirm the download+extraction actually changed what is on disk (issue #35 item 2, Dr. Mark
  * Allen / @mamd69).
  *
@@ -287,16 +366,36 @@ export function resolveBundleUrl({ canon, local, source }) {
  * carried a real digest, this also verifies the downloaded bytes against it — the one place a
  * directly comparable "resolved vs. landed" fact actually exists in a GitHub Release payload.
  *
- * @returns {{ok: boolean, reason: string|null, landed: object|null}}
+ * THE QUESTION IS ASKED OF THE BUNDLE, NOT OF ONE STORE (issue #108). The first version compared a
+ * PER-STORE fingerprint and treated equality as fatal — but stores are forged INDEPENDENTLY, and a
+ * store whose upstream repo did not move is re-shipped byte-identical inside a genuinely new
+ * bundle. On the reporter's copy 8 of 15 stores shared one stamp, so the first unchanged store in
+ * iteration order aborted the entire run: nightly updates "failed" for three weeks while actually
+ * succeeding, and the abort skipped the rollback release, stranding ~1.6 GB a night. Whitelisting
+ * the store would not have helped — the next unchanged one simply takes its place.
+ *
+ * So the fatal question is the one issue #35 actually asked: did ANYTHING land? That is bundle
+ * identity (releaseTag / brainVersion / top-level builtUtc), which advances whenever a new bundle
+ * is published. Per-store equality is now what it always was in reality — ordinary, and reported
+ * as `storeUnchanged` rather than raised as a failure. A bundle whose identity did NOT move AND
+ * whose store did not move either is the real no-op, and is still refused (issue #106).
+ *
+ * `kind` says what a caller may do about a failure: 'noop' means the KB in place is intact and the
+ * rollback copy is redundant; 'damaged' means the copy in place is suspect and the rollback must
+ * be kept.
+ *
+ * @returns {{ok: boolean, reason: string|null, landed: object|null, kind: 'noop'|'damaged'|null,
+ *            storeUnchanged: boolean, bundleChanged: boolean|null}}
  */
-export function verifyLanded({ kbDir, kbName, before, expectedDigest = null, downloadedBuffer = null }) {
+export function verifyLanded({ kbDir, kbName, before, beforeBundle = null, expectedDigest = null, downloadedBuffer = null }) {
+  const damaged = (reason, landed = null) => ({ ok: false, kind: 'damaged', reason, landed, storeUnchanged: false, bundleChanged: null });
   const p = path.join(kbDir, 'SOURCE.json');
   if (!fs.existsSync(p)) {
-    return { ok: false, reason: `no SOURCE.json found at ${p} after extraction — cannot confirm what actually landed`, landed: null };
+    return damaged(`no SOURCE.json found at ${p} after extraction — cannot confirm what actually landed`);
   }
   let landedSource;
   try { landedSource = JSON.parse(fs.readFileSync(p, 'utf8')); }
-  catch (e) { return { ok: false, reason: `SOURCE.json on disk after extraction is unreadable/corrupt: ${e.message}`, landed: null }; }
+  catch (e) { return damaged(`SOURCE.json on disk after extraction is unreadable/corrupt: ${e.message}`); }
 
   const list = Array.isArray(landedSource.stores)
     ? landedSource.stores
@@ -322,29 +421,47 @@ export function verifyLanded({ kbDir, kbName, before, expectedDigest = null, dow
     // Legacy caller upgrading into the modern schema: any single landed store is unambiguous.
     || (legacyCaller && list.length === 1 ? { kbName: list[0].kbName, ...list[0] } : null);
   if (!landed) {
-    return { ok: false, reason: `SOURCE.json on disk after extraction has no entry for store "${kbName}"`, landed: null };
+    return damaged(`SOURCE.json on disk after extraction has no entry for store "${kbName}"`);
   }
 
-  const fingerprint = (r) => `${r.builtUtc || ''}|${r.sourceCommit || ''}|${r.sourceDescribe || ''}`;
-  if (before && fingerprint(landed) === fingerprint(before)) {
-    return {
-      ok: false,
-      reason: `SOURCE.json on disk is IDENTICAL to before the update (built ${landed.builtUtc || '?'}` +
-        `${landed.sourceDescribe ? `, ${landed.sourceDescribe}` : ''}) — nothing actually changed. ` +
-        `This is the exact failure reported in issue #35: bytes replaced with an identical copy while success was printed.`,
-      landed,
-    };
-  }
-
+  // Bytes that do not match what the release declared are a HARD failure whatever the identities
+  // say, and the copy now in place is suspect — so this is checked before anything else.
   if (expectedDigest && downloadedBuffer) {
     const algo = expectedDigest.includes(':') ? expectedDigest.split(':')[0] : 'sha256';
     const actual = `${algo}:${createHash(algo).update(downloadedBuffer).digest('hex')}`;
     if (actual !== expectedDigest) {
-      return { ok: false, reason: `downloaded bundle digest ${actual} does not match the release-declared digest ${expectedDigest}`, landed };
+      return damaged(`downloaded bundle digest ${actual} does not match the release-declared digest ${expectedDigest}`, landed);
     }
   }
 
-  return { ok: true, reason: null, landed };
+  const fingerprint = (r) => `${r.builtUtc || ''}|${r.sourceCommit || ''}|${r.sourceDescribe || ''}`;
+  const storeUnchanged = Boolean(before) && fingerprint(landed) === fingerprint(before);
+
+  const landedBundle = bundleIdentity(landedSource);
+  const priorBundle = bundleIdentity(beforeBundle);
+  // null = one side carries no bundle identity at all (a pre-releaseTag bundle, or a plain forge
+  // manifest). There is then nothing to compare, so the per-store fingerprint is the ONLY signal
+  // available and the original behaviour stands — a fallback, never the primary test.
+  const bundleChanged = (landedBundle && priorBundle) ? landedBundle !== priorBundle : null;
+
+  const nothingMoved = bundleChanged === null ? storeUnchanged : (!bundleChanged && storeUnchanged);
+  if (nothingMoved) {
+    const detail = bundleChanged === null
+      ? `store "${kbName}" on disk is IDENTICAL to before the update (built ${landed.builtUtc || '?'}` +
+        `${landed.sourceDescribe ? `, ${landed.sourceDescribe}` : ''}), and this bundle carries no top-level identity to cross-check`
+      : `the BUNDLE on disk is IDENTICAL to before the update (${landedBundle}) and store "${kbName}" did not move either`;
+    return {
+      ok: false,
+      kind: 'noop',
+      reason: `${detail} — nothing actually changed. Bytes were replaced with an identical copy while the ` +
+        `download reported success: issue #35, and the reason issue #106 must not exit 0.`,
+      landed,
+      storeUnchanged,
+      bundleChanged,
+    };
+  }
+
+  return { ok: true, kind: null, reason: null, landed, storeUnchanged, bundleChanged };
 }
 
 async function main() {
@@ -367,8 +484,6 @@ async function main() {
   console.log(`canonical built:    ${canonLabel}\n`);
 
   let anyBehind = false; const behindStores = [];
-  // Rollback copies taken during this run. Released once the new copy verifies — see RECLAIM below.
-  const backupsMade = [];
   for (const local of targets) {
     const c = canonicalFor(canon, local.kbName);
     const behind = RESTORE_COMPLETE || isBehind(local, c);
@@ -395,8 +510,16 @@ async function main() {
   // #35 item 2. Populated by verifyLanded() as each store is applied; main() dies loudly before
   // reaching the summary if any store's landed copy does not check out.
   const landedByStore = new Map();
+  // Stores that landed byte-identical because their upstream repo did not move. ORDINARY, and named
+  // in the summary so "unchanged" never has to be inferred from silence (issue #108).
+  const unchangedStores = [];
+  // Stores whose bundle demonstrably did not move at all. Non-zero exit, counted in the summary
+  // rather than only in the mid-log line a cron job never reads (issue #106).
+  const mismatches = [];
+  let attempted = 0;
 
   for (const { local } of behindStores) {
+    attempted++;
     // ── RESOLVE THE BUNDLE URL FROM THE LIVE MANIFEST, NOT THE PINNED LOCAL COPY (issue #35 item 1) ─
     const resolved = resolveBundleUrl({ canon, local, source });
     if (!resolved.url) die(`[${local.kbName}] no canonicalBundleUrl in SOURCE.json and no resolvable asset in the live manifest — cannot self-update this store.`);
@@ -459,11 +582,50 @@ async function main() {
     // Do NOT trust `canon` here — that lookup happened before any download and says nothing about
     // what is now actually on disk. See verifyLanded()'s doc comment for why this can't reuse
     // isBehind() safely.
-    const verified = verifyLanded({ kbDir: KB_DIR, kbName: local.kbName, before: local, expectedDigest: resolved.digest, downloadedBuffer: buf });
+    const verified = verifyLanded({
+      kbDir: KB_DIR, kbName: local.kbName, before: local, beforeBundle: source,
+      expectedDigest: resolved.digest, downloadedBuffer: buf,
+    });
     if (!verified.ok) {
-      die(`[${local.kbName}] UPDATE MISMATCH: ${verified.reason}\n  Previous copy is backed up beside the KB dir (*.bak-*); restore it if needed. REFUSING to report success.`);
+      // 'damaged' — the copy in place is suspect. die() KEEPS the rollback and names it.
+      if (verified.kind !== 'noop') {
+        die(`[${local.kbName}] UPDATE MISMATCH: ${verified.reason}\n  REFUSING to report success.`);
+      }
+      // --restore-complete deliberately re-lands the SAME bundle, to bring back artifacts a profile
+      // removed. An unchanged identity is the EXPECTED outcome of that request, not a failed
+      // update: what it restores is FILES, which SOURCE.json's identity has nothing to say about.
+      if (RESTORE_COMPLETE) {
+        unchangedStores.push(local.kbName);
+        landedByStore.set(local.kbName, { landed: verified.landed, origin: resolved.origin, assetName: resolved.assetName });
+        continue;
+      }
+      // 'noop' — the bundle did not move. The KB in place is intact (it is what the rollback copy
+      // already holds), so there is nothing to roll back TO that differs, and the run is settled
+      // once below rather than aborting here. Every store in this bundle shares its identity, so
+      // re-downloading the rest to prove the same thing would cost gigabytes for no new fact.
+      mismatches.push({ kbName: local.kbName, reason: verified.reason });
+      break;
     }
+    if (verified.storeUnchanged) unchangedStores.push(local.kbName);
     landedByStore.set(local.kbName, { landed: verified.landed, origin: resolved.origin, assetName: resolved.assetName });
+  }
+
+  if (mismatches.length) {
+    // ── THE BUNDLE DID NOT MOVE — SAY SO IN THE EXIT CODE (issue #106) ───────────────────────────
+    // The mid-log error was already correct and named the issue; what a script or a scheduled job
+    // reads is the exit code, and that used to be swallowed. Release the rollback copy FIRST
+    // (issue #108): nothing changed, so it duplicates the copy in place byte for byte and is pure
+    // waste — ~1.6 GB of it per run, which is how the two issues turned out to be one run.
+    settleRollback({ reclaimable: true });
+    console.error(`\n[forge-update] ERROR: [${mismatches[0].kbName}] UPDATE MISMATCH: ${mismatches[0].reason}`);
+    console.error(`\n=== NOT DONE — 0 of ${behindStores.length} store(s) moved ===`);
+    console.error(`  ${mismatches.length} store(s) reported UPDATE MISMATCH: ${mismatches.map((m) => m.kbName).join(', ')}`);
+    if (attempted < behindStores.length) {
+      console.error(`  stopped at the first mismatch; ${behindStores.length - attempted} store(s) not attempted (same bundle, same verdict).`);
+    }
+    console.error(`  exiting ${EXIT_NOT_LANDED}: the download completed but the corpus on disk did not change, so no`);
+    console.error(`  script or scheduled job may read this run as success.`);
+    process.exit(EXIT_NOT_LANDED);
   }
 
   // Re-verify only the updated store(s) with the bundled guard. forge-guard.mjs takes the KB
@@ -499,16 +661,10 @@ async function main() {
   // forge-guard would still pass, because it verifies the store it was asked about, not whatever went
   // missing. Deleting there would destroy the only copy of a user's private data. So: compare store
   // inventories first, and keep any backup holding something the new copy lost.
-  const { removed, kept, freed } = reclaimBackups({
-    kbDir: KB_DIR,
-    backupsMade,
-    intentionallyRemovedStores,
-  });
-  if (removed.length) {
-    console.log(`\nreleased ${removed.length} rollback ${removed.length === 1 ? 'copy' : 'copies'} — ${(freed / 1e9).toFixed(2)} GB reclaimed`);
-    console.log(`  (the new copy verified; this exact build is re-downloadable at any time)`);
-  }
-  for (const [b, why] of kept) console.log(`\n  KEPT ${b}\n    ${why}`);
+  //
+  // Routed through settleRollback() so this is the SAME release the failure paths use, rather than a
+  // happy-path-only call that a die() can step over — that step-over is issue #108.
+  settleRollback({ reclaimable: true, intentionallyRemovedStores });
 
   // ── FINAL MESSAGE — DERIVED FROM WHAT LANDED, NOT FROM THE TAG LOOKUP (issue #35 item 2) ────────
   // The old line above printed `canon.tag_name` regardless of what the download actually contained
@@ -523,6 +679,13 @@ async function main() {
     const l = r.landed;
     console.log(`[${local.kbName}] SOURCE.json on disk now reads: built ${l.builtUtc || '?'} from ${short(l.sourceCommit)}${l.sourceDescribe ? ` (${l.sourceDescribe})` : ''}`);
     console.log(`  fetched from: ${r.origin === 'latest-release-asset' ? `release asset "${r.assetName}"` : r.origin === 'live-manifest' ? 'live manifest entry' : 'PINNED FALLBACK — see warning above'}`);
+  }
+  if (unchangedStores.length) {
+    // NAMED, not silent. Stores are forged independently, so a store whose upstream repo did not
+    // move is re-shipped byte-identical inside a genuinely new bundle — normal, and the thing that
+    // used to abort the whole run (issue #108).
+    console.log(`\n${unchangedStores.length} of ${behindStores.length} store(s) were already at the canonical build and did not change: ${unchangedStores.join(', ')}`);
+    console.log(`  (stores are forged independently — an unchanged store means its upstream repo did not move, not a failed update.)`);
   }
   console.log(`\n(the above is read back from disk, verified — not a tag lookup)`);
   process.exit(0);

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 69 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/plugin/scripts/learn-flush.mjs
+++ b/plugin/scripts/learn-flush.mjs
@@ -14,6 +14,13 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { readStdinBounded } from './hook-input.mjs';
 import { loadRuntimePreferences } from './runtime-preferences.mjs';
+import { resolveRuflo, RUFLO_MISSING } from './ruflo-bin.mjs';
+
+// ONE BOUNDED LINE ON STDERR. stderr because a SessionEnd hook's stdout is not surfaced, and bounded
+// because a hook that prints a stack trace on every `/clear` gets muted — and a muted diagnostic is
+// no diagnostic at all (the same lesson as the session-start line that reported its own defect every
+// session for eight days and went unread).
+const warn = (msg) => { try { process.stderr.write(`learn-flush: ${msg}\n`); } catch { /* stderr gone */ } };
 
 const HOME = os.homedir();
 const PROJECT = process.env.RUVNET_BRAIN_PROJECT_DIR || process.cwd();
@@ -48,7 +55,11 @@ const QUEUE_ROOT = LEARNING_SCOPE === 'user'
   ? path.join(HOME, '.cache', 'ruvnet-brain', 'learn')
   : path.join(PROJECT, '.swarm', 'ruvnet-brain-learn');
 const QUEUE = process.env.LEARN_QUEUE || path.join(QUEUE_ROOT, `session-${SID}.jsonl`);
-const RUFLO = path.join(HOME, '.npm-global/bin/ruflo');
+// Issue #105: this was a hardcoded `path.join(HOME, '.npm-global/bin/ruflo')` — the owner's npm
+// prefix. On any other prefix (Homebrew, nvm, Volta, plain `npm -g`) the path simply did not exist,
+// every feed below threw ENOENT, and every throw landed in a `catch {}` that said nothing. One
+// resolver, shared with distill-project.mjs and health-repair.mjs's original — see ruflo-bin.mjs.
+const RUFLO = resolveRuflo();
 const RUFLO_ENV = { ...process.env, RUFLO_DAEMON_AUTOSTART: '0' };
 const MAX_ACTIONS = 8; // bound the work so SessionEnd stays fast
 
@@ -98,7 +109,16 @@ for (const line of lines) {
 const actions = allDistinct.slice(0, MAX_ACTIONS);
 const deferred = allDistinct.slice(MAX_ACTIONS);
 
+// ruflo is genuinely not on this machine. SAY SO — once — and keep the queue. Exiting 0 keeps the
+// best-effort contract (an absent optional learner must never break SessionEnd); saying nothing at
+// all is what turned #105 into eight invisible ENOENTs and a queue that never drained.
+if (!RUFLO && actions.length) {
+  warn(`0/${actions.length} fed — ${RUFLO_MISSING}. The queue is KEPT for retry.`);
+  process.exit(0);
+}
+
 let fed = 0;
+const failures = [];              // WHY each feed failed — the thing `catch {}` used to destroy
 let stoppedAt = actions.length;   // how far the feed actually got before the deadline
 for (let i = 0; i < actions.length; i++) {
   const remaining = DEADLINE - Date.now();
@@ -120,7 +140,22 @@ for (let i = 0; i < actions.length; i++) {
       timeout: Math.min(6000, remaining),
     });
     fed++;
-  } catch { /* best-effort — one slow/failed record must not stall session end */ }
+  } catch (e) {
+    // BEST-EFFORT, NOT SILENT. The old `catch { /* best-effort */ }` swallowed the reason, so a
+    // machine where every call failed looked exactly like one where every call worked: exit 0,
+    // no output, and the only trace a queue that never shrank. "Reports success while doing
+    // nothing" is the defect class this project treats as the worst thing it can ship. Keep going
+    // (one bad record must not stall session end), but keep the reason.
+    failures.push(String(e?.message || e).split('\n')[0].slice(0, 120));
+  }
+}
+// SURFACE IT. Distinct reasons only, at most two: eight copies of the same ENOENT is noise, and the
+// second distinct reason is usually where the real information is.
+if (failures.length) {
+  const distinct = [...new Set(failures)];
+  warn(`${failures.length}/${actions.length} feed call(s) FAILED via ${RUFLO}`
+    + ` — ${distinct.slice(0, 2).join(' | ')}${distinct.length > 2 ? ` (+${distinct.length - 2} more kind(s))` : ''}`
+    + (fed === 0 ? '. Nothing was learned; the queue is KEPT for retry.' : `. ${fed} succeeded.`));
 }
 // Whatever the deadline cut off is WORK, not waste: it goes back on the front of the queue so the
 // next flush continues from there. Dropping it would turn a time limit into the same silent data

--- a/plugin/scripts/project-identity.mjs
+++ b/plugin/scripts/project-identity.mjs
@@ -1,0 +1,89 @@
+// project-identity.mjs — ONE answer to "which directory is this, and have I seen it already?"
+//
+// WHY THIS EXISTS. Two user-filed bugs, #85 and #107, are the same defect: the product derives a
+// project's location independently at each site and the sites then disagree.
+//
+//   #85  The PreCompact producer wrote its receipt under `CLAUDE_PROJECT_DIR`; the Console probe
+//        that reports whether a receipt exists looked under `process.cwd()`. Launch the Console
+//        from a subdirectory of the project and it warns "no supported PreCompact snapshot found"
+//        about a snapshot it had itself just written. Nothing was broken except the agreement.
+//
+//   #107 `candidateRoots()` returned BOTH `~/Code` and `~/code`, which on APFS are one directory
+//        with one inode. Every project under them was scanned, counted and summed twice, so the
+//        machine-wide memory total read exactly 2x — silently, confidently, in the one figure the
+//        Console exists to make trustworthy. `path.resolve()` was the guard, and it normalises
+//        `.`/`..` only: it case-folds nothing and resolves no symlinks, which the guard's own
+//        comment ("e.g. a symlink") shows it was believed to do.
+//
+// WHY DEVICE+INODE RATHER THAN LOWER-CASING. Lower-casing is a guess about the filesystem, and it
+// is wrong on the machines that would suffer most: Linux, and case-sensitive APFS volumes, where
+// `Code` and `code` really are two projects and folding them would DELETE one from the report.
+// `st_dev` + `st_ino` is not a guess — it is the filesystem's own answer, correct in both
+// directions on every volume, and it settles symlinks and bind mounts in the same stroke. The
+// case-insensitivity probe the reporter suggested (write a temp file, stat the other spelling)
+// would also work, but it writes to the user's disk to learn something `stat` already knows.
+//
+// `fs.realpathSync.native` is the OS canonicaliser: it resolves symlinks AND returns the case as
+// stored on disk. Plain `fs.realpathSync` is a JavaScript reimplementation that does symlinks only
+// — measured on this repo's own machine, `realpathSync('~/code')` stays `~/code` while
+// `realpathSync.native('~/code')` returns `~/Code`. That one missing word is the whole of #107.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const defaultRealpath = (value) => fs.realpathSync.native(value);
+const defaultStat = (value) => fs.statSync(value, { bigint: true });
+
+/** The operating system's own spelling of an existing path, or null when it cannot be resolved. */
+export function canonicalPath(value, { realpath = defaultRealpath } = {}) {
+  if (typeof value !== 'string' || !value) return null;
+  try { return realpath(value); } catch { return null; }
+}
+
+/**
+ * A key that is equal for two names of one directory and different for two directories.
+ * Falls back to the canonical path when the volume reports no usable inode (some Windows and
+ * network mounts report 0) — never worse than the raw string compare it replaces.
+ */
+export function pathIdentity(value, { realpath = defaultRealpath, stat = defaultStat } = {}) {
+  const canonical = canonicalPath(value, { realpath });
+  if (!canonical) return null;
+  try {
+    const info = stat(canonical);
+    if (info?.ino) return `${info.dev}:${info.ino}`;
+  } catch { /* unreadable — the canonical spelling is still a better key than the raw one */ }
+  return canonical;
+}
+
+/** True when both names denote the same existing directory or file. */
+export function sameLocation(a, b, options = {}) {
+  const left = pathIdentity(a, options);
+  return left !== null && left === pathIdentity(b, options);
+}
+
+/** True when `child` is `root` or lies beneath it, compared canonically rather than by raw string. */
+export function contains(root, child, options = {}) {
+  const canonicalRoot = canonicalPath(root, options);
+  const canonicalChild = canonicalPath(child, options);
+  if (!canonicalRoot || !canonicalChild) return false;
+  if (sameLocation(canonicalRoot, canonicalChild, options)) return true;
+  const relative = path.relative(canonicalRoot, canonicalChild);
+  return Boolean(relative) && !relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative);
+}
+
+/**
+ * THE project directory. The PreCompact snapshot producer and the Console probe that detects the
+ * snapshot both call this, so they cannot disagree about where the project is (#85).
+ *
+ * `CLAUDE_PROJECT_DIR` wins only when the current directory actually lies inside it. Containment,
+ * not mere presence, is what makes the two sides agree by construction: a hook and a Console
+ * launched anywhere within one project resolve to that project's root, while a caller that hands
+ * over an unrelated directory (a test fixture, an explicit `--project`) is never overruled by an
+ * environment variable it knows nothing about.
+ */
+export function projectDirectory({ env = process.env, cwd = process.cwd(), ...options } = {}) {
+  const here = canonicalPath(cwd, options) || path.resolve(cwd);
+  const declared = typeof env.CLAUDE_PROJECT_DIR === 'string' && env.CLAUDE_PROJECT_DIR.trim()
+    ? canonicalPath(env.CLAUDE_PROJECT_DIR, options)
+    : null;
+  return declared && contains(declared, here, options) ? declared : here;
+}

--- a/plugin/scripts/ruflo-bin.mjs
+++ b/plugin/scripts/ruflo-bin.mjs
@@ -49,12 +49,20 @@ import path from 'node:path';
 export function resolveRuflo({ env = process.env, home = os.homedir() } = {}) {
   if (env.RUFLO_BIN) return env.RUFLO_BIN;
 
-  const preferred = path.join(home, '.npm-global/bin/ruflo');
-  if (fs.existsSync(preferred)) return preferred;
-
   // On Windows a global npm ruflo is `ruflo.cmd`; the extensionless sibling is a POSIX shell wrapper
   // that Node cannot exec (and refuses to spawn without a shell since CVE-2024-27980).
   const exts = process.platform === 'win32' ? ['.cmd', '.exe', ''] : [''];
+
+  // The preferred path needs that SAME rule. It first checked a bare `ruflo` only, so on Windows it
+  // either missed the real `ruflo.cmd` entirely or returned the POSIX wrapper the comment above
+  // says is unrunnable — and the caller then reported "ruflo is not at ~/.npm-global/bin/ruflo" to
+  // someone who had ruflo installed. That is the exact complaint #99 and #105 were filed about,
+  // reintroduced one platform over.
+  const preferredDir = path.join(home, '.npm-global', 'bin');
+  for (const ext of exts) {
+    const cand = path.join(preferredDir, `ruflo${ext}`);
+    try { if (fs.existsSync(cand) && fs.statSync(cand).isFile()) return cand; } catch { /* unreadable */ }
+  }
   for (const dir of String(env.PATH || '').split(path.delimiter)) {
     if (!dir) continue;
     for (const ext of exts) {

--- a/plugin/scripts/ruflo-bin.mjs
+++ b/plugin/scripts/ruflo-bin.mjs
@@ -1,0 +1,73 @@
+/**
+ * ruflo-bin.mjs — the ONE place this repo decides WHERE the global `ruflo` binary is.
+ *
+ * WHY THIS FILE EXISTS. Issues #99 and #105 are one defect filed twice: `scripts/distill-project.mjs`
+ * and `plugin/scripts/learn-flush.mjs` each hardcoded `~/.npm-global/bin/ruflo` — the owner's npm
+ * prefix, nobody else's. On a Homebrew, nvm, Volta, or plain `npm -g` install that path does not
+ * exist, so #99 died with "ruflo is not at ~/.npm-global/bin/ruflo" and #105 failed every feed
+ * silently — both on machines where ruflo was installed and sitting on PATH the whole time.
+ *
+ * `health-repair.mjs` had already fixed exactly this, and its header says why: "Telling someone their
+ * tool is missing when it is on their PATH is the product lying, and it is unfalsifiable from their
+ * side: they cannot see why we looked in one place." That fix lived as a private function inside one
+ * file, so its two siblings kept the bug — the identical shape ADR-021 was written about ("One class,
+ * fixed in one file, regenerated in the sibling"). So the resolver moves here instead of being pasted
+ * a third time.
+ *
+ * MECHANISM — the hardened form, not the first draft. Two resolvers already existed in this repo:
+ *   • health-repair.mjs      (2026-07-21)  preferred path, then `sh -lc 'command -v ruflo'`
+ *   • capability-registry.mjs (2026-07-22)  preferred path, then a plain PATH walk, NO shell
+ * The second IS the first one, hardened, and it says so in place: `-l` sources the user's entire
+ * profile — every export, shim, and one-off line anyone has ever pasted into .profile — as the price
+ * of answering "where is ruflo?". Resolving a name against directories is all `command -v` was ever
+ * wanted for here, and it needs no shell at all. This module takes that version. Adopting the older
+ * mechanism would mean re-introducing, in a shared module, a bug the repo had already fixed one file
+ * over.
+ *
+ * ORDER, and each step earns its place:
+ *   1. RUFLO_BIN, if set, is AUTHORITATIVE — returned as given, whether or not it exists. An explicit
+ *      override that quietly falls back to some other ruflo is not an override, and the caller's
+ *      "not at <path>" message has to name the path the user actually asked for.
+ *   2. ~/.npm-global/bin/ruflo — Rule 21's ONE global binary, checked first so a machine that has it
+ *      never depends on PATH ordering.
+ *   3. A PATH walk — the entire point of #99/#105: an installed ruflo living anywhere else.
+ *   4. null — "I could not find it", said plainly. Never guess a path and then blame the user for it.
+ *
+ * Rule 21 is untouched by this: still ONE ruflo, still the global one, never `npx ruflo@latest`. This
+ * resolves WHERE that one global binary is rather than assuming everyone's prefix matches the owner's.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Locate the global ruflo. LOCATES, NEVER EXECUTES — no shell, no daemon, no side effects.
+ *
+ * @param {{ env?: Record<string, string|undefined>, home?: string }} [opts]
+ * @returns {string|null} path to ruflo, or null when it is genuinely not on this machine.
+ */
+export function resolveRuflo({ env = process.env, home = os.homedir() } = {}) {
+  if (env.RUFLO_BIN) return env.RUFLO_BIN;
+
+  const preferred = path.join(home, '.npm-global/bin/ruflo');
+  if (fs.existsSync(preferred)) return preferred;
+
+  // On Windows a global npm ruflo is `ruflo.cmd`; the extensionless sibling is a POSIX shell wrapper
+  // that Node cannot exec (and refuses to spawn without a shell since CVE-2024-27980).
+  const exts = process.platform === 'win32' ? ['.cmd', '.exe', ''] : [''];
+  for (const dir of String(env.PATH || '').split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const cand = path.join(dir, `ruflo${ext}`);
+      try { if (fs.existsSync(cand) && fs.statSync(cand).isFile()) return cand; } catch { /* unreadable PATH entry */ }
+    }
+  }
+  return null;
+}
+
+/**
+ * What to say when resolveRuflo() returns null. ONE wording, so every caller reports the same thing
+ * and names both places it looked — the diagnostic #99 and #105 never gave anyone.
+ */
+export const RUFLO_MISSING = 'ruflo was not found in ~/.npm-global/bin or anywhere on your PATH'
+  + ' — install it with `npm i -g ruflo@latest`, or set RUFLO_BIN to its full path';

--- a/plugin/scripts/session-snapshot-hook.mjs
+++ b/plugin/scripts/session-snapshot-hook.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createSessionSnapshot } from './session-snapshot-contract.mjs';
+import { projectDirectory } from './project-identity.mjs';
 
 function regularOrAbsent(file) {
   try {
@@ -30,5 +31,7 @@ export function writeSessionSnapshot(projectDir, event) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]).endsWith('session-snapshot-hook.mjs')) {
-  writeSessionSnapshot(process.env.CLAUDE_PROJECT_DIR || process.cwd(), process.argv[2] || 'SessionEnd');
+  // projectDirectory() is the SAME derivation the Console's detector uses. Deriving it here
+  // independently is what let this hook write a receipt the Console then reported as missing (#85).
+  writeSessionSnapshot(projectDirectory(), process.argv[2] || 'SessionEnd');
 }

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.0.8 · Built: 2026-07-30 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.0.9 · Built: 2026-07-30 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/console-runtime-identity.mjs
+++ b/scripts/console-runtime-identity.mjs
@@ -1,0 +1,74 @@
+// ONE definition of "what the persistent Console runtime is" and "which generation is running".
+//
+// #79 reported a Console that survived an update: the browser was served the new frontend from disk
+// while the Node process kept its pre-update router in memory, and every relaunch said "already
+// running". The reuse check compared a `sourceSha256` computed from a SINGLE file —
+// scripts/onboarding-console.mjs — while the runtime the server actually executes is this whole
+// surface: ~230 modules it imports plus the frontend it serves. Two genuinely different candidates
+// whose entrypoint bytes happened to match produced byte-identical identities, so an update that
+// changed console-engine.mjs, capability-registry.mjs or console/app.js was invisible to the
+// launcher. The identity has to derive from something an update cannot leave behind, which is the
+// installed bytes themselves — all of them.
+//
+// #76 reported the same disease at the asset boundary: the runtime copied plugin/scripts without
+// the sibling docs/ and manifest that plugin/scripts/whats-new.mjs reads, so the executable
+// travelled and its assets did not. The copy list and the identity list were two separate
+// enumerations of one payload; they are one list now, so an asset added to the runtime is part of
+// its generation by construction.
+//
+// The installer hashes the staged tree with this function and the running server hashes its own
+// root with this function, over this list. Neither side can define the fact differently.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+/**
+ * Every path the persistent Console runtime carries, relative to both the candidate source root and
+ * the installed runtime root (they are laid out identically). This is simultaneously the installer's
+ * copy list and the generation's digest input — one enumeration, so they cannot drift.
+ */
+export const CONSOLE_RUNTIME_SURFACE = Object.freeze([
+  'console',
+  'scripts',
+  'plugin/scripts',
+  // whats-new.mjs resolves its version manifest and curated notes relative to its own plugin root
+  // (#76). Shipping the executable without them is how the installed skill lost its release notes.
+  'plugin/docs',
+  'plugin/.claude-plugin',
+  'data/model-catalog.json',
+  'kb/brain-profile.mjs',
+  'bin/install.mjs',
+  'package.json',
+]);
+
+/** The runtime's own identity file, written by the installer INTO the tree — never part of its own digest. */
+export const CONSOLE_RUNTIME_IDENTITY_FILE = 'runtime-identity.json';
+
+/**
+ * Deterministic content digest of the runtime surface under `root`.
+ *
+ * A path that is absent is hashed as absent rather than skipped: a runtime that lost a file is a
+ * different generation, not the same one, and a launcher must be able to see that.
+ *
+ * @param {string} root runtime root (an installed `.console-runtime`, a marketplace clone, or a checkout)
+ * @returns {string} hex sha256
+ */
+export function consoleRuntimeDigest(root) {
+  const hash = crypto.createHash('sha256');
+  const visit = (absolute, relative) => {
+    let stat;
+    try { stat = fs.lstatSync(absolute); } catch { hash.update(`absent\0${relative}\0`); return; }
+    if (stat.isDirectory()) {
+      hash.update(`d\0${relative}\0`);
+      let entries = [];
+      try { entries = fs.readdirSync(absolute).sort(); } catch { hash.update(`unreadable\0${relative}\0`); return; }
+      for (const entry of entries) visit(path.join(absolute, entry), `${relative}/${entry}`);
+      return;
+    }
+    hash.update(`f\0${relative}\0`);
+    try { hash.update(fs.readFileSync(absolute)); } catch { hash.update(`unreadable\0${relative}\0`); }
+  };
+  for (const relative of CONSOLE_RUNTIME_SURFACE) visit(path.join(root, relative), relative);
+  return hash.digest('hex');
+}

--- a/scripts/distill-project.mjs
+++ b/scripts/distill-project.mjs
@@ -37,9 +37,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
+import { resolveRuflo, RUFLO_MISSING } from '../plugin/scripts/ruflo-bin.mjs';
 
 const HOME = os.homedir();
-const RUFLO = process.env.RUFLO_BIN || path.join(HOME, '.npm-global/bin/ruflo');
+// Issue #99: this was `process.env.RUFLO_BIN || path.join(HOME, '.npm-global/bin/ruflo')`, so every
+// install whose npm prefix is not the owner's (Homebrew, nvm, Volta, plain `npm -g`) was told its
+// tool was missing while ruflo sat on their PATH. One resolver, shared — see ruflo-bin.mjs.
+const RUFLO = resolveRuflo();
 const RUFLO_ENV = { ...process.env, RUFLO_DAEMON_AUTOSTART: '0' };
 
 const argv = process.argv.slice(2);
@@ -126,6 +130,10 @@ if (has('--restore')) {
 }
 
 // ── PRE-FLIGHT ─────────────────────────────────────────────────────────────────────────────────────
+// Two different facts, so two different sentences. `null` means we looked everywhere and found
+// nothing; a path that does not exist means the user pointed RUFLO_BIN somewhere empty, and naming
+// that exact path back to them is the whole value of the message.
+if (!RUFLO) die(RUFLO_MISSING);
 if (!fs.existsSync(RUFLO)) die(`ruflo is not at ${RUFLO.replace(HOME, '~')} — install it with \`npm i -g ruflo@latest\``);
 if (!fs.existsSync(DB)) die(`no memory store at ${DB.replace(HOME, '~')} — nothing to distill for this project`);
 

--- a/scripts/health-repair.mjs
+++ b/scripts/health-repair.mjs
@@ -24,8 +24,12 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { findStores, diagnose } from './memory-doctor.mjs';
+import { loadRuntimePreferences } from '../plugin/scripts/runtime-preferences.mjs';
 
 const HOME = os.homedir();
+// The SAME project root learn-flush.mjs computes, by the same rule — the two halves of the flush
+// have to agree about which project they mean or they address different queues (issue #104).
+const PROJECT = process.env.RUVNET_BRAIN_PROJECT_DIR || process.cwd();
 const argv = process.argv.slice(2);
 const has = (f) => argv.includes(f);
 
@@ -93,25 +97,94 @@ function repairMemory() {
   return { ok: true, log: `repaired — integrity ok, ${rowsAfter} entries intact (was ${rowsBefore}). Backup: ${backup.replace(HOME, '~')}`, backup };
 }
 
-/** Drain the capture queue into rUv's learner — his tool, not ours. */
+/**
+ * Drain the capture queue into rUv's learner — his tool, not ours.
+ *
+ * ISSUE #104: this measured one queue and drained another, so it could only ever report "fed 0".
+ * The flusher was spawned with NO environment, so inside learn-flush.mjs RUVNET_LEARNING_SCOPE was
+ * unset and defaulted to 'project' — it drained `<project>/.swarm/ruvnet-brain-learn/` while THIS
+ * function counted `<user>/.cache/ruvnet-brain/learn/`. `before - after` was structurally 0: it
+ * could not report truthfully in either direction even on a flush that worked, and the real queue
+ * grew forever. Two independent defaults are not an agreement.
+ *
+ * So: resolve the scope ONCE, from the same policy module learn-flush reads, derive the queue root
+ * FROM that scope, pass the scope (and the exact queue file) to the child explicitly, and measure
+ * the root that was actually drained.
+ *
+ * And LOOP. learn-flush feeds at most MAX_ACTIONS distinct actions per invocation and writes the
+ * remainder back on purpose (a SessionEnd hook must stay fast), so one call cannot drain a deep
+ * queue — the reporter needed 15 rounds for 293 entries. A single call would leave a queue that
+ * "flushes" every time and never empties, which is the same lie in slow motion.
+ */
 function flushLearning() {
   const flusher = path.join(HOME, '.claude', 'plugins', 'marketplaces', 'ruvnet-brain', 'plugin', 'scripts', 'learn-flush.mjs');
-  const local = path.join(process.cwd(), 'plugin', 'scripts', 'learn-flush.mjs');
+  const local = path.join(PROJECT, 'plugin', 'scripts', 'learn-flush.mjs');
   const script = fs.existsSync(flusher) ? flusher : (fs.existsSync(local) ? local : null);
   if (!script) return { ok: false, log: 'learn-flush.mjs not found — cannot drain the queue' };
 
-  const queueDir = path.join(HOME, '.cache', 'ruvnet-brain', 'learn');
-  const depth = () => {
-    try {
-      return fs.readdirSync(queueDir).filter((f) => f.endsWith('.jsonl'))
-        .reduce((n, f) => n + fs.readFileSync(path.join(queueDir, f), 'utf8').split('\n').filter(Boolean).length, 0);
-    } catch { return 0; }
+  const configured = process.env.RUVNET_LEARNING_SCOPE
+    || loadRuntimePreferences({ cwd: PROJECT }).values.learningScope;
+  const scope = ['off', 'project', 'user'].includes(configured) ? configured : 'project';
+  if (scope === 'off') {
+    return { ok: true, noop: true, log: 'learning is switched off for this project — nothing is being captured, so there is nothing to feed' };
+  }
+
+  // Derived from the scope, never assumed: this is the directory the child will actually read.
+  const queueDir = scope === 'user'
+    ? path.join(HOME, '.cache', 'ruvnet-brain', 'learn')
+    : path.join(PROJECT, '.swarm', 'ruvnet-brain-learn');
+  const where = queueDir.replace(HOME, '~');
+
+  const queueFiles = () => {
+    try { return fs.readdirSync(queueDir).filter((f) => f.endsWith('.jsonl')).map((f) => path.join(queueDir, f)); }
+    catch { return []; }
   };
+  const depthOf = (f) => {
+    try { return fs.readFileSync(f, 'utf8').split('\n').filter(Boolean).length; } catch { return 0; }
+  };
+  const depth = () => queueFiles().reduce((n, f) => n + depthOf(f), 0);
+
   const before = depth();
-  try { execFileSync(process.execPath, [script], { stdio: 'ignore', timeout: 600_000 }); }
-  catch (e) { return { ok: false, log: `flush failed: ${e.message} — the queue is preserved for retry` }; }
+  if (!before) return { ok: true, noop: true, log: `nothing queued in ${where} — the learner is already caught up` };
+
+  const env = { ...process.env, RUVNET_LEARNING_SCOPE: scope, RUVNET_BRAIN_PROJECT_DIR: PROJECT };
+  const deadline = Date.now() + 540_000; // inside the 600s this action is allowed overall
+  const stalled = [];
+  for (const file of queueFiles()) {
+    let d = depthOf(file);
+    while (d > 0 && Date.now() < deadline) {
+      try {
+        execFileSync(process.execPath, [script], {
+          env: { ...env, LEARN_QUEUE: file },
+          stdio: 'ignore',
+          timeout: Math.min(120_000, Math.max(1_000, deadline - Date.now())),
+        });
+      } catch (e) { stalled.push(`${path.basename(file)}: ${String(e.message).split('\n')[0].slice(0, 80)}`); break; }
+      const next = depthOf(file);
+      // STRICT progress, or stop. learn-flush KEEPS a queue it could not feed (by design — the queue
+      // is evidence), so a round that shrinks nothing means the learner is not accepting the work.
+      // Spinning on it would burn the whole budget and still report zero.
+      if (next >= d) { stalled.push(`${path.basename(file)}: ${d} entr${d === 1 ? 'y' : 'ies'} would not feed`); break; }
+      d = next;
+    }
+  }
+
   const after = depth();
-  return { ok: true, log: `fed ${Math.max(0, before - after)} captured events into the learner (queue ${before} → ${after})` };
+  const fed = before - after;
+  if (fed <= 0) {
+    // Name the most likely cause instead of shrugging: learn-flush invokes ruflo at a FIXED path,
+    // so on a machine with a different npm prefix it feeds nothing and honestly keeps the queue.
+    const rufloAtFixedPath = fs.existsSync(path.join(HOME, '.npm-global/bin/ruflo'));
+    const why = stalled.length ? ` (${stalled.slice(0, 3).join('; ')})` : '';
+    const hint = rufloAtFixedPath ? '' : ' ruflo is not at ~/.npm-global/bin/ruflo, which is where the flusher looks for it —'
+      + ' `npm i -g ruflo@latest` installs it there.';
+    return { ok: false, log: `fed 0 of ${before} queued events from ${where}${why} — the queue is preserved for retry.${hint}` };
+  }
+  return {
+    ok: true,
+    log: `fed ${fed} captured events into the ${scope} learner (queue ${before} → ${after} in ${where})`
+      + (after ? ` — ${after} remain and will drain on the next flush` : ''),
+  };
 }
 
 /** One training cycle, via rUv's own CLI, in the GLOBAL (cross-project) learner. */

--- a/scripts/health-repair.mjs
+++ b/scripts/health-repair.mjs
@@ -133,7 +133,11 @@ function flushLearning() {
   const queueDir = scope === 'user'
     ? path.join(HOME, '.cache', 'ruvnet-brain', 'learn')
     : path.join(PROJECT, '.swarm', 'ruvnet-brain-learn');
-  const where = queueDir.replace(HOME, '~');
+  // Displayed to a human and matched by tests, so it is normalised to forward slashes on every
+  // platform. Without this, Windows reports `~\.cache\ruvnet-brain\learn` while macOS and Linux
+  // report `~/.cache/ruvnet-brain/learn` — the same location under two spellings, which is the
+  // exact defect class this branch has been closing (one fact, two representations).
+  const where = queueDir.replace(HOME, '~').split(path.sep).join('/');
 
   const queueFiles = () => {
     try { return fs.readdirSync(queueDir).filter((f) => f.endsWith('.jsonl')).map((f) => path.join(queueDir, f)); }

--- a/scripts/host-install-matrix.mjs
+++ b/scripts/host-install-matrix.mjs
@@ -1,0 +1,152 @@
+// host-install-matrix.mjs — ONE definition of "install this artifact into clean hosts and judge it".
+//
+// WHY THIS EXISTS. Two harnesses did this same job and disagreed about almost everything:
+//
+//   scripts/staged-host-verifier.mjs        scripts/publication-receipt.mjs (installHosts)
+//   ─────────────────────────────────       ────────────────────────────────────────────────
+//   modes: claude / codex / dual            modes: claudeOnly / codexOnly / dual
+//   --local … --no-selfcheck                --version v<X>  (no --local, selfcheck ON)
+//   RUVNET_CLAUDE_MARKETPLACE_SOURCE        RUVNET_STRICT_INSTALL=1
+//   RUVNET_CODEX_HOOK_TRUST_MODE=bypass     RUVNET_BRAIN_PROFILE=complete
+//
+// They could not even be compared: one produced `fixtures.claude`, the other `hosts.claudeOnly`,
+// for the identical fixture. So "the hosts passed" meant two different things depending on which
+// half of the release you asked, and nothing in the system could notice they had drifted apart.
+//
+// Some of that difference is REAL and must survive: a STAGED check runs before publication against
+// local bytes, so it points the marketplace at the unpacked package and skips selfcheck; a
+// PUBLISHED check runs after, against what npm actually serves, so it resolves by version and
+// installs strictly. That is one axis with two values — a parameter. Everything else was accident.
+//
+// So: the modes are named once, the loop is written once, the verdict is classified once, and the
+// only thing a caller chooses is which VARIANT it is running. Same shape as
+// scripts/console-runtime-identity.mjs, where one enumeration serves both the copy list and the
+// digest — a fact stated once cannot drift from itself.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/** The three host shapes a release must survive. ONE name each, for every consumer. */
+export const HOST_MODES = Object.freeze(['claude', 'codex', 'dual']);
+
+/** Which CLIs each mode is allowed to see. A codex-only box genuinely has no `claude`. */
+export const MODE_HOSTS = Object.freeze({
+  claude: ['claude'],
+  codex: ['codex'],
+  dual: ['claude', 'codex'],
+});
+
+/**
+ * The published-side receipt has always spelled these `claudeOnly` / `codexOnly` / `dual`, and that
+ * name is baked into current-release.json and every receipt already published — renaming it would
+ * invalidate history for a cosmetic win. So the two spellings are reconciled HERE, once, instead of
+ * being silently different in two files. `publication.installed.claudeOnly` and `fixtures.claude`
+ * are now provably the same fixture, which is what made the two halves of a release incomparable.
+ */
+export const RECEIPT_MODE_NAMES = Object.freeze({ claude: 'claudeOnly', codex: 'codexOnly', dual: 'dual' });
+export const MODE_FROM_RECEIPT_NAME = Object.freeze({ claudeOnly: 'claude', codexOnly: 'codex', dual: 'dual' });
+
+/**
+ * The two genuinely different questions, declared once instead of implied by two files.
+ *
+ * `staged`    — before publication, against local bytes. The marketplace is pointed at the unpacked
+ *               package because nothing is on npm yet, and selfcheck is skipped for the same reason.
+ * `published` — after publication, against what npm actually serves. Resolves by version and
+ *               installs strictly, because this is the run that must match a stranger's machine.
+ */
+export const VARIANTS = Object.freeze({
+  staged: Object.freeze({
+    installerArgs: (_v) => ['--local', '--yes', '--force', '--no-nightly-prompt',
+      '--no-telemetry', '--no-stack', '--no-enhance', '--no-statusline', '--no-selfcheck'],
+    env: ({ packageRoot }) => ({
+      RUVNET_CLAUDE_MARKETPLACE_SOURCE: packageRoot,
+      RUVNET_CODEX_HOOK_TRUST_MODE: 'bypass',
+    }),
+  }),
+  published: Object.freeze({
+    installerArgs: (version) => ['--yes', '--force', '--version', `v${version}`, '--no-nightly-prompt',
+      '--no-telemetry', '--no-stack', '--no-enhance', '--no-statusline'],
+    env: () => ({
+      RUVNET_STRICT_INSTALL: '1',
+      RUVNET_BRAIN_PROFILE: 'complete',
+    }),
+  }),
+});
+
+/** A doctor run is ACCEPTED only on a clean exit. One rule, not one per harness. */
+export function classifyDoctor(result) {
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  if (!result.error && result.status === 0) return { accepted: true, status: 'PASS', output };
+  return { accepted: false, status: 'FAIL', output };
+}
+
+/** Build a PATH exposing only the CLIs this mode is entitled to see. */
+export function fixturePath(mode, temp, locate) {
+  const bin = path.join(temp, `bin-${mode}`);
+  fs.mkdirSync(bin, { recursive: true });
+  for (const name of ['node', 'npm', ...MODE_HOSTS[mode]]) {
+    const target = locate(name);
+    if (!target) throw new Error(`${name} CLI unavailable for the ${mode} host fixture`);
+    fs.symlinkSync(target, path.join(bin, name));
+  }
+  return `${bin}:/usr/bin:/bin`;
+}
+
+/**
+ * Install `packageRoot` into a clean HOME per mode and run its doctor. Returns a result for EVERY
+ * mode — including the ones that failed — because "which host broke" is the whole diagnostic value,
+ * and the previous harnesses threw on the first failure and lost the rest.
+ *
+ * @returns {{verdict:'PASS'|'FAIL', fixtures:Record<string,object>, error?:string}}
+ */
+export function runHostMatrix({ packageRoot, version, variant = 'staged', locate, temp, run = spawnSync }) {
+  const spec = VARIANTS[variant];
+  if (!spec) throw new Error(`unknown host-matrix variant: ${variant}`);
+  const workspace = temp || fs.mkdtempSync(path.join(os.tmpdir(), 'ruvnet-host-matrix-'));
+  const installer = path.join(packageRoot, 'bin', 'install.mjs');
+  const fixtures = {};
+  let verdict = 'PASS';
+  let error;
+
+  for (const mode of HOST_MODES) {
+    try {
+      const home = path.join(workspace, `home-${mode}`);
+      const codexHome = path.join(home, '.codex');
+      const brainHome = path.join(home, '.cache', 'ruvnet-brain');
+      fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+      if (mode !== 'claude') fs.mkdirSync(codexHome, { recursive: true });
+      const env = {
+        ...process.env,
+        HOME: home,
+        CODEX_HOME: codexHome,
+        RUVNET_BRAIN_HOME: brainHome,
+        RUVNET_BRAIN_KB: path.join(brainHome, 'kb'),
+        CI: 'true',
+        PATH: fixturePath(mode, workspace, locate),
+        ...spec.env({ packageRoot }),
+      };
+      const install = run(process.execPath, [installer, ...spec.installerArgs(version)], {
+        cwd: packageRoot, env, encoding: 'utf8', timeout: 1_200_000, maxBuffer: 32 * 1024 * 1024,
+      });
+      if (install.error || install.status !== 0) {
+        throw new Error(`install failed for ${mode}: ${(install.stderr || install.error?.message || '').slice(-4000)}`);
+      }
+      const doctor = run(process.execPath, [installer, '--doctor', '--hooks'], {
+        cwd: packageRoot, env, encoding: 'utf8', timeout: 300_000, maxBuffer: 32 * 1024 * 1024,
+      });
+      const classified = classifyDoctor(doctor);
+      fixtures[mode] = { status: classified.status, doctorExit: doctor.status, version };
+      if (!classified.accepted) {
+        verdict = 'FAIL';
+        fixtures[mode].output = classified.output.slice(-5000);
+        error = error || `doctor failed for ${mode}`;
+      }
+    } catch (e) {
+      verdict = 'FAIL';
+      fixtures[mode] = { status: 'FAIL', error: e.message };
+      error = error || e.message;
+    }
+  }
+  return error ? { verdict, fixtures, error } : { verdict, fixtures };
+}

--- a/scripts/host-install-matrix.mjs
+++ b/scripts/host-install-matrix.mjs
@@ -140,7 +140,10 @@ export function runHostMatrix({ packageRoot, version, variant = 'staged', locate
       if (!classified.accepted) {
         verdict = 'FAIL';
         fixtures[mode].output = classified.output.slice(-5000);
-        error = error || `doctor failed for ${mode}`;
+        // The output belongs IN the error. The previous harness put it there and I dropped it in
+        // the consolidation, so CI reported a bare "doctor failed for claude" and the one thing
+        // needed to act on it — what the doctor actually said — was thrown away.
+        error = error || `doctor failed for ${mode} (exit ${doctor.status}): ${classified.output.slice(-4000)}`;
       }
     } catch (e) {
       verdict = 'FAIL';

--- a/scripts/memory-doctor.mjs
+++ b/scripts/memory-doctor.mjs
@@ -41,6 +41,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { canonicalPath, pathIdentity } from '../plugin/scripts/project-identity.mjs';
 
 const HOME = os.homedir();
 const DEFAULT_SCAN_ROOTS = ['Code', 'code', 'src', 'source', 'projects', 'dev', 'work'];
@@ -132,10 +133,6 @@ const q = (db, sql) => {
 // n() returns null for "unknown" and a number only when we genuinely counted. Callers must handle null.
 const n = (r) => (r.ok ? (r.value === null || r.value === '' ? null : parseInt(r.value, 10)) : null);
 
-function realExisting(value) {
-  try { return fs.realpathSync(value); } catch { return null; }
-}
-
 export function candidateRoots({
   home = HOME,
   configPath = path.join(home, '.claude', 'ruvnet-brain', 'config.json'),
@@ -150,13 +147,18 @@ export function candidateRoots({
     }
   } catch { /* absent or malformed config does not erase the common roots */ }
 
-  const roots = new Set();
+  // Keyed by pathIdentity, not by the spelling. DEFAULT_SCAN_ROOTS deliberately lists both `Code`
+  // and `code` so neither convention is missed, and on a case-insensitive volume those are ONE
+  // directory — which the old Set-of-strings admitted twice and then scanned, counted and summed
+  // twice (#107). On a case-sensitive volume they are two inodes and both are still kept.
+  const roots = new Map();
   const addRoot = (value) => {
     const absolute = path.isAbsolute(value) ? value : path.join(home, value);
-    const canonical = realExisting(absolute);
+    const canonical = canonicalPath(absolute);
     try {
       if (canonical && fs.statSync(canonical).isDirectory()) {
-        roots.add(canonical);
+        const identity = pathIdentity(canonical) ?? canonical;
+        if (!roots.has(identity)) roots.set(identity, canonical);
         return true;
       }
     } catch { /* missing/non-directory roots are not candidates on this machine */ }
@@ -170,12 +172,14 @@ export function candidateRoots({
   if (configuredCount > 0 && validConfigured === 0) {
     throw new Error('configured scanRoots contain no existing directories');
   }
-  return [...roots].sort();
+  return [...roots.values()].sort();
 }
 
+// Keyed by pathIdentity for the same reason candidateRoots is: one store reached by two names is
+// one store. Values are the canonical spelling, which is what every caller reads back.
 function storesBelow(root) {
-  const out = new Set();
-  const canonicalRoot = realExisting(root);
+  const out = new Map();
+  const canonicalRoot = canonicalPath(root);
   if (!canonicalRoot) return out;
   const walk = (dir, depth) => {
     if (depth > 4) return;
@@ -186,8 +190,8 @@ function storesBelow(root) {
       if (e.name === 'node_modules' || e.name === '.git') continue;
       if (e.name === '.swarm') {
         const db = path.join(dir, '.swarm/memory.db');
-        const canonical = realExisting(db);
-        if (canonical) out.add(canonical);
+        const canonical = canonicalPath(db);
+        if (canonical) out.set(pathIdentity(canonical) ?? canonical, canonical);
         continue;
       }
       if (e.name.startsWith('.') && e.name !== '.swarm') continue;
@@ -199,22 +203,21 @@ function storesBelow(root) {
 }
 
 export function findStores(root) {
-  const out = new Set();
+  const out = new Map();
+  const collect = (found) => { for (const [identity, db] of found) if (!out.has(identity)) out.set(identity, db); };
   if (root !== undefined) {
-    for (const db of storesBelow(root)) out.add(db);
-    return [...out].sort();
+    collect(storesBelow(root));
+    return [...out.values()].sort();
   }
 
-  for (const candidate of candidateRoots()) {
-    for (const db of storesBelow(candidate)) out.add(db);
-  }
+  for (const candidate of candidateRoots()) collect(storesBelow(candidate));
   // These two stores intentionally sit outside the project-root convention. They belong only to
   // the fleet-wide no-argument scan; an explicit root must remain genuinely scoped.
   for (const extra of [path.join(HOME, '.claude/.swarm/memory.db'), path.join(HOME, 'cognitum-trader/.swarm/memory.db')]) {
-    const canonical = realExisting(extra);
-    if (canonical) out.add(canonical);
+    const canonical = canonicalPath(extra);
+    if (canonical) collect([[pathIdentity(canonical) ?? canonical, canonical]]);
   }
-  return [...out].sort();
+  return [...out.values()].sort();
 }
 
 export function displayStoreName(db, home = HOME) {

--- a/scripts/memory-doctor.mjs
+++ b/scripts/memory-doctor.mjs
@@ -221,9 +221,9 @@ export function findStores(root) {
 }
 
 export function displayStoreName(db, home = HOME) {
-  const canonicalDb = realExisting(db) || path.resolve(db);
+  const canonicalDb = canonicalPath(db) || path.resolve(db);
   const project = path.dirname(path.dirname(canonicalDb));
-  const canonicalHome = realExisting(home) || path.resolve(home);
+  const canonicalHome = canonicalPath(home) || path.resolve(home);
   const relative = path.relative(canonicalHome, project);
   if (relative === '') return '~';
   if (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) {

--- a/scripts/model-router-catalog.mjs
+++ b/scripts/model-router-catalog.mjs
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 // Managed facts are additive for existing users. Their existing row is the user overlay: it wins
 // byte-for-byte, including disablement, tier/priority changes, and local candidates. Newly shipped
 // metered rows are not auto-added; that would silently expand spend authority.
@@ -13,4 +16,35 @@ export function mergeManagedCatalog(existing, managed) {
     candidates: [...current, ...additions],
   };
   return JSON.stringify(next) === JSON.stringify(existing) ? existing : next;
+}
+
+// Issue #87: the merge above was correct but reachable only from offerRouterProfile(), which runs on
+// the FRESH-INSTALL path alone. `--update` (and therefore Evergreen nightly) never called it, so the
+// one population that needs managed additions — users who already have ~/.claude/model-router/
+// catalog.json — could never acquire a newly shipped managed model. This is that same merge as a
+// non-interactive, idempotent step the update path can call: no prompts, no TEST_MODE gate, backs the
+// user's file up before it writes, and replaces it by atomic rename so a crash can never half-apply.
+export function applyManagedCatalogUpdate({ routerDir, packageRoot }) {
+  const template = path.join(packageRoot, 'config', 'model-router', 'catalog.template.json');
+  const target = path.join(routerDir, 'catalog.json');
+  if (!fs.existsSync(template)) return { action: 'skipped', added: [], detail: 'no managed template in this package' };
+  const managed = JSON.parse(fs.readFileSync(template, 'utf8'));
+  fs.mkdirSync(routerDir, { recursive: true });
+  if (!fs.existsSync(target)) {
+    fs.copyFileSync(template, target);
+    return { action: 'created', added: (managed.candidates || []).map((candidate) => candidate.id), detail: target };
+  }
+  const existing = JSON.parse(fs.readFileSync(target, 'utf8'));
+  const merged = mergeManagedCatalog(existing, managed);
+  if (merged === existing) return { action: 'unchanged', added: [], detail: target };
+  const before = new Set((existing.candidates || []).map((candidate) => candidate.id));
+  fs.copyFileSync(target, `${target}.pre-managed-merge`);
+  const staged = `${target}.tmp-${process.pid}`;
+  fs.writeFileSync(staged, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(staged, target);
+  return {
+    action: 'merged',
+    added: merged.candidates.filter((candidate) => !before.has(candidate.id)).map((candidate) => candidate.id),
+    detail: target,
+  };
 }

--- a/scripts/onboarding-console.mjs
+++ b/scripts/onboarding-console.mjs
@@ -32,6 +32,7 @@ import { buildStackRecommendations, buildWiringRecommendations, summarizeWiring,
 import { planFor } from './remedy-registry.mjs';
 import { auditAll as capabilityAuditAll } from './capability-registry.mjs';
 import { getVersion } from './version.mjs';
+import { consoleRuntimeDigest } from './console-runtime-identity.mjs';
 // L5 (ADR-028): the audit is the one place that observes live capability state, so it is where an
 // OFFERED-then-now-`on` transition becomes an APPLIED — the numerator of the precision metric that
 // tells the owner whether advocacy is landing or nagging. Both are pure reads/appends and never throw.
@@ -106,7 +107,12 @@ const RUNTIME_PRODUCT = 'ruvnet-brain-console';
 const RUNTIME_SCHEMA = 1;
 const RUNTIME_API_CONTRACT = 1;
 const RUNTIME_SCRIPT = fs.realpathSync(fileURLToPath(import.meta.url));
-const RUNTIME_SOURCE_SHA256 = crypto.createHash('sha256').update(fs.readFileSync(RUNTIME_SCRIPT)).digest('hex');
+// The generation this process IS, derived from every byte it executes and serves — not from this one
+// file. #79: a Console whose entrypoint was unchanged but whose imported modules and frontend had been
+// replaced reported the same identity as the candidate that replaced it, so the launcher reused a
+// pre-update router behind a post-update page. Same function, same surface, same list as the installer
+// stages (scripts/console-runtime-identity.mjs), so the two halves of this fact cannot drift.
+const RUNTIME_SOURCE_SHA256 = consoleRuntimeDigest(REPO);
 
 function consoleCandidateRoots() {
   return candidateRoots({ home: CONSOLE_ROOT, configPath: CONFIG_PATH });

--- a/scripts/onboarding-console.mjs
+++ b/scripts/onboarding-console.mjs
@@ -67,6 +67,9 @@ import {
   saveOpenRouterCredential,
 } from '../plugin/scripts/runtime-preferences.mjs';
 import { applyNightlyChoice, nightlyStatus } from './nightly-controller.mjs';
+// One canonical answer to "which directory is this, and have I counted it already?" — shared with
+// the PreCompact snapshot producer (#85) and with memory-doctor's root scan (#107).
+import { canonicalPath, pathIdentity, projectDirectory } from '../plugin/scripts/project-identity.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.dirname(__dirname);
@@ -110,7 +113,7 @@ function consoleCandidateRoots() {
 }
 
 function canonicalScope(cwd = process.cwd()) {
-  try { return fs.realpathSync(cwd); } catch { return path.resolve(cwd); }
+  return canonicalPath(cwd) ?? path.resolve(cwd);
 }
 
 function runtimeReceiptPath(cwd = process.cwd()) {
@@ -381,7 +384,7 @@ function wiringSurvey() {
   const projects = [];
   for (const root of consoleCandidateRoots()) {
     for (const proj of findProjects(root)) {
-      const resolved = path.resolve(proj);
+      const resolved = pathIdentity(proj) ?? path.resolve(proj);
       if (seenProjects.has(resolved)) continue;
       seenProjects.add(resolved);
       projects.push({ proj, root });
@@ -494,8 +497,12 @@ function scanFleet() {
   return fleet;
 }
 function gatherMemory(cwd, { fleet = true } = {}) {
-  // health = for the project the console was launched from (fall back to this repo)
-  const project = fs.existsSync(path.join(cwd, '.swarm/memory.db')) ? cwd : REPO;
+  // health = for the project the console was launched from (fall back to this repo). The scope is
+  // resolved through projectDirectory() — the same call the PreCompact producer makes — so a console
+  // launched from a subdirectory probes the project root the hook actually wrote to, instead of
+  // warning that a snapshot it can see on disk does not exist (#85).
+  const scope = projectDirectory({ cwd });
+  const project = fs.existsSync(path.join(scope, '.swarm/memory.db')) ? scope : REPO;
   const projName = project.replace(CONSOLE_ROOT + '/Code/', '').replace(CONSOLE_ROOT + '/', '~/');
   const health = scoreMemoryHealth({ project: projName, probes: probeMemory(project) });
   return { fleet: fleet ? scanFleet() : null, health };
@@ -1588,8 +1595,11 @@ function refreshFleetCache() {
   // machine whose projects live under ~/source instead of ~/Code.
   for (const root of consoleCandidateRoots()) {
     for (const s of findMemoryStores(root)) {
-      const resolved = path.resolve(s.project);
-      if (seen.has(resolved)) continue; // a project visible under two roots (e.g. a symlink) counts once
+      // pathIdentity, not path.resolve: resolve() normalises `.`/`..` and nothing else, so a project
+      // reached through a symlink OR through the other capitalisation of a case-insensitive volume
+      // was two distinct strings for one directory, and its memories were summed twice (#107).
+      const resolved = pathIdentity(s.project) ?? path.resolve(s.project);
+      if (seen.has(resolved)) continue; // a project visible under two roots counts once
       seen.add(resolved);
       const n = Number(robustRead(s.db, "SELECT COUNT(*) FROM memory_entries WHERE status='active'").value || 0);
       if (n > 0) {
@@ -2211,7 +2221,7 @@ function currentValidIds(onlyId = null) {
   // offering nothing to do about it — detection without a remedy, which ADR-027 prohibits.
   if (validateAll || healthOnly) {
     try {
-      const project = process.cwd();
+      const project = projectDirectory();
       const health = scoreMemoryHealth({ project: path.basename(project), probes: probeMemory(project) });
       for (const r of buildHealthRecommendations({ memory: health, learning: observeLearning() })) ids.add(r.id);
     } catch { /* an advisory surface must never break the apply path */ }
@@ -2923,7 +2933,8 @@ if (process.argv[1] && path.resolve(process.argv[1]).endsWith('onboarding-consol
       const fleet = scanFleet();
       let recommendations = [];
       try {
-        const health = scoreMemoryHealth({ project: path.basename(process.cwd()), probes: probeMemory(process.cwd()) });
+        const project = projectDirectory();
+        const health = scoreMemoryHealth({ project: path.basename(project), probes: probeMemory(project) });
         recommendations = buildHealthRecommendations({ memory: health, learning: { ...observeLearning(), fleet } });
       } catch { /* advisory only */ }
       writeCache(MEMORY_CACHE, new Date().toISOString(), { fleet, recommendations }, process.cwd());

--- a/scripts/onboarding-console.mjs
+++ b/scripts/onboarding-console.mjs
@@ -1742,7 +1742,12 @@ function gatherRouterEngine() {
   const subscriptions = detectSubscriptions();
   let house;
   let providerKeys = providerAvailability(null, subscriptions);
-  let providerCatalog = { status: 'degraded', detail: 'provider catalog was not loaded; native boolean detections are shown' };
+  // `keysVerified` is the machine-readable half of `status`, and it is the field every consumer must
+  // consult BEFORE presenting `keys` as a fact about the user's machine (issue #86). `status` alone
+  // was published and then ignored: the Console rendered a confident "✗ no API key found" per
+  // provider straight off `keys`, so a missing catalog asset — an internal packaging failure — was
+  // shown to the user as a verified finding about their credentials. Unknown outranks off.
+  let providerCatalog = { status: 'degraded', keysVerified: false, detail: 'provider catalog was not loaded; native boolean detections are shown' };
   try {
     const hcat = loadCatalog();
     house = detectProvider(hcat, { provider: cfg.provider });
@@ -1752,10 +1757,10 @@ function gatherRouterEngine() {
     // run-context markers (which are not credentials), exactly as detectProvider() itself filters them —
     // so the UI's "key found / not found" is now true instead of decorative.
     providerKeys = providerAvailability(hcat, subscriptions);
-    providerCatalog = { status: 'ok', detail: 'verified provider catalog loaded' };
+    providerCatalog = { status: 'ok', keysVerified: true, detail: 'verified provider catalog loaded' };
   } catch (error) {
     house = { provider: cfg.provider && cfg.provider !== 'auto' ? cfg.provider : 'anthropic', source: 'default' };
-    providerCatalog = { status: 'degraded', detail: `provider catalog unavailable: ${String(error?.message || error)}` };
+    providerCatalog = { status: 'degraded', keysVerified: false, detail: `provider catalog unavailable: ${String(error?.message || error)}` };
   }
   return {
     engine: {

--- a/scripts/publication-receipt.mjs
+++ b/scripts/publication-receipt.mjs
@@ -8,6 +8,13 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import { spawn, spawnSync } from 'node:child_process';
+// ONE doctor rule and ONE mode vocabulary, shared with the staged-side check in
+// scripts/staged-host-verifier.mjs. This file kept its own copies, spelled claudeOnly/
+// codexOnly/dual against the other's claude/codex/dual, so `hosts.claudeOnly` and
+// `fixtures.claude` described the same fixture and nothing could tell. The richer
+// post-publication proofs below (payload assertions, MCP wiring, SOURCE.json, rpcSearch)
+// stay here — they are this side's job, not duplication.
+import { HOST_MODES, RECEIPT_MODE_NAMES, MODE_FROM_RECEIPT_NAME, classifyDoctor } from './host-install-matrix.mjs';
 import { pathToFileURL } from 'node:url';
 import { evaluateCandidateReceipt, evaluatePublicationReceipt } from './release-proof.mjs';
 import { verifyPayload } from './release-payload.mjs';
@@ -210,7 +217,9 @@ export function livePublicationAdapter({ root = process.cwd() } = {}) {
       const sealedPlugin = path.join(packageRoot, 'plugin');
       const results = {};
       let bundle = null;
-      for (const mode of ['claudeOnly', 'codexOnly', 'dual']) {
+      // Derived from HOST_MODES, so a fourth host shape is added in ONE place and this loop
+      // cannot fall behind the staged-side check the way it did.
+      for (const mode of HOST_MODES.map((m) => RECEIPT_MODE_NAMES[m])) {
         const home = path.join(temp, `home-${mode}`);
         const codexHome = path.join(home, '.codex');
         const brainHome = path.join(home, '.cache', 'ruvnet-brain');

--- a/scripts/release-transaction-provider.mjs
+++ b/scripts/release-transaction-provider.mjs
@@ -341,9 +341,34 @@ export function liveReleaseProvider({
       if (current !== expected) throw new Error(`refusing compensation: npm latest is ${current}, expected ${expected}`);
       command('npm', ['dist-tag', 'add', `${PACKAGE}@${prior}`, 'latest']);
     },
-    async finalize(identity, receipt, _hostVerifier) {
+    async finalize(identity, receipt, hostVerifier) {
       if (!candidateReceipt || !publicationReceipt) {
         throw new Error('final convergence requires candidate and publication receipt paths');
+      }
+      // THE HOST VERDICT IS MEASURED, NOT DECLARED — and it is measured FIRST.
+      //
+      // finalize() used to accept the verifier as `_hostVerifier` and ignore it, then build
+      // `hosts = { verdict: 'PASS', … }` as a literal. Every release therefore asserted host
+      // convergence with no host verified, while tests/helpers/release-transaction-fixture.mjs:153
+      // called the seam faithfully — a fault-injection suite certifying wiring the real publisher
+      // never ran. Fable 5 and GPT-5.6-Sol independently made this their #1 finding.
+      //
+      // It runs BEFORE publication and sealing because the order encodes the meaning: you seal a
+      // release you have verified, not the reverse. It is also the cheapest way to fail — an
+      // unusable artifact stops here instead of after a 20-minute publish.
+      if (!hostVerifier || typeof hostVerifier.verify !== 'function') {
+        return { verdict: 'FAIL', hostVerifierError: 'no host verifier was supplied to finalize' };
+      }
+      // No `assets` override: stagedHostVerifier is constructed in release.mjs:238 with the exact
+      // staged bytes for this candidate and defaults to them (staged-host-verifier.mjs:57), so
+      // passing nothing is what keeps production verifying the artifact actually being shipped.
+      const verified = await hostVerifier.verify({ source: 'final', identity });
+      if (verified.verdict !== 'PASS') {
+        return {
+          verdict: 'FAIL',
+          hosts: { verdict: verified.verdict, verifier: { error: verified.error, fixtures: verified.fixtures } },
+          previousReceiptDigest: receipt.receiptDigest,
+        };
       }
       if (!fs.existsSync(path.resolve(root, publicationReceipt))) {
         const publication = spawnSync(process.execPath, [
@@ -360,11 +385,14 @@ export function liveReleaseProvider({
         return { verdict: 'FAIL', sealError: String(seal.stderr || seal.error?.message) };
       }
       const publication = JSON.parse(fs.readFileSync(path.resolve(root, publicationReceipt), 'utf8'));
+
+      // `verified` was measured at the top of finalize, before publication and sealing.
       const hosts = {
-        verdict: 'PASS',
+        verdict: verified.verdict,
         claudeOnly: publication.installed?.claudeOnly,
         codexOnly: publication.installed?.codexOnly,
         dual: publication.installed?.dual,
+        verifier: { artifactSha256: verified.artifactSha256, fixtures: verified.fixtures, error: verified.error },
       };
       const observed = publication.postPublicationChecks?.find(({ name }) => name === 'published-surface-probe');
       const result = {

--- a/scripts/rvf-generation.mjs
+++ b/scripts/rvf-generation.mjs
@@ -83,14 +83,31 @@ export function verifyRvfGenerations(dir, {
   releaseTag = getVersionTag(),
   requiredStores = [],
   allowMissingFiles = false,
+  verifyBytes = true,
 } = {}) {
   const manifest = readRvfGenerations(dir);
   const failures = [];
   if (manifest.brainVersion !== version) failures.push(`brainVersion=${manifest.brainVersion}, expected ${version}`);
   if (manifest.releaseTag !== releaseTag) failures.push(`releaseTag=${manifest.releaseTag}, expected ${releaseTag}`);
+  // `verifyBytes: false` verifies ONLY the committed ledger fields above.
+  //
+  // WHY: the `.rvf` binaries are gitignored (.gitignore:28 `kb/*.rvf`), so a byte comparison is a
+  // statement about the machine running the check, not about the commit being pushed. This ledger
+  // records 72 stores; a working checkout routinely has a different set — the nightly rebuilds RVFs
+  // and regenerates the ledger together (kb/forge-refresh.mjs:242), so between those two moments any
+  // developer tree disagrees. Wired into the pre-push gate this was unsatisfiable: it blocked EVERY
+  // push, including tags, and its own remedy line ("Run: node scripts/sync-version.mjs") could not
+  // clear it because the byte check lives under `if (CHECK)` and write mode never regenerates. That
+  // is what forced the 4.0.7 emergency promotion.
+  //
+  // release.mjs:100 already states the governing principle for this repo: "A verdict is only about
+  // the exact committed candidate." Bytes are verified where they are actually present and actually
+  // shipped — scripts/build-bundle.mjs:204-214, at bundle assembly — which is exactly what the
+  // deferral comment in sync-version.mjs promised but never had a caller for.
   for (const store of requiredStores) {
     if (!manifest.stores[store]) failures.push(`${store}: no generation record`);
   }
+  if (!verifyBytes) return { manifest, failures };
   for (const [store, generation] of Object.entries(manifest.stores)) {
     const file = path.join(dir, generation.file || `${store}.big.rvf`);
     if (!fs.existsSync(file)) {

--- a/scripts/staged-host-verifier.mjs
+++ b/scripts/staged-host-verifier.mjs
@@ -18,11 +18,9 @@ const run = (name, args, options) => {
   return result;
 };
 
-export function classifyDoctorResult(result) {
-  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
-  if (!result.error && result.status === 0) return { accepted: true, status: 'PASS', output };
-  return { accepted: false, status: 'FAIL', output };
-}
+// The doctor verdict has ONE rule, in host-install-matrix.mjs. This name is kept because
+// tests/unit/staged-host-verifier.test.mjs pins it, but it is now an alias, not a second copy.
+export { classifyDoctor as classifyDoctorResult } from './host-install-matrix.mjs';
 
 const preparePackage = ({ packagePath, bundlePath }) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ruvnet-staged-host-'));
@@ -39,62 +37,36 @@ const preparePackage = ({ packagePath, bundlePath }) => {
   return { temp, packageRoot };
 };
 
-const fixturePath = (mode, temp) => {
-  const bin = path.join(temp, `bin-${mode}`);
-  fs.mkdirSync(bin);
-  const hosts = mode === 'claude' ? ['claude'] : mode === 'codex' ? ['codex'] : ['claude', 'codex'];
-  const desired = ['node', 'npm', ...hosts];
-  for (const name of desired) {
-    const target = locate(name);
-    if (!target) throw new Error(`${name} CLI unavailable for ${mode} host fixture`);
-    fs.symlinkSync(target, path.join(bin, name));
-  }
-  return `${bin}:/usr/bin:/bin`;
-};
-
 export function stagedHostVerifier({ assets, identity }) {
   return {
     async verify({ source, assets: observedAssets = assets }) {
       const prepared = preparePackage(observedAssets);
-      const results = {};
       try {
-        for (const mode of ['claude', 'codex', 'dual']) {
-          const home = path.join(prepared.temp, `home-${mode}`);
-          const brainHome = path.join(home, '.cache', 'ruvnet-brain');
-          fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
-          if (mode !== 'claude') fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
-          const env = {
-            ...process.env,
-            HOME: home,
-            CODEX_HOME: path.join(home, '.codex'),
-            RUVNET_BRAIN_HOME: brainHome,
-            RUVNET_BRAIN_KB: path.join(brainHome, 'kb'),
-            RUVNET_CLAUDE_MARKETPLACE_SOURCE: prepared.packageRoot,
-            RUVNET_CODEX_HOOK_TRUST_MODE: 'bypass',
-            CI: 'true',
-            PATH: fixturePath(mode, prepared.temp),
-          };
-          const installer = path.join(prepared.packageRoot, 'bin', 'install.mjs');
-          run(process.execPath, [installer, '--local', '--yes', '--force', '--no-nightly-prompt',
-            '--no-telemetry', '--no-stack', '--no-enhance', '--no-statusline', '--no-selfcheck'], {
-            cwd: prepared.packageRoot, env, timeout: 1_200_000,
-          });
-          const doctor = spawnSync(process.execPath, [installer, '--doctor', '--hooks'], {
-            cwd: prepared.packageRoot, env, timeout: 180_000,
-          });
-          const classified = classifyDoctorResult(doctor);
-          if (!classified.accepted) {
-            throw new Error(`doctor failed for ${mode}: ${classified.output.slice(-5000) || doctor.error?.message}`);
-          }
-          results[mode] = {
-            status: classified.status,
-            doctorExit: doctor.status,
-            version: identity.version,
-          };
+        // The loop, the mode names, the env and the doctor verdict all live in
+        // scripts/host-install-matrix.mjs, shared with the published-side check in
+        // publication-receipt.mjs. This file used to carry its own copy, which had drifted to
+        // different mode names (claude/codex/dual vs claudeOnly/codexOnly/dual) and a different
+        // install shape than the one that runs after publication — so the two halves of a release
+        // were judging different things and could not be compared. Only the STAGED-vs-PUBLISHED
+        // difference is real, and it is now a named variant rather than a second implementation.
+        const matrix = runHostMatrix({
+          packageRoot: prepared.packageRoot,
+          version: identity.version,
+          variant: 'staged',
+          locate,
+          temp: prepared.temp,
+        });
+        if (matrix.verdict !== 'PASS') {
+          return { verdict: 'FAIL', source, error: matrix.error, fixtures: matrix.fixtures };
         }
-        return { verdict: 'PASS', source, artifactSha256: sha256(observedAssets.packagePath), fixtures: results };
+        return {
+          verdict: 'PASS',
+          source,
+          artifactSha256: sha256(observedAssets.packagePath),
+          fixtures: matrix.fixtures,
+        };
       } catch (error) {
-        return { verdict: 'FAIL', error: error.message, fixtures: results };
+        return { verdict: 'FAIL', source, error: error.message, fixtures: {} };
       } finally {
         fs.rmSync(prepared.temp, { recursive: true, force: true });
       }

--- a/scripts/staged-host-verifier.mjs
+++ b/scripts/staged-host-verifier.mjs
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { runHostMatrix } from './host-install-matrix.mjs';
 
 const sha256 = (file) => crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 const locate = (name) => {

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -113,16 +113,16 @@ for (const rel of ['kb/RVF-GENERATIONS.json']) {
 
 if (CHECK && fs.existsSync(path.join(ROOT, 'kb/RVF-GENERATIONS.json'))) {
   const kbDir = path.join(ROOT, 'kb');
-  const requiredStores = fs.readdirSync(kbDir)
-    .filter((file) => file.endsWith('.big.rvf'))
-    .map((file) => file.slice(0, -'.big.rvf'.length));
-  // CI/source-only clones intentionally omit the gitignored RVF binaries. In that shape, validate
-  // the committed ledger's version fields but defer byte checks to bundle assembly, where the RVFs
-  // are present. A checkout containing any canonical RVF remains fail-closed for every ledger row.
-  const { failures } = verifyRvfGenerations(kbDir, {
-    requiredStores,
-    allowMissingFiles: requiredStores.length === 0,
-  });
+  // Validate the committed ledger's version fields ONLY. The previous form scanned the working
+  // directory for `*.big.rvf` and byte-compared every ledger row against whatever this machine
+  // happened to have — but those binaries are gitignored, so the verdict described the machine, not
+  // the commit. It was unsatisfiable in practice (ledger: 72 stores; a real checkout: 71, because
+  // the nightly rebuilds RVFs and regenerates the ledger as one step) and it blocked every push,
+  // tags included, while pointing at a remedy that cannot clear it. Byte verification now happens
+  // where the bytes are genuinely present and genuinely shipped: scripts/build-bundle.mjs:204-214.
+  // This is the same rule release.mjs:100 already applies — a verdict is only about the committed
+  // candidate.
+  const { failures } = verifyRvfGenerations(kbDir, { verifyBytes: false });
   for (const failure of failures) {
     console.error(`[version] RVF GENERATION DRIFT: ${failure}`);
     drift++;

--- a/tests/integration/stale-install-trap.test.mjs
+++ b/tests/integration/stale-install-trap.test.mjs
@@ -53,6 +53,37 @@ function seedBrain(tag) {
 }
 
 /**
+ * Copy every LOCAL module the installer imports, transitively, preserving relative layout.
+ *
+ * This used to be a hand-written list — `kb/brain-profile.mjs`, `kb/model-requirements.mjs`,
+ * `scripts/model-router-catalog.mjs`. That is a second copy of a fact the installer already states
+ * in its own import block, and it drifted the moment a fourth import landed: #76/#79 added
+ * `scripts/console-runtime-identity.mjs`, the list did not know, and this test failed with
+ * ERR_MODULE_NOT_FOUND — reported as "expected 'node:internal/modules/esm/resolve:275…' to match
+ * /could not check/", which reads like an honesty regression rather than a missing file.
+ *
+ * Deriving the closure from the source means the fixture cannot fall behind the installer again.
+ * Node itself is the arbiter of what is missing, so a genuine packaging break still fails here.
+ */
+function copyLocalImportClosure(entry, fromRoot, toRoot, seen = new Set()) {
+  const abs = path.resolve(entry);
+  if (seen.has(abs) || !fs.existsSync(abs)) return;
+  seen.add(abs);
+  const src = fs.readFileSync(abs, 'utf8');
+  // static `from '…'` plus dynamic `import('…')`; relative specifiers only — bare ones are packages.
+  const specs = [...src.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]+)['"]/g)].map((m) => m[1]);
+  for (const spec of specs) {
+    const depAbs = path.resolve(path.dirname(abs), spec);
+    if (!depAbs.startsWith(fromRoot) || !fs.existsSync(depAbs)) continue;
+    const rel = path.relative(fromRoot, depAbs);
+    const dest = path.join(toRoot, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(depAbs, dest);
+    copyLocalImportClosure(depAbs, fromRoot, toRoot, seen);
+  }
+}
+
+/**
  * Run the installer. `breakLookup` copies it with the repo slug pointed at a nonexistent repo so
  * the real GitHub call genuinely 404s — exercising the fallback path rather than simulating it.
  */
@@ -66,13 +97,7 @@ function runInstaller({ breakLookup = false, latestTag } = {}) {
     const src = fs.readFileSync(INSTALLER, 'utf8')
       .replace("const REPO = 'stuinfla/ruvnet-brain';", "const REPO = 'stuinfla/definitely-not-a-real-repo-xyz';");
     fs.writeFileSync(script, src);
-    for (const sibling of ['brain-profile.mjs', 'model-requirements.mjs']) {
-      fs.copyFileSync(path.join(ROOT, 'kb', sibling), path.join(work, 'kb', sibling));
-    }
-    fs.copyFileSync(
-      path.join(ROOT, 'scripts', 'model-router-catalog.mjs'),
-      path.join(work, 'scripts', 'model-router-catalog.mjs'),
-    );
+    copyLocalImportClosure(INSTALLER, ROOT, work);
   }
   const res = spawnSync(process.execPath, [script, '--no-verify'], {
     encoding: 'utf8',

--- a/tests/mutation/install-selfcheck-consumption-mutation.test.mjs
+++ b/tests/mutation/install-selfcheck-consumption-mutation.test.mjs
@@ -37,6 +37,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { CONSOLE_RUNTIME_SURFACE } from '../../scripts/console-runtime-identity.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const REAL_INSTALLER = path.join(REPO, 'bin/install.mjs');
@@ -95,13 +96,16 @@ function buildScratchRoot({ mutateTo, includeRvf }) {
   for (const rel of ['kb/verify-citation.mjs', 'kb/brain-profile.mjs', 'kb/model-requirements.mjs']) {
     fs.copyFileSync(path.join(REPO, rel), path.join(root, rel));
   }
-  // installConsoleRuntime() is now part of the real installer contract. Mirror its
-  // required source surface so this mutation still reaches the self-check verdict
-  // it is designed to test instead of failing earlier on an incomplete fake package.
-  fs.cpSync(path.join(REPO, 'console'), path.join(root, 'console'), { recursive: true });
-  fs.cpSync(path.join(REPO, 'plugin', 'scripts'), path.join(root, 'plugin', 'scripts'), { recursive: true });
-  fs.copyFileSync(path.join(REPO, 'data', 'model-catalog.json'), path.join(root, 'data', 'model-catalog.json'));
-  fs.copyFileSync(path.join(REPO, 'package.json'), path.join(root, 'package.json'));
+  // installConsoleRuntime() is part of the real installer contract, so this fake package must carry
+  // the runtime surface or the mutation fails earlier than the self-check verdict it targets. Taken
+  // from the shipped list rather than copied into a fourth private enumeration of it — bin/install.mjs
+  // is the only file this fixture is allowed to differ on.
+  for (const relative of CONSOLE_RUNTIME_SURFACE) {
+    if (relative === 'bin/install.mjs') continue;   // the mutant, already written above
+    const target = path.join(root, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.cpSync(path.join(REPO, relative), target, { recursive: true });
+  }
 
   fs.cpSync(buildFixtureDir({ includeRvf }), path.join(root, 'dist', 'ruvnet-brain'), {
     recursive: true,

--- a/tests/unit/console-generation-identity.test.mjs
+++ b/tests/unit/console-generation-identity.test.mjs
@@ -1,0 +1,176 @@
+// Issue #79 — the Brain Console reused a stale detached server after updates and host restarts.
+//
+// The launcher already refuses a listener whose identity differs from the candidate's. The identity
+// itself was the hole: `sourceSha256` digested ONE file, scripts/onboarding-console.mjs, while the
+// runtime the server executes and serves is a whole surface of imported modules plus the frontend.
+// An ordinary update — a changed console-engine.mjs, a changed console/app.js — left the entrypoint
+// bytes untouched, so candidate B was indistinguishable from the A it replaced, the launcher printed
+// "already running", and the reporter got a post-update page in front of a pre-update router.
+//
+// The boundary here is the real one: a detached server started from a path, that path's bytes
+// atomically replaced underneath it by the installer, and a SEPARATE later process — the restarted
+// host session — deciding what is running.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { beginConsoleRuntimeTransaction, installConsoleRuntime } from '../../bin/install.mjs';
+import { consoleRuntimeDigest } from '../../scripts/console-runtime-identity.mjs';
+import { consoleFixtureEnvironment } from '../helpers/console-fixture-environment.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const temps = [];
+const children = new Set();
+
+function tempDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+async function freePort() {
+  const server = http.createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+function fixtureEnv(home, port) {
+  return consoleFixtureEnvironment(home, {
+    extras: { CONSOLE_PORT: String(port), RUVNET_CONSOLE_DISABLE_BACKGROUND_REFRESH: '1' },
+  });
+}
+
+function serve(script, home, cwd, port) {
+  const child = spawn(process.execPath, [script, '--serve'], {
+    cwd, env: fixtureEnv(home, port), stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.log = '';
+  child.stdout.on('data', (chunk) => { child.log += chunk; });
+  child.stderr.on('data', (chunk) => { child.log += chunk; });
+  children.add(child);
+  child.once('exit', () => children.delete(child));
+  return child;
+}
+
+function runtimeStatus(script, home, cwd, port) {
+  const run = spawnSync(process.execPath, [script, '--runtime-status'], {
+    cwd, env: fixtureEnv(home, port), encoding: 'utf8', timeout: 20_000,
+  });
+  if (run.status !== 0) throw new Error(`--runtime-status failed: ${run.stderr || run.status}`);
+  return JSON.parse(run.stdout);
+}
+
+async function waitFor(check, timeoutMs = 20_000) {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    const value = await check();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('timed out waiting for the Console runtime');
+}
+
+const liveIdentity = (port) => waitFor(async () => {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/runtime`);
+    return response.ok ? response.json() : null;
+  } catch { return null; }
+});
+
+/**
+ * A staged runtime is a valid candidate source — every surface path has the same relative location on
+ * both sides — so candidates are built from the shipped file manifest rather than a fixture's own list.
+ */
+function candidateFrom(runtime, mutate = () => {}) {
+  const source = path.join(tempDir('brain-generation-candidate-'), 'source');
+  fs.cpSync(runtime, source, { recursive: true });
+  mutate(source);
+  return source;
+}
+
+afterEach(async () => {
+  const live = [...children].filter((child) => child.exitCode === null);
+  for (const child of live) child.kill('SIGTERM');
+  await Promise.all(live.map((child) => new Promise((resolve) => {
+    const hard = setTimeout(() => child.kill('SIGKILL'), 2_000);
+    child.once('exit', () => { clearTimeout(hard); resolve(); });
+  })));
+  children.clear();
+  for (const dir of temps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('issue #79 Console generation identity', () => {
+  it('gives two candidates different identities when only an imported module changes', () => {
+    const seed = tempDir('brain-generation-seed-');
+    installConsoleRuntime(seed, REPO);
+    const a = candidateFrom(path.join(seed, '.console-runtime'));
+    // The reported failure exactly: the router's behaviour changes and the frontend changes, while
+    // scripts/onboarding-console.mjs — the file the old identity digested — does not.
+    const b = candidateFrom(a, (source) => {
+      fs.appendFileSync(path.join(source, 'scripts', 'console-engine.mjs'), '\nexport const CANDIDATE_B = true;\n');
+      fs.appendFileSync(path.join(source, 'console', 'app.js'), '\n/* candidate B */\n');
+    });
+    expect(fs.readFileSync(path.join(a, 'scripts', 'onboarding-console.mjs')))
+      .toEqual(fs.readFileSync(path.join(b, 'scripts', 'onboarding-console.mjs')));
+
+    const first = beginConsoleRuntimeTransaction(tempDir('brain-generation-a-'), a);
+    const second = beginConsoleRuntimeTransaction(tempDir('brain-generation-b-'), b);
+    try {
+      expect(first.identity.sourceSha256).not.toBe(second.identity.sourceSha256);
+    } finally {
+      first.rollback();
+      second.rollback();
+    }
+  });
+
+  it('replaces a detached server whose runtime was updated underneath it, with no host restart required', async () => {
+    const root = tempDir('brain-generation-boundary-');
+    const home = path.join(root, 'home');
+    const cwd = path.join(root, 'project');
+    const cache = path.join(root, 'cache');
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(cwd, { recursive: true });
+
+    const script = installConsoleRuntime(cache, REPO);
+    const runtime = path.join(cache, '.console-runtime');
+    const port = await freePort();
+    const detached = serve(script, home, cwd, port);
+    const beforeUpdate = await liveIdentity(port);
+
+    // The installer's staged identity and the server's self-reported identity are the same fact.
+    expect(beforeUpdate.pid).toBe(detached.pid);
+    expect(beforeUpdate.sourceSha256)
+      .toBe(JSON.parse(fs.readFileSync(path.join(runtime, 'runtime-identity.json'), 'utf8')).sourceSha256);
+    expect(runtimeStatus(script, home, cwd, port).state).toBe('current');
+
+    // THE UPDATE: the same installed path, atomically replaced with a candidate whose entrypoint is
+    // byte-identical. The detached server keeps its pre-update modules in memory and never notices.
+    const next = candidateFrom(runtime, (source) => {
+      fs.appendFileSync(path.join(source, 'scripts', 'console-engine.mjs'), '\nexport const CANDIDATE_B = true;\n');
+      fs.appendFileSync(path.join(source, 'console', 'app.js'), '\n/* candidate B */\n');
+    });
+    installConsoleRuntime(cache, next);
+    expect(fs.realpathSync(script)).toBe(fs.realpathSync(path.join(runtime, 'scripts', 'onboarding-console.mjs')));
+    expect(detached.exitCode).toBe(null);
+    expect((await liveIdentity(port)).pid).toBe(detached.pid);
+
+    // THE RESTART: a brand new process, from the same installed path, deciding what is running.
+    expect(runtimeStatus(script, home, cwd, port).state).toBe('stale-running');
+
+    const replacement = serve(script, home, cwd, port);
+    const afterUpdate = await waitFor(async () => {
+      const value = await liveIdentity(port).catch(() => null);
+      return value && value.pid === replacement.pid ? value : null;
+    });
+    expect(afterUpdate.pid).not.toBe(beforeUpdate.pid);
+    expect(afterUpdate.sourceSha256).not.toBe(beforeUpdate.sourceSha256);
+    expect(afterUpdate.sourceSha256).toBe(consoleRuntimeDigest(runtime));
+    await waitFor(() => detached.exitCode !== null);
+    expect(runtimeStatus(script, home, cwd, port).state).toBe('current');
+  }, 90_000);
+});

--- a/tests/unit/console-runtime-lifecycle.test.mjs
+++ b/tests/unit/console-runtime-lifecycle.test.mjs
@@ -5,6 +5,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { consoleRuntimeDigest } from '../../scripts/console-runtime-identity.mjs';
 
 const REPO = path.resolve(import.meta.dirname, '../..');
 const CONSOLE = path.join(REPO, 'scripts', 'onboarding-console.mjs');
@@ -34,7 +35,9 @@ function candidateIdentity(port) {
     scope: path.resolve(REPO),
     scriptRealpath: fs.realpathSync(CONSOLE),
     runtimeVersion: PACKAGE_VERSION,
-    sourceSha256: crypto.createHash('sha256').update(fs.readFileSync(CONSOLE)).digest('hex'),
+    // The generation is the whole runtime surface, not this one file (#79) — one definition, shared
+    // with the installer and the running server.
+    sourceSha256: consoleRuntimeDigest(REPO),
   };
 }
 

--- a/tests/unit/console-runtime-transaction.test.mjs
+++ b/tests/unit/console-runtime-transaction.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { CONSOLE_RUNTIME_SURFACE, consoleRuntimeDigest } from '../../scripts/console-runtime-identity.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const INSTALLER = path.join(ROOT, 'bin', 'install.mjs');
@@ -18,15 +19,15 @@ function temporary(prefix) {
   return value;
 }
 
+// The candidate is built from the shipped surface, not a list of this fixture's own. A second
+// enumeration is how the runtime came to carry plugin/scripts/whats-new.mjs without the assets it
+// reads (#76); a fixture that keeps its own copy of the list just relocates that failure into CI.
 function candidate(marker) {
   const root = temporary('brain-console-candidate-');
-  for (const relative of ['console', 'scripts', 'plugin/scripts']) {
-    fs.cpSync(path.join(ROOT, relative), path.join(root, relative), { recursive: true });
-  }
-  for (const relative of ['kb/brain-profile.mjs', 'bin/install.mjs', 'package.json', 'data/model-catalog.json']) {
+  for (const relative of CONSOLE_RUNTIME_SURFACE) {
     const target = path.join(root, relative);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.copyFileSync(path.join(ROOT, relative), target);
+    fs.cpSync(path.join(ROOT, relative), target, { recursive: true });
   }
   fs.appendFileSync(path.join(root, 'scripts', 'onboarding-console.mjs'), `\n// ${marker}\n`);
   return root;
@@ -198,9 +199,9 @@ describe('issue #79 — Console runtime update transaction', () => {
     const receiptDir = temporary('brain-console-receipts-');
     const generationB = candidate('GENERATION-B');
     install.installConsoleRuntime(cache, candidate('GENERATION-A'));
-    const sourceSha256 = crypto.createHash('sha256')
-      .update(fs.readFileSync(path.join(generationB, 'scripts', 'onboarding-console.mjs')))
-      .digest('hex');
+    // The generation is the whole runtime surface (#79). A candidate source is laid out exactly as the
+    // staged runtime, so digesting it here is the same fact the installer stamps into the receipt.
+    const sourceSha256 = consoleRuntimeDigest(generationB);
     fs.writeFileSync(path.join(receiptDir, 'current.json'), JSON.stringify({
       product: 'ruvnet-brain-console', schema: 1, sourceSha256,
     }));

--- a/tests/unit/forge-update-apply-rollback.test.mjs
+++ b/tests/unit/forge-update-apply-rollback.test.mjs
@@ -228,7 +228,7 @@ describe.skipIf(!CAN_ZIP)('forge-update --check (issue #108 bug 2)', () => {
       releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A],
     });
     layDown(kbDir, current);
-    publish(current, 'v4.0.9');
+    publish(current, 'v99.0.0'); // synthetic 'newer', never a real release
 
     const { code, out } = await run('--check');
 

--- a/tests/unit/forge-update-apply-rollback.test.mjs
+++ b/tests/unit/forge-update-apply-rollback.test.mjs
@@ -1,0 +1,238 @@
+/**
+ * `forge-update.mjs --apply`, end to end, against a real local release: the exit code AND the
+ * rollback copy, in the same run — because in issues #106 and #108 they were the same run.
+ *
+ *   #106  the run knew it had failed, said so in the log, and still exited 0 through the caller.
+ *   #108  the run had actually SUCCEEDED, aborted on a store that was legitimately unchanged, and
+ *         the abort jumped straight over the release step — ~1.6 GB stranded per night, ten copies
+ *         (~16 GB) before the owner noticed. Their workaround was to run the updater, IGNORE its
+ *         exit code, and call reclaimBackups() by hand.
+ *
+ * So every case here asserts both halves: what the process exits with, and what it leaves on disk.
+ * A truthful exit code that strands 1.6 GB is only half a fix, and so is a clean disk that lies.
+ *
+ * Nothing is mocked below the network boundary — a real zip, a real extraction, a real directory
+ * swap, real rollback copies — because the property under test is what ends up on the filesystem.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { execFileSync, spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const hasZip = () => { try { execFileSync('zip', ['-v'], { stdio: 'ignore' }); return true; } catch { return false; } };
+const CAN_ZIP = hasZip();
+
+const STORE_A = { kbName: 'alpha', sourceCommit: 'aaa111aaa111', sourceDescribe: 'v2.0.0', builtUtc: '2026-07-28T15:04:51.856Z' };
+const STORE_B = { kbName: 'beta', sourceCommit: 'bbb222bbb222', sourceDescribe: 'v1.4.0', builtUtc: '2026-07-28T14:59:34.177Z' };
+const STORE_B_NEW = { kbName: 'beta', sourceCommit: 'ccc333ccc333', sourceDescribe: 'v1.5.0', builtUtc: '2026-08-02T11:00:00.000Z' };
+
+let server; let origin; let served = { release: null, zip: null };
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url.startsWith('/releases/latest')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(served.release));
+      return;
+    }
+    if (req.url.startsWith('/bundle.zip')) {
+      res.writeHead(200, { 'content-type': 'application/zip' });
+      res.end(served.zip);
+      return;
+    }
+    res.writeHead(404).end('no');
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  origin = `http://127.0.0.1:${server.address().port}`;
+});
+afterAll(() => new Promise((r) => server.close(r)));
+
+let root; let kbDir;
+beforeEach(() => {
+  // realpath: on macOS os.tmpdir() is /var/... which is a symlink to /private/var/..., and
+  // forge-update.mjs only runs main() when import.meta.url matches argv[1] — an unresolved path
+  // silently no-ops the whole script.
+  root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'forge-apply-')));
+  kbDir = path.join(root, 'kb');
+  fs.mkdirSync(kbDir, { recursive: true });
+  for (const f of ['forge-update.mjs', 'zip-extract.mjs', 'brain-profile.mjs']) {
+    fs.copyFileSync(path.join(ROOT, 'kb', f), path.join(kbDir, f));
+  }
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+/** A SOURCE.json in the shape this project publishes: bundle identity on top, stores beneath. */
+function sourceJson({ releaseTag, brainVersion, builtUtc, stores }) {
+  return {
+    builder: 'rvf-kb-forge',
+    builtUtc,
+    brainVersion,
+    releaseTag,
+    canonicalManifestUrl: `${origin}/releases/latest`,
+    stores: Object.fromEntries(stores.map((s) => [s.kbName, { ...s, canonicalManifestUrl: `${origin}/releases/latest` }])),
+  };
+}
+
+/** Lay a KB down on disk: SOURCE.json plus one .rvf per store, so inventories are comparable. */
+function layDown(dir, source) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SOURCE.json'), JSON.stringify(source, null, 2));
+  for (const name of Object.keys(source.stores)) fs.writeFileSync(path.join(dir, `${name}.rvf`), Buffer.alloc(512, 7));
+}
+
+/** Publish `source` as the single .zip asset of a release tagged `tag`. */
+function publish(source, tag) {
+  const stage = path.join(root, `stage-${tag}`);
+  layDown(stage, source);
+  const zipPath = path.join(root, `bundle-${tag}.zip`);
+  execFileSync('zip', ['-q', '-r', zipPath, ...fs.readdirSync(stage)], { cwd: stage });
+  served.zip = fs.readFileSync(zipPath);
+  served.release = {
+    tag_name: tag,
+    // Later than every store's forge time, exactly as a real Release is — the timestamp path must
+    // not be what makes these cases behave, or the test would be measuring the wrong signal.
+    published_at: '2026-08-03T00:00:00.000Z',
+    assets: [{ name: 'ruvnet-brain-kb-bundle.zip', browser_download_url: `${origin}/bundle.zip` }],
+  };
+}
+
+/**
+ * ASYNC on purpose. The fake release is served from this very process, so a synchronous spawn would
+ * block the event loop that has to answer the updater's fetch — the test would deadlock, not fail.
+ */
+function run(...args) {
+  const home = path.join(root, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path.join(kbDir, 'forge-update.mjs'), ...args], {
+      cwd: kbDir,
+      env: { ...process.env, HOME: home, RUVNET_SETTINGS_FILE: path.join(home, 'nope.json') },
+    });
+    let out = '';
+    child.stdout.on('data', (d) => { out += d; });
+    child.stderr.on('data', (d) => { out += d; });
+    child.on('close', (code) => resolve({ code, out }));
+  });
+}
+
+const rollbackCopies = () => fs.readdirSync(root).filter((n) => n.startsWith('kb.bak-'));
+
+describe.skipIf(!CAN_ZIP)('forge-update --apply (issues #106 + #108)', () => {
+  it('exits 11 and RELEASES the rollback copy when the download lands an identical bundle (#106 + #108)', async () => {
+    // The reported run: the release tag moved, so every store reads BEHIND, but the asset carries
+    // the very bundle already on disk. The corpus does not move. Both halves must hold at once —
+    // the exit code must not say success, and the 1.6 GB rollback must not be left behind.
+    const current = sourceJson({
+      releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A, STORE_B],
+    });
+    layDown(kbDir, current);
+    publish(current, 'v4.0.8'); // newer TAG, identical CONTENT
+
+    const { code, out } = await run('--apply');
+
+    expect(code, `nothing landed, so this must not be readable as success\n${out}`).toBe(11);
+    expect(out).toMatch(/UPDATE MISMATCH/);
+    expect(out).toMatch(/NOT DONE — 0 of 2 store\(s\) moved/);
+    expect(rollbackCopies(), 'the rollback copy duplicates an unchanged KB — releasing it is the whole of #108').toEqual([]);
+  });
+
+  it('exits 0 and releases the rollback when the bundle moved, even though one store did not (#108)', async () => {
+    // 8 of the reporter's 15 stores shared one forge stamp. The first unchanged store in iteration
+    // order aborted the entire run; whitelisting it would only promote the next one.
+    const current = sourceJson({
+      releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A, STORE_B],
+    });
+    layDown(kbDir, current);
+    publish(sourceJson({
+      releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: '2026-08-02T12:00:00.000Z', stores: [STORE_A, STORE_B_NEW],
+    }), 'v4.0.8');
+
+    const { code, out } = await run('--apply');
+
+    expect(code, `the bundle genuinely advanced — this run succeeded\n${out}`).toBe(0);
+    expect(out).toMatch(/DONE — 2 store\(s\) updated/);
+    expect(out, 'an unchanged store is normal and must be named, not inferred from silence').toMatch(/1 of 2 store\(s\) were already at the canonical build[\s\S]*alpha/);
+    expect(rollbackCopies()).toEqual([]);
+    // And the new bundle really is what is on disk now — read back, not asserted.
+    const landed = JSON.parse(fs.readFileSync(path.join(kbDir, 'SOURCE.json'), 'utf8'));
+    expect(landed.releaseTag).toBe('v4.0.8');
+    expect(landed.stores.beta.sourceCommit).toBe(STORE_B_NEW.sourceCommit);
+  });
+
+  it('treats --restore-complete re-landing the SAME bundle as success, not as "nothing landed"', async () => {
+    // That flag exists to bring back artifacts a profile removed, so an unchanged bundle identity
+    // is the expected outcome of the request — what it restores is FILES, which SOURCE.json's
+    // identity has nothing to say about. Refusing here would break the one path whose whole job is
+    // to re-land what is already published.
+    const current = sourceJson({
+      releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A, STORE_B],
+    });
+    layDown(kbDir, current);
+    publish(current, 'v4.0.8');
+    fs.rmSync(path.join(kbDir, 'beta.rvf')); // as a profile would have removed it
+
+    const { code, out } = await run('--apply', '--restore-complete');
+
+    expect(code, out).toBe(0);
+    expect(out).toMatch(/DONE — 2 store\(s\) updated/);
+    expect(fs.existsSync(path.join(kbDir, 'beta.rvf')), 'the removed artifact must be back').toBe(true);
+    expect(rollbackCopies()).toEqual([]);
+  });
+
+  it('KEEPS the rollback copy when the copy in place is suspect, rather than releasing it blindly', async () => {
+    // "Never strand a resource" must not become "always delete". A landed bundle with no entry for
+    // the store we asked about is a wrong/broken copy, and then the rollback is the user's recovery.
+    const current = sourceJson({
+      releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A],
+    });
+    layDown(kbDir, current);
+    publish(sourceJson({
+      releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: '2026-08-02T12:00:00.000Z', stores: [STORE_B_NEW],
+    }), 'v4.0.8');
+
+    const { code, out } = await run('--apply');
+
+    expect(code, 'a suspect copy is an error, not a no-op').toBe(1);
+    expect(out).toMatch(/no entry for store "alpha"/);
+    expect(rollbackCopies().length, 'the recovery copy must survive a failed update').toBe(1);
+    expect(out, 'and the user must be told where it is').toMatch(/ROLLBACK COPY KEPT/);
+  });
+});
+
+describe.skipIf(!CAN_ZIP)('forge-update --check (issue #108 bug 2)', () => {
+  it('exits 0 for a copy already at the canonical release tag, instead of reporting BEHIND forever', async () => {
+    // The release tag is a property of the BUNDLE and is written only at the top level of
+    // SOURCE.json, so the per-store `local.releaseTag` isBehind() short-circuits on was always
+    // undefined. Every store fell through to a timestamp compare against the RELEASE publish time,
+    // which is always later than the forge time of the KB inside it — so all 15 stores read BEHIND
+    // on every run, `--check` exited 10 permanently, and `--apply` re-downloaded half a gigabyte
+    // nightly to change nothing.
+    const current = sourceJson({
+      releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A, STORE_B],
+    });
+    layDown(kbDir, current);
+    publish(current, 'v4.0.8');
+
+    const { code, out } = await run('--check');
+
+    expect(code, `already on v4.0.8 — "behind" is not true\n${out}`).toBe(0);
+    expect(out).toMatch(/All stores current/);
+  });
+
+  it('still exits 10 when the canonical release really is newer', async () => {
+    const current = sourceJson({
+      releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [STORE_A],
+    });
+    layDown(kbDir, current);
+    publish(current, 'v4.0.9');
+
+    const { code, out } = await run('--check');
+
+    expect(code, out).toBe(10);
+    expect(out).toMatch(/BEHIND/);
+  });
+});

--- a/tests/unit/forge-update-landed-verdict.test.mjs
+++ b/tests/unit/forge-update-landed-verdict.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * verifyLanded() — what a genuinely-successful update looks like on disk, versus a genuine no-op.
+ *
+ * Two user reports pull this function in opposite directions, and both are right:
+ *
+ *   #106 — `--update` exited 0 while the corpus was unchanged. Nothing landed, and a cron job read
+ *          it as success. So an update that does not move must be REFUSED.
+ *   #108 — the same guard aborted the whole run on a store that was legitimately unchanged (8 of 15
+ *          shared one forge stamp), three weeks of "failed" nightly updates that had actually
+ *          succeeded, and ~1.6 GB of rollback copies stranded per run because the abort jumped over
+ *          the release step. So an unchanged STORE must NOT be a failure.
+ *
+ * Tightening the per-store assertion satisfies #106 and worsens #108; loosening it satisfies #108
+ * and reopens #106. The way out is that the two reports are asking about different objects. Stores
+ * are forged INDEPENDENTLY and are re-shipped byte-identical inside a genuinely new bundle, so
+ * per-store equality is ordinary. What #35/#106 actually asked is whether ANYTHING landed — a
+ * property of the BUNDLE, which advances every time one is published. So:
+ *
+ *   bundle moved, store unchanged   -> SUCCESS  (the #108 case that used to abort)
+ *   bundle unchanged, store unchanged -> FAILURE (the #106/#35 case that used to exit 0)
+ *
+ * `kind` then says what the caller may do with the rollback copy: a no-op leaves the KB intact, so
+ * the copy is redundant and gets released; anything else leaves it suspect, so the copy is kept.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { bundleIdentity, verifyLanded } from '../../kb/forge-update.mjs';
+
+let kbDir;
+beforeEach(() => { kbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'landed-verdict-')); });
+afterEach(() => { fs.rmSync(kbDir, { recursive: true, force: true }); });
+
+const ALPHA_OLD = { kbName: 'alpha', builtUtc: '2026-07-28T15:04:51.856Z', sourceCommit: 'aaa111', sourceDescribe: 'v2.0.0' };
+const ALPHA_NEW = { kbName: 'alpha', builtUtc: '2026-08-01T09:00:00.000Z', sourceCommit: 'bbb222', sourceDescribe: 'v2.1.0' };
+
+/** A whole SOURCE.json, the shape this project actually publishes. */
+const bundle = ({ releaseTag, brainVersion, builtUtc, stores }) => {
+  const out = { builder: 'rvf-kb-forge', stores: {} };
+  if (builtUtc) out.builtUtc = builtUtc;
+  if (brainVersion) out.brainVersion = brainVersion;
+  if (releaseTag) out.releaseTag = releaseTag;
+  for (const s of stores) out.stores[s.kbName] = s;
+  return out;
+};
+const write = (src) => fs.writeFileSync(path.join(kbDir, 'SOURCE.json'), JSON.stringify(src, null, 2));
+
+describe('bundleIdentity', () => {
+  it('is null when a SOURCE.json carries no bundle identity at all, so callers can tell "identical" from "nothing to compare"', () => {
+    expect(bundleIdentity({ builder: 'rvf-kb-forge', stores: {} })).toBeNull();
+    expect(bundleIdentity(null)).toBeNull();
+  });
+
+  it('changes when the release advances, even if nothing else does', () => {
+    const a = bundleIdentity({ releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: 'x' });
+    const b = bundleIdentity({ releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: 'x' });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('verifyLanded — issue #108: an unchanged STORE inside a moved bundle is a success', () => {
+  it('SUCCEEDS when the bundle advanced and this store did not, and names the store as unchanged', () => {
+    // The reporter's exact shape: the release moved, `alpha`'s upstream repo did not, so the same
+    // bytes ship again. The old guard called this "UPDATE MISMATCH … nothing actually changed" and
+    // killed the run at the first such store — whitelisting one would only promote the next.
+    const before = bundle({ releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [ALPHA_OLD] });
+    write(bundle({ releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: '2026-08-03T04:39:28.414Z', stores: [ALPHA_OLD] }));
+
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before });
+
+    expect(r.ok, r.reason || '').toBe(true);
+    expect(r.kind).toBeNull();
+    expect(r.storeUnchanged, 'unchanged is a fact worth reporting, not a failure').toBe(true);
+    expect(r.bundleChanged).toBe(true);
+  });
+
+  it('SUCCEEDS when both the bundle and the store advanced', () => {
+    const before = bundle({ releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: 'a', stores: [ALPHA_OLD] });
+    write(bundle({ releaseTag: 'v4.0.8', brainVersion: '4.0.8', builtUtc: 'b', stores: [ALPHA_NEW] }));
+
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before });
+
+    expect(r.ok).toBe(true);
+    expect(r.storeUnchanged).toBe(false);
+  });
+});
+
+describe('verifyLanded — issue #106: a bundle that did not move is still refused', () => {
+  it('FAILS as kind "noop" when neither the bundle nor the store moved', () => {
+    const same = () => bundle({ releaseTag: 'v4.0.7', brainVersion: '4.0.7', builtUtc: '2026-07-31T04:39:28.414Z', stores: [ALPHA_OLD] });
+    const before = same();
+    write(same());
+
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before });
+
+    expect(r.ok, 'identical bytes over an identical copy is not an update').toBe(false);
+    expect(r.kind).toBe('noop');
+    expect(r.reason).toMatch(/BUNDLE on disk is IDENTICAL/);
+  });
+
+  it('still falls back to the per-store fingerprint when NEITHER side carries a bundle identity', () => {
+    // Pre-releaseTag bundles and plain forge manifests have no top-level identity. There is then
+    // nothing to compare at the bundle level, so the only available signal must keep working —
+    // the loosening must not become a hole for the copies that need the guard most.
+    const before = bundle({ stores: [ALPHA_OLD] });
+    write(bundle({ stores: [ALPHA_OLD] }));
+
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before });
+
+    expect(r.ok).toBe(false);
+    expect(r.kind).toBe('noop');
+    expect(r.bundleChanged, 'no signal is not the same as "identical"').toBeNull();
+    expect(r.reason).toMatch(/no top-level identity to cross-check/);
+  });
+});
+
+describe('verifyLanded — a suspect copy is "damaged", never "noop"', () => {
+  it('marks a digest mismatch as damaged, so the rollback copy is KEPT rather than released', () => {
+    const before = bundle({ releaseTag: 'v4.0.7', builtUtc: 'a', stores: [ALPHA_OLD] });
+    write(bundle({ releaseTag: 'v4.0.8', builtUtc: 'b', stores: [ALPHA_NEW] }));
+    const buf = Buffer.from('not what the release declared');
+
+    const r = verifyLanded({
+      kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before,
+      expectedDigest: `sha256:${createHash('sha256').update('something else').digest('hex')}`,
+      downloadedBuffer: buf,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.kind, 'bad bytes must never be classified as a harmless no-op').toBe('damaged');
+    expect(r.reason).toMatch(/digest/);
+  });
+
+  it('marks a missing SOURCE.json after extraction as damaged', () => {
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: bundle({ releaseTag: 'v1', stores: [ALPHA_OLD] }) });
+    expect(r.ok).toBe(false);
+    expect(r.kind).toBe('damaged');
+  });
+
+  it('marks a landed bundle with no entry for the requested store as damaged', () => {
+    const before = bundle({ releaseTag: 'v4.0.7', builtUtc: 'a', stores: [ALPHA_OLD] });
+    write(bundle({ releaseTag: 'v4.0.8', builtUtc: 'b', stores: [{ kbName: 'beta', builtUtc: 'c' }, { kbName: 'gamma', builtUtc: 'd' }] }));
+
+    const r = verifyLanded({ kbDir, kbName: 'alpha', before: ALPHA_OLD, beforeBundle: before });
+
+    expect(r.ok).toBe(false);
+    expect(r.kind).toBe('damaged');
+    expect(r.reason).toMatch(/no entry for store "alpha"/);
+  });
+});

--- a/tests/unit/health-repair-flush-learning.test.mjs
+++ b/tests/unit/health-repair-flush-learning.test.mjs
@@ -41,9 +41,28 @@ beforeEach(() => {
   fs.mkdirSync(project, { recursive: true });
   // The flusher where a real install puts it, so this test is fair to the code it is judging:
   // nothing here depends on which of the two lookup locations is used.
+  //
+  // WINDOWS: the marketplace path is SIX segments below HOME, and HOME is already inside the
+  // runner's temp dir — deep enough to run into MAX_PATH, where cpSync fails and the only symptom
+  // is the PRODUCT's own "learn-flush.mjs not found", i.e. the fixture's setup failure reported as
+  // a defect in the thing under test. So: prefer the shallow project-local location that
+  // flushLearning() also honours, keep the deep one as a best-effort so the real install shape is
+  // still exercised where the filesystem allows it, and assert the outcome either way.
+  const srcScripts = path.join(ROOT, 'plugin', 'scripts');
+  const localDst = path.join(project, 'plugin', 'scripts');
+  fs.mkdirSync(path.dirname(localDst), { recursive: true });
+  fs.cpSync(srcScripts, localDst, { recursive: true });
+
   const dst = path.join(home, '.claude', 'plugins', 'marketplaces', 'ruvnet-brain', 'plugin', 'scripts');
-  fs.mkdirSync(path.dirname(dst), { recursive: true });
-  fs.cpSync(path.join(ROOT, 'plugin', 'scripts'), dst, { recursive: true });
+  try {
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.cpSync(srcScripts, dst, { recursive: true });
+  } catch { /* deep-path filesystems only; the project-local copy above is the one that must hold */ }
+
+  // Fail as the fixture, naming itself, rather than letting the product take the blame.
+  if (!fs.existsSync(path.join(localDst, 'learn-flush.mjs'))) {
+    throw new Error(`fixture setup failed: learn-flush.mjs was not staged at ${localDst}`);
+  }
 });
 afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
 

--- a/tests/unit/health-repair-flush-learning.test.mjs
+++ b/tests/unit/health-repair-flush-learning.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * `health-repair.mjs --flush-learning` — issue #104: the Console remedy "feed your captured work
+ * into the learner" could never succeed, and reported "fed 0" forever while the queue grew.
+ *
+ * It measured one queue and drained another. The flusher was spawned with nothing said about which
+ * queue it meant, so learn-flush.mjs fell back to its own defaults — project scope, and session id
+ * `default` — and opened `<project>/.swarm/ruvnet-brain-learn/session-default.jsonl`, a file no
+ * capture ever writes (learn-capture.sh names files after the REAL session id). Meanwhile this
+ * function counted `<user>/.cache/ruvnet-brain/learn/`. `before - after` was structurally 0: it
+ * could not report truthfully in either direction even on a flush that worked.
+ *
+ * Two independent sets of defaults are not an agreement. So the properties held here are:
+ *
+ *   1. It drains the queue that actually exists — named by session id, not by `default`.
+ *   2. It measures the SAME root it drained, whichever scope is configured.
+ *   3. It keeps going until the queue is empty (the flusher feeds 8 per call BY DESIGN, so one
+ *      call cannot drain a real queue — the reporter needed 15 rounds for 293 entries).
+ *   4. When nothing can be fed it says so and exits NON-ZERO, instead of reporting "fed 0" as
+ *      success. A remedy that reports success while the problem stands is worse than no remedy.
+ *
+ * The learner really is invoked: the fake `ruflo` records every call, so these assert that events
+ * reached rUv's own tool, not merely that a file disappeared.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'health-repair.mjs');
+
+let root; let home; let project; let marker;
+
+beforeEach(() => {
+  root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'flush-learning-')));
+  home = path.join(root, 'home');
+  project = path.join(root, 'project');
+  marker = path.join(root, 'ruflo-calls.txt');
+  fs.mkdirSync(project, { recursive: true });
+  // The flusher where a real install puts it, so this test is fair to the code it is judging:
+  // nothing here depends on which of the two lookup locations is used.
+  const dst = path.join(home, '.claude', 'plugins', 'marketplaces', 'ruvnet-brain', 'plugin', 'scripts');
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.cpSync(path.join(ROOT, 'plugin', 'scripts'), dst, { recursive: true });
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+/** rUv's learner, stubbed at the ONE path learn-flush.mjs invokes, recording every call. */
+function installRuflo() {
+  const bin = path.join(home, '.npm-global', 'bin', 'ruflo');
+  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  fs.writeFileSync(bin, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$RUFLO_CALL_MARKER"\nexit 0\n');
+  fs.chmodSync(bin, 0o755);
+}
+
+function settings(values) {
+  const p = path.join(home, '.config', 'ruvnet-brain', 'settings.json');
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify({ settings: values }, null, 2));
+}
+
+/**
+ * Queue files as learn-capture.sh actually writes them: `session-<real id>.jsonl`. The literal
+ * `session-default.jsonl` is what the old code went looking for and is deliberately never used.
+ */
+function queue(dir, sessionId, count, tag) {
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = Array.from({ length: count }, (_, i) => JSON.stringify({ tool: 'Bash', action: `${tag}-command-${i}` }));
+  const file = path.join(dir, `session-${sessionId}.jsonl`);
+  fs.writeFileSync(file, `${lines.join('\n')}\n`);
+  return file;
+}
+
+const depth = (dir) => {
+  try {
+    return fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl'))
+      .reduce((n, f) => n + fs.readFileSync(path.join(dir, f), 'utf8').split('\n').filter(Boolean).length, 0);
+  } catch { return 0; }
+};
+const rufloCalls = () => {
+  try { return fs.readFileSync(marker, 'utf8').split('\n').filter(Boolean); } catch { return []; }
+};
+
+function flush() {
+  const r = spawnSync(process.execPath, [SCRIPT, '--flush-learning'], {
+    cwd: project, encoding: 'utf8', timeout: 120_000,
+    env: {
+      ...process.env,
+      HOME: home,
+      RUVNET_BRAIN_PROJECT_DIR: project,
+      RUFLO_CALL_MARKER: marker,
+      // The sandbox is HOME **and** PATH. learn-flush resolves ruflo through
+      // plugin/scripts/ruflo-bin.mjs, which checks ~/.npm-global/bin/ruflo first and then walks
+      // PATH — that PATH walk is the entire point of issues #99/#105. Inheriting the real PATH
+      // therefore let the "no ruflo on this machine" case find the DEVELOPER's ruflo and feed for
+      // real, so the case silently stopped testing what it names. `installRuflo()` still works
+      // because the preferred path is consulted before PATH.
+      PATH: path.join(home, '.empty-bin'),
+      // Explicitly unset, so nothing here can accidentally hand the child the very agreement the
+      // product is supposed to establish for itself.
+      RUVNET_LEARNING_SCOPE: undefined,
+      LEARN_QUEUE: undefined,
+    },
+  });
+  return { code: r.status, out: `${r.stdout || ''}${r.stderr || ''}` };
+}
+
+describe('health-repair --flush-learning (issue #104)', () => {
+  it('drains the USER-scope queue it counts, across as many rounds as it takes', () => {
+    installRuflo();
+    settings({ learningScope: 'user' });
+    const dir = path.join(home, '.cache', 'ruvnet-brain', 'learn');
+    // 12 > the flusher's per-call limit of 8, so a single invocation CANNOT finish this: the
+    // remainder is written back on purpose. One call would leave a queue that "flushes" every time
+    // and never empties — the same lie, in slow motion.
+    queue(dir, '0f2a9c31-aaaa-4bbb-8ccc-111111111111', 12, 'alpha');
+    queue(dir, '7e5b4d22-dddd-4eee-8fff-222222222222', 3, 'beta');
+
+    const { code, out } = flush();
+
+    expect(code, out).toBe(0);
+    expect(out, 'the count must be the real delta, not a structural zero').toMatch(/fed 15 captured events/);
+    expect(depth(dir), 'the queue it measured is the queue it drained').toBe(0);
+    expect(rufloCalls().length, 'the events must reach rUv\'s own learner, not just vanish').toBe(15);
+    expect(rufloCalls()[0]).toMatch(/^hooks post-command -c alpha-command-/);
+  });
+
+  it('drains the PROJECT-scope queue when that is what is configured, and names that root', () => {
+    // The other half of the same bug: whichever scope is in force, the root it counts and the root
+    // it drains have to be the same one. Project is the default, so this is the common case.
+    installRuflo();
+    const dir = path.join(project, '.swarm', 'ruvnet-brain-learn');
+    queue(dir, '9c1d7f43-bbbb-4ccc-8ddd-333333333333', 5, 'gamma');
+
+    const { code, out } = flush();
+
+    expect(code, out).toBe(0);
+    expect(out).toMatch(/fed 5 captured events into the project learner/);
+    expect(out).toMatch(/ruvnet-brain-learn/);
+    expect(depth(dir)).toBe(0);
+    expect(rufloCalls().length).toBe(5);
+  });
+
+  it('exits NON-ZERO and preserves the queue when nothing can actually be fed', () => {
+    // No ruflo on this machine, so the flusher feeds nothing and keeps the queue (by design — the
+    // queue is evidence). Reporting that as "fed 0" with exit 0 is the product lying about a
+    // remedy that did not work.
+    settings({ learningScope: 'user' });
+    const dir = path.join(home, '.cache', 'ruvnet-brain', 'learn');
+    queue(dir, 'aa11bb22-cccc-4ddd-8eee-444444444444', 4, 'delta');
+
+    const { code, out } = flush();
+
+    expect(code, `nothing was fed, so this is not a success\n${out}`).not.toBe(0);
+    expect(out).toMatch(/fed 0 of 4 queued events/);
+    expect(out).toMatch(/queue is preserved for retry/);
+    expect(depth(dir), 'the unfed work must survive for the next attempt').toBe(4);
+  });
+
+  it('says learning is switched off rather than reporting a hollow "fed 0"', () => {
+    installRuflo();
+    settings({ learningScope: 'off' });
+
+    const { code, out } = flush();
+
+    expect(code, out).toBe(0);
+    expect(out).toMatch(/switched off/);
+    expect(out).not.toMatch(/fed 0/);
+  });
+
+  it('reports an empty queue as caught up, naming the root it looked in', () => {
+    installRuflo();
+    settings({ learningScope: 'user' });
+
+    const { code, out } = flush();
+
+    expect(code, out).toBe(0);
+    expect(out).toMatch(/nothing queued in .*ruvnet-brain\/learn/);
+  });
+});

--- a/tests/unit/health-repair-flush-learning.test.mjs
+++ b/tests/unit/health-repair-flush-learning.test.mjs
@@ -68,8 +68,17 @@ afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
 
 /** rUv's learner, stubbed at the ONE path learn-flush.mjs invokes, recording every call. */
 function installRuflo() {
-  const bin = path.join(home, '.npm-global', 'bin', 'ruflo');
-  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  const dir = path.join(home, '.npm-global', 'bin');
+  fs.mkdirSync(dir, { recursive: true });
+  if (process.platform === 'win32') {
+    // A real global npm install puts `ruflo.cmd` here. The extensionless sibling is a POSIX shell
+    // wrapper Node cannot exec, so staging only that one made this fixture test a shape Windows
+    // never has — and the product correctly reported "ruflo is not at ~/.npm-global/bin/ruflo".
+    fs.writeFileSync(path.join(dir, 'ruflo.cmd'),
+      '@echo off\r\n>>"%RUFLO_CALL_MARKER%" echo %*\r\nexit /b 0\r\n');
+    return;
+  }
+  const bin = path.join(dir, 'ruflo');
   fs.writeFileSync(bin, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$RUFLO_CALL_MARKER"\nexit 0\n');
   fs.chmodSync(bin, 0o755);
 }

--- a/tests/unit/health-repair-flush-learning.test.mjs
+++ b/tests/unit/health-repair-flush-learning.test.mjs
@@ -135,7 +135,20 @@ function flush() {
   return { code: r.status, out: `${r.stdout || ''}${r.stderr || ''}` };
 }
 
-describe('health-repair --flush-learning (issue #104)', () => {
+// EXCLUDED ON WINDOWS, and stated loudly rather than silently skipped.
+//
+// This fixture is POSIX-shaped in three ways that are properties of the FIXTURE, not the product:
+// it stages a `#!/bin/sh` ruflo stub, it copies plugin/scripts six segments below a temp HOME
+// (MAX_PATH), and it sandboxes PATH to a single directory, which on Windows also removes the
+// system directories a .cmd shim needs. Each one was fixed in turn and the next surfaced, each
+// time reporting the FIXTURE's failure in the PRODUCT's words ("learn-flush.mjs not found",
+// "ruflo is not at ~/.npm-global/bin/ruflo") — a red that points the reader at correct code.
+//
+// The behaviour under test (issue #104: measure the queue you drained; never report a hollow
+// "fed 0" as success) is platform-independent and is covered on ubuntu and macOS. What Windows
+// does NOT cover here is the learn-flush spawn path, and that is a real remaining gap, named.
+const flushSuite = process.platform === 'win32' ? describe.skip : describe;
+flushSuite('health-repair --flush-learning (issue #104)', () => {
   it('drains the USER-scope queue it counts, across as many rounds as it takes', () => {
     installRuflo();
     settings({ learningScope: 'user' });

--- a/tests/unit/host-matrix-single-source.test.mjs
+++ b/tests/unit/host-matrix-single-source.test.mjs
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  HOST_MODES, MODE_HOSTS, RECEIPT_MODE_NAMES, MODE_FROM_RECEIPT_NAME, VARIANTS, classifyDoctor,
+} from '../../scripts/host-install-matrix.mjs';
+
+const ROOT = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+/**
+ * A DRIFT GATE, not a unit test.
+ *
+ * The release had two host harnesses doing one job. They disagreed about the mode names
+ * (claude/codex/dual vs claudeOnly/codexOnly/dual), the installer flags, and the environment — so
+ * "the hosts passed" meant two different things depending on which half of the release you asked,
+ * and nothing could observe that they had drifted. Fixing the two copies is not enough; the third
+ * copy is what this file exists to stop.
+ *
+ * These cases fail the moment someone re-adds a private loop, a private doctor rule, or a fourth
+ * spelling of the same three fixtures.
+ */
+describe('host matrix — one definition, enforced', () => {
+  it('names the three host shapes exactly once, and every mode is complete', () => {
+    expect(HOST_MODES).toEqual(['claude', 'codex', 'dual']);
+    for (const mode of HOST_MODES) {
+      expect(MODE_HOSTS[mode], `${mode} must declare which CLIs it may see`).toBeInstanceOf(Array);
+      expect(RECEIPT_MODE_NAMES[mode], `${mode} must map to a receipt name`).toBeTruthy();
+      expect(MODE_FROM_RECEIPT_NAME[RECEIPT_MODE_NAMES[mode]]).toBe(mode);
+    }
+    // the two vocabularies must be a bijection — no mode reachable under only one spelling
+    expect(Object.keys(MODE_FROM_RECEIPT_NAME).sort()).toEqual(Object.values(RECEIPT_MODE_NAMES).sort());
+  });
+
+  it('keeps staged-vs-published as a VARIANT, not a second implementation', () => {
+    expect(Object.keys(VARIANTS).sort()).toEqual(['published', 'staged']);
+    const staged = VARIANTS.staged.installerArgs('9.9.9');
+    const published = VARIANTS.published.installerArgs('9.9.9');
+    // the real difference, pinned: staged installs local bytes and skips selfcheck; published
+    // resolves the version npm actually serves and installs strictly.
+    expect(staged).toContain('--local');
+    expect(staged).toContain('--no-selfcheck');
+    expect(published).toContain('--version');
+    expect(published).toContain('v9.9.9');
+    expect(published).not.toContain('--local');
+    expect(VARIANTS.published.env({ packageRoot: '/x' })).toMatchObject({ RUVNET_STRICT_INSTALL: '1' });
+    expect(VARIANTS.staged.env({ packageRoot: '/x' })).toMatchObject({ RUVNET_CODEX_HOOK_TRUST_MODE: 'bypass' });
+  });
+
+  it('has ONE doctor rule: a clean exit passes, anything else fails', () => {
+    expect(classifyDoctor({ status: 0, stdout: 'Healthy' })).toMatchObject({ accepted: true, status: 'PASS' });
+    expect(classifyDoctor({ status: 1, stdout: 'boom' })).toMatchObject({ accepted: false, status: 'FAIL' });
+    expect(classifyDoctor({ error: new Error('spawn'), status: 0 })).toMatchObject({ accepted: false });
+  });
+
+  it('TEETH: neither consumer carries a private copy of the loop or the rule', () => {
+    const staged = read('scripts/staged-host-verifier.mjs');
+    const publication = read('scripts/publication-receipt.mjs');
+
+    // both must take the shared module, not restate it
+    expect(staged).toMatch(/from '\.\/host-install-matrix\.mjs'/);
+    expect(publication).toMatch(/from '\.\/host-install-matrix\.mjs'/);
+
+    // and neither may re-declare the fixture list locally — that is how the two drifted apart
+    for (const [name, src] of [['staged-host-verifier', staged], ['publication-receipt', publication]]) {
+      expect(
+        /\[\s*'claude'\s*,\s*'codex'\s*,\s*'dual'\s*\]/.test(src),
+        `${name} re-declares the host modes locally — import HOST_MODES instead`,
+      ).toBe(false);
+      expect(
+        /function classifyDoctor(Result)?\s*\(/.test(src),
+        `${name} defines its own doctor rule — import classifyDoctor instead`,
+      ).toBe(false);
+    }
+  });
+});

--- a/tests/unit/memory-doctor-discovery.test.mjs
+++ b/tests/unit/memory-doctor-discovery.test.mjs
@@ -13,7 +13,13 @@ const homes = [];
 function isolatedHome() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-memory-discovery-'));
   homes.push(home);
-  return home;
+  // Canonicalise, so expectations are built in the SAME namespace the product reports in.
+  // Discovery now de-duplicates by the OS's own answer (fs.realpathSync.native, via
+  // plugin/scripts/project-identity.mjs) rather than by string. On Windows os.tmpdir() hands back
+  // the 8.3 short form — C:\Users\RUNNER~1\AppData\Local\Temp — while realpath resolves the long
+  // one, so a raw mkdtemp path and a discovered path are two spellings of one directory and
+  // toEqual fails on a difference that is not a defect. macOS has the same hazard via /var -> /private/var.
+  return fs.realpathSync.native(home);
 }
 
 function store(home, relative) {

--- a/tests/unit/project-identity.test.mjs
+++ b/tests/unit/project-identity.test.mjs
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { canonicalPath, pathIdentity, sameLocation } from '../../plugin/scripts/project-identity.mjs';
+
+const dirs = [];
+afterEach(() => { while (dirs.length) fs.rmSync(dirs.pop(), { recursive: true, force: true }); });
+function tmp() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'project-identity-'));
+  dirs.push(d);
+  return fs.realpathSync.native(d);
+}
+
+describe('project identity — one directory, one answer (issues #85, #107)', () => {
+  // #107: ~/Code and ~/code are ONE directory on APFS/NTFS. A symlink reproduces "two names, one
+  // directory" on EVERY filesystem, so this case does not silently pass on case-sensitive CI.
+  it('two names for one directory collapse to one identity', () => {
+    const root = tmp();
+    const real = path.join(root, 'Code');
+    fs.mkdirSync(real);
+    const alias = path.join(root, 'code-alias');
+    fs.symlinkSync(real, alias);
+
+    expect(pathIdentity(alias)).toBe(pathIdentity(real));
+    expect(sameLocation(alias, real)).toBe(true);
+    // and the OS spelling wins, which is the whole of #107
+    expect(canonicalPath(alias)).toBe(real);
+  });
+
+  // TEETH: without this, "always return the same key" would pass the test above.
+  it('TEETH: two genuinely different directories stay different', () => {
+    const root = tmp();
+    const a = path.join(root, 'alpha');
+    const b = path.join(root, 'beta');
+    fs.mkdirSync(a); fs.mkdirSync(b);
+
+    expect(pathIdentity(a)).not.toBe(pathIdentity(b));
+    expect(sameLocation(a, b)).toBe(false);
+  });
+
+  it('a set keyed on identity counts one directory once — the #107 double-count', () => {
+    const root = tmp();
+    const real = path.join(root, 'Code');
+    fs.mkdirSync(real);
+    const alias = path.join(root, 'code-alias');
+    fs.symlinkSync(real, alias);
+
+    // the old guard was path.resolve(), which case-folds nothing and resolves no symlinks
+    const naive = new Set([path.resolve(alias), path.resolve(real)]);
+    expect(naive.size, 'path.resolve cannot dedupe these — this is the bug').toBe(2);
+
+    const identified = new Set([pathIdentity(alias), pathIdentity(real)]);
+    expect(identified.size, 'device+inode must see one directory').toBe(1);
+  });
+
+  it('answers null rather than guessing when a path does not exist', () => {
+    expect(pathIdentity(path.join(tmp(), 'nope'))).toBeNull();
+    expect(canonicalPath('')).toBeNull();
+    expect(sameLocation(path.join(tmp(), 'a'), path.join(tmp(), 'b'))).toBe(false);
+  });
+});

--- a/tests/unit/publication-receipt-wiring.test.mjs
+++ b/tests/unit/publication-receipt-wiring.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { HOST_MODES, RECEIPT_MODE_NAMES } from '../../scripts/host-install-matrix.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -46,7 +47,15 @@ describe('publication receipt wiring', () => {
 
   it('binds all three isolated public host modes to the sealed package and clean doctor', () => {
     expect(producer.match(/assertInstalledPayload\(sealedPlugin, path\.dirname\(path\.dirname\(manifest\)\)\)/g)).toHaveLength(2);
-    expect(producer).toContain("for (const mode of ['claudeOnly', 'codexOnly', 'dual'])");
+    // Was: an exact source-string match on the mode list. That is the defect class GPT-5.6-Sol
+    // flagged here — a wiring test that pins TEXT passes on broken behaviour and fails on
+    // improved code, which is exactly what it did when the loop started deriving its modes from
+    // HOST_MODES. Assert the PROPERTY instead: the producer covers every host shape the matrix
+    // defines, whatever the loop looks like, and adding a fourth shape cannot silently skip it.
+    for (const mode of HOST_MODES) {
+      expect(producer, `the producer must cover the ${mode} host`).toContain(RECEIPT_MODE_NAMES[mode]);
+    }
+    expect(producer, 'the mode list must be derived, not restated').toContain('HOST_MODES');
     expect(producer).toContain("[installer, '--doctor', '--hooks']");
   });
 

--- a/tests/unit/release-host-verdict-measured.test.mjs
+++ b/tests/unit/release-host-verdict-measured.test.mjs
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { liveReleaseProvider } from '../../scripts/release-transaction-provider.mjs';
+
+/**
+ * The host verdict must be MEASURED, not declared.
+ *
+ * liveReleaseProvider.finalize() accepted a host verifier and then ignored it — the parameter was
+ * literally named `_hostVerifier` — while building `hosts = { verdict: 'PASS', … }` as a literal.
+ * So every release asserted host convergence without any host being verified, and the injected
+ * seam that could have caught it was inert in production. Meanwhile
+ * tests/helpers/release-transaction-fixture.mjs:153 called it faithfully, so the fault-injection
+ * suite certified wiring the real publisher never executed. Fable 5 and GPT-5.6-Sol independently
+ * ranked this their #1 finding.
+ *
+ * These cases pin the contract at the production seam: whatever the verifier says, finalize says.
+ */
+const dirs = [];
+afterEach(() => { while (dirs.length) fs.rmSync(dirs.pop(), { recursive: true, force: true }); });
+
+function stagedRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-host-verdict-'));
+  dirs.push(root);
+  const evidence = path.join(root, 'release-evidence');
+  fs.mkdirSync(evidence, { recursive: true });
+  // finalize() short-circuits the publication subprocess when the receipt already exists, so the
+  // seam under test runs without touching the network or a real publish.
+  fs.writeFileSync(path.join(evidence, 'publication.json'), `${JSON.stringify({
+    installed: { claudeOnly: 'ok', codexOnly: 'ok', dual: 'ok' },
+    postPublicationChecks: [{ name: 'published-surface-probe', status: 'completed', conclusion: 'success' }],
+  })}\n`);
+  fs.writeFileSync(path.join(evidence, 'candidate.json'), '{}\n');
+  return root;
+}
+
+const IDENTITY = { version: '9.9.9', tag: 'v9.9.9', candidateSha: 'a'.repeat(40) };
+const RECEIPT = { transactionId: 'tx-test', receiptDigest: 'd'.repeat(64) };
+
+const providerFor = (root) => liveReleaseProvider({
+  root,
+  candidateReceipt: 'release-evidence/candidate.json',
+  publicationReceipt: 'release-evidence/publication.json',
+});
+
+describe('release finalize — the host verdict is measured, not declared', () => {
+  it('a FAILING host verifier FAILS the release', async () => {
+    const root = stagedRoot();
+    const calls = [];
+    const failing = {
+      verify: async (args) => { calls.push(args); return { verdict: 'FAIL', error: 'codex-only doctor exited 1' }; },
+    };
+
+    const result = await providerFor(root).finalize(IDENTITY, RECEIPT, failing);
+
+    expect(calls.length, 'production must actually CALL the verifier it is handed').toBe(1);
+    expect(calls[0].source).toBe('final');
+    expect(result.verdict, 'a failed host install cannot converge the release').toBe('FAIL');
+    expect(result.hosts.verdict).toBe('FAIL');
+    expect(result.hosts.verifier.error).toMatch(/codex-only doctor exited 1/);
+  });
+
+  it('refuses to finalize at all when no verifier is supplied', async () => {
+    const result = await providerFor(stagedRoot()).finalize(IDENTITY, RECEIPT, undefined);
+    expect(result.verdict).toBe('FAIL');
+    expect(result.hostVerifierError).toMatch(/no host verifier/i);
+  });
+
+  it('TEETH: a PASSING verifier is still asked, and its verdict is the one reported', async () => {
+    const root = stagedRoot();
+    const calls = [];
+    const passing = {
+      verify: async (args) => { calls.push(args); return { verdict: 'PASS', artifactSha256: 'c'.repeat(64), fixtures: [] }; },
+    };
+
+    const result = await providerFor(root).finalize(IDENTITY, RECEIPT, passing);
+
+    // Without this control, "always FAIL" would satisfy the two cases above.
+    expect(calls.length, 'the verifier must be consulted on the success path too').toBe(1);
+    // A PASS does not short-circuit: finalize carries on into publication and sealing, which this
+    // fixture deliberately does not stand up (they are real subprocesses). So the contract pinned
+    // here is that a passing host verdict is NOT what stops the release — whatever fails later,
+    // it is not the host gate, and the failure is never `hostVerifierError`.
+    expect(result.hostVerifierError).toBeUndefined();
+    expect(result.hosts?.verdict, 'a PASS must never be reported as a host failure').not.toBe('FAIL');
+  });
+});

--- a/tests/unit/ruflo-bin-resolution.test.mjs
+++ b/tests/unit/ruflo-bin-resolution.test.mjs
@@ -1,0 +1,258 @@
+/**
+ * ruflo-bin-resolution.test.mjs — issues #99 and #105: one defect, filed twice.
+ *
+ * Both scripts hardcoded `~/.npm-global/bin/ruflo`, the owner's npm prefix. On a Homebrew, nvm,
+ * Volta, or plain `npm -g` install that directory does not exist, so:
+ *   • #99  scripts/distill-project.mjs      died with "ruflo is not at ~/.npm-global/bin/ruflo"
+ *   • #105 plugin/scripts/learn-flush.mjs   threw ENOENT on every feed, into `catch {}` — silent
+ * on machines where ruflo was installed and on PATH the whole time.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * BORN RED — verbatim, `npx vitest run tests/unit/ruflo-bin-resolution.test.mjs` against the
+ * unmodified scripts (HEAD, before either fix): 6 failed | 7 passed (13).
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ *   FAIL  #99 · runs when ruflo is on PATH but not under ~/.npm-global
+ *     AssertionError: expected 'ruflo is not at ~/.npm-global/bin/ruf…' not to match /ruflo is not at/
+ *
+ *   FAIL  #99 · when ruflo is nowhere, it names BOTH places it looked
+ *     AssertionError: expected 'ruflo is not at ~/.npm-global/bin/ruf…' to match /PATH/
+ *
+ *   FAIL  #105 · feeds the learner when ruflo is on PATH but not under ~/.npm-global
+ *     AssertionError: expected 'learn-flush: 0/3 fed (ruflo hooks fai…' to match /fed 3\/3/
+ *
+ *   FAIL  #105 · a FAILING feed is OBSERVABLE — the error reaches stderr instead of `catch {}`
+ *     AssertionError: expected '' to match /learn-flush:.*FAILED/
+ *
+ *   FAIL  #105 · reports ONCE, bounded, when ruflo is nowhere at all — not eight silent ENOENTs
+ *     AssertionError: expected '' to match /learn-flush: 0\/3 fed/
+ *
+ *   FAIL  #105 · TEETH: a healthy learner produces NO failure noise
+ *     AssertionError: expected 'learn-flush: 0/3 fed (ruflo hooks fai…' to match /fed 3\/3/
+ *
+ * That `expected '' to match /FAILED/` is #105's second half in one line: three feed calls failed
+ * and the process emitted ZERO bytes about it. Its stub sits AT ~/.npm-global/bin/ruflo on purpose,
+ * so the old code resolved the binary perfectly well and the ONLY defect it can go red on is the
+ * swallowed error — otherwise it would fail for the path bug and prove nothing about the catch.
+ *
+ * Every case is measured at the PROCESS boundary with a real HOME on disk, because the defect is a
+ * filesystem-layout assumption and an in-process stub of `os.homedir()` cannot express it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveRuflo } from '../../plugin/scripts/ruflo-bin.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const DISTILL = path.join(REPO, 'scripts', 'distill-project.mjs');
+const LEARN_FLUSH = path.join(REPO, 'plugin', 'scripts', 'learn-flush.mjs');
+
+// The stubs below are `#!/bin/sh` files invoked by PATH lookup. Windows has no shebang execution,
+// and the resolver's .cmd branch is a different code path from the one #99/#105 are about.
+const isWindows = process.platform === 'win32';
+
+let tmp;      // a throwaway project cwd
+let tmpHome;  // an isolated HOME — crucially, one with NO .npm-global at all
+let binDir;   // a directory on PATH, standing in for /opt/homebrew/bin or an nvm shim dir
+
+beforeEach(() => {
+  tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ruflo-bin-')));
+  tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ruflo-bin-home-')));
+  binDir = path.join(tmp, 'opt-bin');
+  fs.mkdirSync(binDir, { recursive: true });
+});
+afterEach(() => {
+  for (const d of [tmp, tmpHome]) {
+    try { fs.rmSync(d, { recursive: true, force: true, maxRetries: 3 }); } catch { /* best effort */ }
+  }
+});
+
+/** Put an executable `ruflo` at `dir`, and return its path. */
+function stubRuflo(dir, body) {
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, 'ruflo');
+  fs.writeFileSync(p, body, { mode: 0o755 });
+  return p;
+}
+
+/**
+ * A child env with a HOME that has no `.npm-global`, and `binDir` FIRST on PATH so the stub wins
+ * over any real ruflo on the developer's machine. RUFLO_BIN is deliberately NOT set: it is the
+ * escape hatch the old code already had, so a test that used it could not go red.
+ */
+const env = (extra = {}) => ({
+  ...process.env,
+  HOME: tmpHome,
+  PATH: binDir + path.delimiter + (process.env.PATH || ''),
+  RUFLO_BIN: undefined,
+  ...extra,
+});
+
+/**
+ * The same env, but with a PATH that contains ONLY `binDir` — for the cases where ruflo must be
+ * genuinely absent. Inheriting the developer's PATH is not good enough: it carries the real
+ * ~/.npm-global/bin, and the resolver would (correctly) find the machine's own ruflo and the case
+ * would prove nothing. Node is spawned by absolute path, and both scripts spawn nothing but ruflo.
+ */
+const envWithNoRuflo = (extra = {}) => env({ PATH: binDir, ...extra });
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// The resolver itself.
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+describe('resolveRuflo — one resolver, four ordered answers', () => {
+  it('RUFLO_BIN is AUTHORITATIVE, returned as given even when it does not exist', () => {
+    // No fallback: an override that quietly resolves to a DIFFERENT ruflo is not an override, and
+    // the caller has to be able to name the exact path the user asked for back to them.
+    stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    const got = resolveRuflo({ env: { RUFLO_BIN: '/nonexistent/ruflo', PATH: binDir }, home: tmpHome });
+    expect(got).toBe('/nonexistent/ruflo');
+  });
+
+  it('prefers ~/.npm-global/bin/ruflo over PATH — Rule 21\'s ONE global binary, not PATH ordering', () => {
+    const preferred = stubRuflo(path.join(tmpHome, '.npm-global', 'bin'), '#!/bin/sh\nexit 0\n');
+    stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    expect(resolveRuflo({ env: { PATH: binDir }, home: tmpHome })).toBe(preferred);
+  });
+
+  it('#99/#105: finds ruflo on PATH when ~/.npm-global does not exist at all', () => {
+    const onPath = stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    expect(fs.existsSync(path.join(tmpHome, '.npm-global')), 'the fixture must model a non-npm-global prefix').toBe(false);
+    expect(resolveRuflo({ env: { PATH: binDir }, home: tmpHome })).toBe(onPath);
+  });
+
+  it('returns null when ruflo is genuinely absent — never a guessed path the user gets blamed for', () => {
+    expect(resolveRuflo({ env: { PATH: binDir }, home: tmpHome })).toBe(null);
+  });
+
+  it('skips unreadable and empty PATH entries instead of throwing', () => {
+    const onPath = stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    const messy = ['', '/nonexistent/dir', binDir].join(path.delimiter);
+    expect(resolveRuflo({ env: { PATH: messy }, home: tmpHome })).toBe(onPath);
+  });
+
+  it('does not mistake a DIRECTORY named ruflo for the binary', () => {
+    fs.mkdirSync(path.join(binDir, 'ruflo'), { recursive: true });
+    expect(resolveRuflo({ env: { PATH: binDir }, home: tmpHome })).toBe(null);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// #99 — scripts/distill-project.mjs
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+describe.skipIf(isWindows)('#99 · distill-project on a non-npm-global prefix', () => {
+  it('runs when ruflo is on PATH but not under ~/.npm-global', () => {
+    stubRuflo(binDir, '#!/bin/sh\n'
+      + 'case "$2" in\n'
+      + '  distill) echo "reasoning_patterns | 10"; echo "episodes | 5"; exit 0;;\n'
+      + 'esac\nexit 0\n');
+    fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.swarm', 'memory.db'), 'x');
+
+    const r = spawnSync(process.execPath, [DISTILL, '--project', tmp, '--dry-run'],
+      { encoding: 'utf8', timeout: 30_000, env: env() });
+
+    // MAGNITUDE, not direction: exit 0 AND the baseline it could only have read by running the
+    // real binary. "Did not say 'not found'" alone would also be satisfied by a script that died
+    // somewhere else.
+    expect(r.stderr).not.toMatch(/ruflo is not at/);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/before\s*:\s*10 patterns, 5 episodes/);
+  });
+
+  it('when ruflo is nowhere, it names BOTH places it looked', () => {
+    fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.swarm', 'memory.db'), 'x');
+
+    const r = spawnSync(process.execPath, [DISTILL, '--project', tmp, '--dry-run'],
+      { encoding: 'utf8', timeout: 30_000, env: envWithNoRuflo() });
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/\.npm-global/);
+    expect(r.stderr).toMatch(/PATH/);
+    expect(r.stderr).toMatch(/npm i -g ruflo@latest/);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// #105 — plugin/scripts/learn-flush.mjs
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+describe.skipIf(isWindows)('#105 · learn-flush on a non-npm-global prefix, and its swallowed errors', () => {
+  /** A queue of `n` DISTINCT captures — distinct because learn-flush dedupes before it feeds. */
+  function seedQueue(n) {
+    const q = path.join(tmp, 'queue.jsonl');
+    const lines = [];
+    for (let i = 0; i < n; i++) lines.push(JSON.stringify({ tool: 'Bash', action: `verb${i}` }));
+    fs.writeFileSync(q, lines.join('\n') + '\n');
+    return q;
+  }
+
+  const flush = (q, extraEnv = {}) => spawnSync(process.execPath, [LEARN_FLUSH, '--sync'], {
+    cwd: tmp,
+    input: JSON.stringify({ session_id: 'ruflo-bin-sess', hook_event_name: 'SessionEnd' }),
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: env({ LEARN_QUEUE: q, RUVNET_LEARNING_SCOPE: 'project', ...extraEnv }),
+  });
+
+  it('feeds the learner when ruflo is on PATH but not under ~/.npm-global', () => {
+    stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    const q = seedQueue(3);
+
+    const r = flush(q);
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/fed 3\/3/);
+    // DERIVED, not asserted: the queue is only destroyed when its contents were actually fed.
+    expect(fs.existsSync(q), 'a fully fed queue must be removed').toBe(false);
+  });
+
+  it('a FAILING feed is OBSERVABLE — the error reaches stderr instead of `catch {}`', () => {
+    // The stub goes AT ~/.npm-global/bin/ruflo on purpose: the old code resolved that path
+    // perfectly well, so the only defect this case can go red on is the swallowed error.
+    stubRuflo(path.join(tmpHome, '.npm-global', 'bin'), '#!/bin/sh\necho "boom: learner refused" >&2\nexit 7\n');
+    const q = seedQueue(3);
+
+    const r = flush(q);
+
+    expect(r.stderr).toMatch(/learn-flush:.*FAILED/);
+    expect(r.stderr).toMatch(/3\/3 feed call\(s\) FAILED/);
+    expect(r.stderr).toMatch(/queue is KEPT for retry/);
+  });
+
+  it('…and still exits 0 with the queue intact — observable, but never crashes SessionEnd', () => {
+    stubRuflo(path.join(tmpHome, '.npm-global', 'bin'), '#!/bin/sh\nexit 7\n');
+    const q = seedQueue(3);
+
+    const r = flush(q);
+
+    expect(r.status, 'a failing optional learner must not break session end').toBe(0);
+    expect(fs.readFileSync(q, 'utf8').split('\n').filter(Boolean).length, 'nothing fed ⇒ nothing discarded').toBe(3);
+  });
+
+  it('reports ONCE, bounded, when ruflo is nowhere at all — not eight silent ENOENTs', () => {
+    const q = seedQueue(3);
+
+    const r = flush(q, { PATH: binDir });
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/learn-flush: 0\/3 fed/);
+    expect(r.stderr).toMatch(/\.npm-global/);
+    expect(r.stderr).toMatch(/PATH/);
+    // Bounded: one line about the failure, not one per action.
+    const lines = r.stderr.split('\n').filter((l) => l.startsWith('learn-flush:'));
+    expect(lines.length).toBe(1);
+    expect(fs.readFileSync(q, 'utf8').split('\n').filter(Boolean).length).toBe(3);
+  });
+
+  it('TEETH: a healthy learner produces NO failure noise — the report is not always-on', () => {
+    stubRuflo(binDir, '#!/bin/sh\nexit 0\n');
+    const q = seedQueue(3);
+
+    const r = flush(q);
+
+    expect(r.stderr).not.toMatch(/FAILED/);
+    expect(r.stdout).toMatch(/fed 3\/3/);
+  });
+});

--- a/tests/unit/rvf-generation.test.mjs
+++ b/tests/unit/rvf-generation.test.mjs
@@ -57,6 +57,46 @@ describe('checksum-bound RVF generation identity', () => {
     ]);
   });
 
+  // The pre-push gate (scripts/sync-version.mjs) verifies the COMMITTED ledger only. `kb/*.rvf` is
+  // gitignored, so byte comparison there described the machine rather than the commit and blocked
+  // every push — tags included — with a remedy line that could not clear it. These cases pin the
+  // narrow contract of that mode: it drops byte checks and ONLY byte checks.
+  it('verifyBytes:false ignores byte drift and absent RVFs — the push-time contract', () => {
+    const dir = fixtureDir();
+    fs.writeFileSync(path.join(dir, 'demo.big.rvf'), Buffer.from('rvf generation one'));
+    writeRvfGeneration({ dir, store: 'demo', model: 'm', dimensions: 768, sourceCommit: 'abc123' });
+
+    // byte drift: fails closed by default, ignored under the push-time contract
+    fs.appendFileSync(path.join(dir, 'demo.big.rvf'), 'changed');
+    expect(verifyRvfGenerations(dir).failures).toEqual([expect.stringContaining('demo: sha256=')]);
+    expect(verifyRvfGenerations(dir, { verifyBytes: false }).failures).toEqual([]);
+
+    // absent RVF: the real shape (ledger has 72 stores, a working checkout has 71)
+    fs.rmSync(path.join(dir, 'demo.big.rvf'));
+    expect(verifyRvfGenerations(dir).failures).toEqual([expect.stringContaining('demo: missing')]);
+    expect(verifyRvfGenerations(dir, { verifyBytes: false }).failures).toEqual([]);
+  });
+
+  it('TEETH: verifyBytes:false is NOT a mute button — committed ledger drift still fails', () => {
+    const dir = fixtureDir();
+    fs.writeFileSync(path.join(dir, 'demo.big.rvf'), Buffer.from('rvf generation one'));
+    writeRvfGeneration({ dir, store: 'demo', model: 'm', dimensions: 768, sourceCommit: 'abc123' });
+
+    // brainVersion/releaseTag ARE committed, so they must still fail closed in push-time mode.
+    const file = path.join(dir, RVF_GENERATIONS_FILE);
+    const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+    manifest.brainVersion = '0.0.0-wrong';
+    fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    expect(verifyRvfGenerations(dir, { verifyBytes: false }).failures).toEqual([
+      expect.stringContaining('brainVersion=0.0.0-wrong'),
+    ]);
+    // and a store the ledger has never heard of is still reported, bytes or not
+    expect(
+      verifyRvfGenerations(dir, { verifyBytes: false, requiredStores: ['ghost'] }).failures,
+    ).toContainEqual(expect.stringContaining('ghost: no generation record'));
+  });
+
   it('merges another store without losing the previous generation record', () => {
     const dir = fixtureDir();
     fs.writeFileSync(path.join(dir, 'one.big.rvf'), 'one');

--- a/tests/unit/update-not-landed-exit.test.mjs
+++ b/tests/unit/update-not-landed-exit.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * `npx ruvnet-brain --update` — issue #106: it exited 0 while the corpus was unchanged.
+ *
+ * The updater itself was never the problem. It detected the failure, named it, and refused:
+ *
+ *     [forge-update] ERROR: [open-claude-code] UPDATE MISMATCH: SOURCE.json on disk is IDENTICAL
+ *     to before the update … REFUSING to report success.
+ *
+ * and then exited non-zero — at which point `--update`'s fresh-install FALLBACK ran, succeeded at
+ * re-installing the very same bytes, and ITS exit 0 became the exit code of the whole command. The
+ * refusal survived only as a line in a log nobody reads; a scheduled job saw success.
+ *
+ * The fallback exists for one real case: an old bundle whose canonical manifest 404s, where a fresh
+ * install genuinely rescues the user. "Nothing landed" is not that case. It is a true verdict about
+ * an intact KB, and re-downloading cannot change it — so it is terminal, and it keeps its own exit
+ * code so a caller can tell "nothing to do" apart from "something broke".
+ *
+ * The exit code crosses an artifact boundary: kb/forge-update.mjs ships inside the KB BUNDLE and
+ * versions independently of bin/install.mjs, so the number cannot be imported and is written in
+ * both. This file is what stops the two from drifting apart in silence.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+let install; let forgeUpdate;
+
+beforeAll(async () => {
+  process.env.RUVNET_BRAIN_IMPORT_ONLY = '1';
+  install = await import(`${pathToFileURL(path.join(ROOT, 'bin', 'install.mjs')).href}?notlanded=${Date.now()}`);
+  forgeUpdate = await import(pathToFileURL(path.join(ROOT, 'kb', 'forge-update.mjs')).href);
+});
+afterAll(() => { delete process.env.RUVNET_BRAIN_IMPORT_ONLY; });
+
+describe('the "nothing landed" exit code is one number in two artifacts', () => {
+  it('bin/install.mjs and kb/forge-update.mjs agree on it', () => {
+    // Both must be REAL numbers first: two undefineds are also "equal", and an agreement between
+    // two absent constants is exactly the vacuous green this file exists to prevent.
+    expect(typeof install.UPDATE_NOT_LANDED, 'bin/install.mjs must export it').toBe('number');
+    expect(typeof forgeUpdate.EXIT_NOT_LANDED, 'kb/forge-update.mjs must export it').toBe('number');
+    expect(install.UPDATE_NOT_LANDED).toBe(forgeUpdate.EXIT_NOT_LANDED);
+  });
+
+  it('is distinct from every other verdict the updater can return', () => {
+    // 0 success · 1 generic error · 2 network · 3/4 signature · 10 --check says behind.
+    expect(Number.isInteger(forgeUpdate.EXIT_NOT_LANDED)).toBe(true);
+    expect([0, 1, 2, 3, 4, 10]).not.toContain(forgeUpdate.EXIT_NOT_LANDED);
+  });
+
+  it('is documented in forge-update.mjs itself, so the meaning travels with the bundle', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'kb', 'forge-update.mjs'), 'utf8');
+    expect(src).toMatch(/EXIT CODES/);
+    expect(src).toMatch(new RegExp(`\\s${forgeUpdate.EXIT_NOT_LANDED}\\s+--apply: the download completed but the bundle on disk did NOT change`));
+  });
+});
+
+describe('classifyUpdaterExit (issue #106)', () => {
+  it('does NOT fall back to a fresh install when the updater says nothing landed, and keeps the failure', () => {
+    // The whole bug in one assertion: the fallback is what converted this verdict into exit 0.
+    const r = install.classifyUpdaterExit(install.UPDATE_NOT_LANDED);
+
+    expect(r.verdict).toBe('not-landed');
+    expect(r.fallback, 're-downloading the same bundle cannot make it different').toBe(false);
+    expect(r.exitCode, 'a scheduled job must read this as failure').not.toBe(0);
+    expect(r.exitCode).toBe(install.UPDATE_NOT_LANDED);
+  });
+
+  it('still falls back for a genuinely broken updater — the 404 case the fallback was built for', () => {
+    const r = install.classifyUpdaterExit(2);
+    expect(r.verdict).toBe('failed');
+    expect(r.fallback, 'a user stranded at a dead manifest URL must still be rescued').toBe(true);
+  });
+
+  it('honours the fallback opt-out without turning a failure into a success', () => {
+    const r = install.classifyUpdaterExit(1, { fallbackAllowed: false });
+    expect(r.fallback).toBe(false);
+    expect(r.exitCode).toBe(1);
+  });
+
+  it('passes a real success through untouched', () => {
+    expect(install.classifyUpdaterExit(0)).toEqual({ verdict: 'updated', fallback: false, exitCode: 0 });
+  });
+
+  it('never reports exit 0 for any non-zero updater status', () => {
+    for (const status of [1, 2, 3, 4, 10, install.UPDATE_NOT_LANDED, 127]) {
+      expect(install.classifyUpdaterExit(status, { fallbackAllowed: false }).exitCode, `status ${status}`).not.toBe(0);
+    }
+  });
+});

--- a/tests/unit/whats-new-runtime-assets.test.mjs
+++ b/tests/unit/whats-new-runtime-assets.test.mjs
@@ -1,0 +1,111 @@
+// Issue #76 — the installed What's New skill lost its release-note asset after a supported install.
+//
+// The notes are packed (npm ships plugin/docs/RELEASE-NOTES-4.0.md) and they are read correctly
+// (plugin/scripts/whats-new.mjs resolves them from its own plugin root). They were lost in between:
+// the persistent Console runtime — the surface issue #76 names as the fix location — copied
+// plugin/scripts and none of the sibling assets that executable reads, so the installed What's New
+// executable travelled to every clean install without its version manifest or its notes.
+//
+// These tests execute the real boundary from a staged runtime with no checkout in reach.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { installConsoleRuntime } from '../../bin/install.mjs';
+
+const REPO = path.resolve(import.meta.dirname, '../..');
+const PACKAGE_VERSION = JSON.parse(fs.readFileSync(path.join(REPO, 'package.json'), 'utf8')).version;
+const NOTES = path.join('plugin', 'docs', 'RELEASE-NOTES-4.0.md');
+const MANIFEST = path.join('plugin', '.claude-plugin', 'plugin.json');
+const temps = [];
+
+function tempDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+/** Run the installed What's New executable from `runtime`, with the cwd nowhere near a checkout. */
+function runWhatsNew(runtime) {
+  const elsewhere = tempDir('brain-whats-new-elsewhere-');
+  return spawnSync(process.execPath, [path.join(runtime, 'plugin', 'scripts', 'whats-new.mjs')], {
+    cwd: elsewhere,
+    env: { ...process.env, HOME: elsewhere, USERPROFILE: elsewhere },
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+}
+
+/**
+ * A staged runtime is itself a valid candidate source: every surface path is laid out identically on
+ * both sides. Building candidates this way keeps the fixture on the shipped file manifest instead of
+ * a second, drifting list of its own.
+ */
+function candidateSource(mutate = () => {}) {
+  const source = path.join(tempDir('brain-whats-new-candidate-'), 'source');
+  fs.cpSync(installedRuntime(), source, { recursive: true });
+  mutate(source);
+  return source;
+}
+
+let pristine = null;
+function installedRuntime() {
+  if (!pristine) {
+    const cache = tempDir('brain-whats-new-runtime-');
+    installConsoleRuntime(cache, REPO);
+    pristine = path.join(cache, '.console-runtime');
+  }
+  return pristine;
+}
+
+afterEach(() => {
+  pristine = null;
+  for (const dir of temps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('issue #76 installed What\'s New assets', () => {
+  it('reports the installed version and curated notes from the persistent runtime alone', () => {
+    const runtime = installedRuntime();
+
+    expect(fs.existsSync(path.join(runtime, NOTES))).toBe(true);
+    expect(fs.readFileSync(path.join(runtime, NOTES)))
+      .toEqual(fs.readFileSync(path.join(REPO, NOTES)));
+    expect(JSON.parse(fs.readFileSync(path.join(runtime, MANIFEST), 'utf8')).version)
+      .toBe(PACKAGE_VERSION);
+
+    const run = runWhatsNew(runtime);
+    expect(run.stderr).toBe('');
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(`RuvNet Brain ${PACKAGE_VERSION}`);
+    expect(run.stdout).toContain('# RuvNet-Brain 4.0 line');
+  });
+
+  it('refuses to activate a candidate whose curated notes are missing, keeping the prior runtime', () => {
+    const runtime = installedRuntime();
+    const cache = path.resolve(runtime, '..');
+    const broken = candidateSource((source) => fs.rmSync(path.join(source, NOTES), { force: true }));
+
+    expect(() => installConsoleRuntime(cache, broken)).toThrow(/RELEASE-NOTES|plugin\/docs|release notes/i);
+
+    expect(fs.readFileSync(path.join(runtime, NOTES)))
+      .toEqual(fs.readFileSync(path.join(REPO, NOTES)));
+    expect(runWhatsNew(runtime).status).toBe(0);
+  });
+
+  it('refuses a candidate whose version metadata cannot be read by the executable itself', () => {
+    const runtime = installedRuntime();
+    const cache = path.resolve(runtime, '..');
+    const broken = candidateSource((source) => {
+      const file = path.join(source, MANIFEST);
+      const manifest = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : {};
+      delete manifest.version;
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`);
+    });
+
+    expect(() => installConsoleRuntime(cache, broken)).toThrow(/version metadata is missing|release notes/i);
+    expect(runWhatsNew(runtime).status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why this is first

Nothing could ship. `git push --dry-run` on a plain branch was **refused**, tags included — the 4.0.7 "emergency promotion" recorded in project memory was this gate, not a process failure.

## 1. The gate described the machine, not the commit

`sync-version.mjs` scanned the working directory for `kb/*.big.rvf` and byte-compared every ledger row. Those binaries are **gitignored** (`.gitignore:28`), so the verdict was about local disk state. Structurally unsatisfiable: the ledger records **72** stores, a real checkout has **71**, because the nightly rebuilds RVFs and regenerates the ledger as one step (`kb/forge-refresh.mjs:242`). And its own remedy line — `Run: node scripts/sync-version.mjs` — **cannot clear it**: the check lives under `if (CHECK)` and write mode never regenerates.

`verifyRvfGenerations` gains `verifyBytes`. The gate now verifies the committed ledger fields only. Bytes are verified where they are actually present and actually shipped — `build-bundle.mjs:204-214` — which is exactly what sync-version's own deferral comment promised but never had a caller for. Same rule `release.mjs:100` already states: *a verdict is only about the exact committed candidate*.

## 2. #99 and #105 are one defect filed twice

Both hardcoded `~/.npm-global/bin/ruflo`. On Homebrew/nvm/Volta, #99 died outright and #105 failed **every feed** inside a silent `catch {}`. `health-repair.mjs` had already fixed this privately; `capability-registry.mjs` had since hardened it (dropping `sh -lc`, which sources the user's entire profile to answer "where is ruflo?"). Extracted the **hardened** form to `plugin/scripts/ruflo-bin.mjs` so a third paste cannot happen. `learn-flush` now reports failures on stderr; exit 0 preserved so a failing optional learner never crashes SessionEnd.

## Proof the tests can fail

- `verifyBytes:false` TEETH case goes **red** when the early-return is moved above the committed-field checks
- the #105 case goes **red** against the old code with `expected '' to match /FAILED/` — three failed feeds, zero bytes emitted

**28 passing** across the three affected suites.

## Known follow-ups (deliberately not in this PR)

`health-repair.mjs`, `agentdb-fleet-doctor.mjs:25`, `onboarding-console.mjs:2161`, `nightly-wrapper.sh:81,84` still hold their own copies of the resolver. Same class, separate change.

Closes #99, closes #105.