### PR TITLE
release(4.0.10): land the #86/#87 proofs that shipped without them

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.0.9 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.0.9-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.0.10 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.0.10-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.0.9",
+  "brainVersion": "4.0.10",
   "generated": "2026-07-30T07:24:51.903Z",
   "generatedHuman": "Thu, 30 Jul 2026 07:24:51 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.0.9",
+    "softwareVersion": "4.0.10",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 69 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.0.9</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.0.10</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.0.9",
-  "releaseTag": "v4.0.9",
+  "brainVersion": "4.0.10",
+  "releaseTag": "v4.0.10",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.0.9",
+      "version": "4.0.10",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 69 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.0.9 · Built: 2026-07-30 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.0.10 · Built: 2026-07-30 · Covers: 69/192 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/tests/unit/model-catalog-packaging.test.mjs
+++ b/tests/unit/model-catalog-packaging.test.mjs
@@ -45,7 +45,11 @@ async function requiredConsoleAssets() {
 
 /** The REAL published file list, from npm itself — never a restatement of package.json#files. */
 function packedFiles() {
-  const report = JSON.parse(execFileSync('npm', ['pack', '--dry-run', '--json'], {
+  // On Windows npm is `npm.cmd`; execFileSync spawns without a shell, so a bare 'npm' is
+  // ENOENT there. Third instance of this exact class on this branch (ruflo.cmd was the other
+  // two), which is why the name is resolved rather than assumed.
+  const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const report = JSON.parse(execFileSync(NPM, ['pack', '--dry-run', '--json'], {
     cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
   }));
   // npm reports paths with the HOST separator, so on Windows every entry comes back as

--- a/tests/unit/model-catalog-packaging.test.mjs
+++ b/tests/unit/model-catalog-packaging.test.mjs
@@ -1,0 +1,100 @@
+// tests/unit/model-catalog-packaging.test.mjs — issue #86, both halves of it.
+//
+// #86 was a RELEASE-BOUNDARY bug, not a logic bug: `data/model-catalog.json` was read by
+// scripts/model-catalog.mjs and staged by beginConsoleRuntimeTransaction(), but was absent from the
+// npm `files` allow-list, so the published package simply did not contain it. Everything passed in a
+// developer checkout. The console then reported the user's OpenAI/Google keys as absent while its own
+// native detector saw them.
+//
+// TWO GUARDS, because a packaging fix alone leaves the lie one regression away:
+//
+//   1. THE MANIFEST GUARD. The required-asset set is DERIVED from bin/install.mjs's own `required`
+//      table and checked against the REAL `npm pack --dry-run --json` file list. A hardcoded list
+//      would only restate today's answer; this fails the moment those two independently-maintained
+//      lists disagree — which is exactly the divergence that shipped #86.
+//   2. THE HONESTY GUARD. With the asset genuinely unreachable, the API must publish an explicit
+//      not-verified signal, and the Console must render "not checked" rather than a confident ✗.
+//      An instrument that could not run has found nothing; it has not found "no key".
+
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const CATALOG_ASSET = 'data/model-catalog.json';
+
+/** The assets the persistent Console runtime refuses to start without, taken from whichever
+ *  declaration the installer currently owns, so this test tracks the code it guards instead of
+ *  restating a list of its own. It fails loudly if neither declaration can be found — an empty
+ *  required-set would make the guard below vacuous, which is the one outcome that must not be quiet. */
+async function requiredConsoleAssets() {
+  const surfaceModule = path.join(ROOT, 'scripts', 'console-runtime-identity.mjs');
+  if (fs.existsSync(surfaceModule)) {
+    const { CONSOLE_RUNTIME_SURFACE } = await import(pathToFileURL(surfaceModule).href);
+    if (Array.isArray(CONSOLE_RUNTIME_SURFACE) && CONSOLE_RUNTIME_SURFACE.length) return CONSOLE_RUNTIME_SURFACE;
+  }
+  const source = fs.readFileSync(path.join(ROOT, 'bin', 'install.mjs'), 'utf8');
+  const block = source.match(/const required = \[(.*?)\n {2}\];/s);
+  expect(block, 'the installer no longer declares its required Console assets anywhere this test can read').toBeTruthy();
+  const assets = [...block[1].matchAll(/\['([^']+)',/g)].map((m) => m[1]);
+  expect(assets.length).toBeGreaterThan(3);
+  return assets;
+}
+
+/** The REAL published file list, from npm itself — never a restatement of package.json#files. */
+function packedFiles() {
+  const report = JSON.parse(execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+  }));
+  return report[0].files.map((entry) => entry.path);
+}
+
+describe('issue #86 — the model catalog must actually ship', () => {
+  it('publishes every asset the Console runtime declares it requires', async () => {
+    const packed = new Set(packedFiles());
+    const missing = (await requiredConsoleAssets()).filter((asset) => {
+      if (asset === 'package.json') return false; // npm always includes it, never listed in `files`
+      return !packed.has(asset) && ![...packed].some((file) => file.startsWith(`${asset}/`));
+    });
+    expect(missing, `the published package omits Console-required asset(s): ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('publishes a model catalog that parses with real providers', () => {
+    expect(packedFiles()).toContain(CATALOG_ASSET);
+    const catalog = JSON.parse(fs.readFileSync(path.join(ROOT, CATALOG_ASSET), 'utf8'));
+    expect(Object.keys(catalog.providers || {}).length).toBeGreaterThan(0);
+  });
+}, 120_000);
+
+describe('issue #86 — an unreachable catalog is reported as not checked, never as "no key"', () => {
+  it('the API publishes keysVerified:false so no consumer can present keys as a measurement', async () => {
+    const { gatherRouterEngine } = await import('../../scripts/onboarding-console.mjs');
+    const before = process.env.RUVNET_MODEL_CATALOG;
+    try {
+      process.env.RUVNET_MODEL_CATALOG = path.join(ROOT, 'data', 'model-catalog.json');
+      expect(gatherRouterEngine().providerCatalog).toMatchObject({ status: 'ok', keysVerified: true });
+
+      process.env.RUVNET_MODEL_CATALOG = '/definitely/not/packaged/model-catalog.json';
+      expect(gatherRouterEngine().providerCatalog).toMatchObject({ status: 'degraded', keysVerified: false });
+    } finally {
+      if (before === undefined) delete process.env.RUVNET_MODEL_CATALOG;
+      else process.env.RUVNET_MODEL_CATALOG = before;
+    }
+  });
+
+  it('the Console renders a third not-checked state instead of a confident absence', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'console', 'app.js'), 'utf8');
+    // The chip decision consults catalog health, and the "no key found" claim is unreachable
+    // without it: providerKeyChip returns the not-checked branch before it ever reads `keys`.
+    expect(source).toMatch(/function providerKeyChip\(id, keys, keysVerified, names\)/);
+    expect(source).toMatch(/if \(!keysVerified\) \{[\s\S]*?plan-key unknown[\s\S]*?\}\s*const found = !!keys\[id\];/);
+    expect(source).toMatch(/const keysVerified = !catalogHealth\s*\|\|/);
+    expect(source).toMatch(/catalogHealth\.keysVerified !== false && catalogHealth\.status !== 'degraded'/);
+    expect(source).toContain('providerKeyChip(id, keys, keysVerified, KEY_NAME)');
+    // The old shape — a two-state chip computed straight off `keys` inside renderProviders — is gone.
+    expect(source).not.toMatch(/\.\.\.others\.map\(\(id\) => \{\s*\n\s*const ok = !!keys\[id\];/);
+    expect(fs.readFileSync(path.join(ROOT, 'console', 'style.css'), 'utf8')).toContain('.plan-key.unknown');
+  });
+});

--- a/tests/unit/model-catalog-packaging.test.mjs
+++ b/tests/unit/model-catalog-packaging.test.mjs
@@ -48,7 +48,11 @@ function packedFiles() {
   const report = JSON.parse(execFileSync('npm', ['pack', '--dry-run', '--json'], {
     cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
   }));
-  return report[0].files.map((entry) => entry.path);
+  // npm reports paths with the HOST separator, so on Windows every entry comes back as
+  // `data\\model-catalog.json` and every comparison against the declared `data/model-catalog.json`
+  // fails — a green-on-POSIX, red-on-Windows test that says nothing about packaging. The manifest
+  // is defined in forward slashes because that is what npm publishes, so normalise to that.
+  return report[0].files.map((entry) => entry.path.split(path.sep).join('/'));
 }
 
 describe('issue #86 — the model catalog must actually ship', () => {

--- a/tests/unit/model-router-update-convergence.test.mjs
+++ b/tests/unit/model-router-update-convergence.test.mjs
@@ -1,0 +1,135 @@
+// tests/unit/model-router-update-convergence.test.mjs — issue #87's actual mechanism.
+//
+// mergeManagedCatalog() was already correct, and the managed template already carries the new Claude
+// candidate. The reason a user still never acquired it: the merge's ONLY caller was
+// offerRouterProfile(), which runs on the FRESH-INSTALL path. runUpdate() — `--update`, and therefore
+// the Evergreen nightly job — never reached it. So the merge could only ever help someone who had no
+// ~/.claude/model-router/catalog.json yet, i.e. precisely the population that was never behind. Every
+// existing user, the only ones who can be missing a model, updated forever and converged on nothing.
+//
+// The regression test that matters is therefore NOT another unit test of the merge function. It is:
+// run the REAL update entrypoint against an old user catalog and assert the file on disk changed.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { applyManagedCatalogUpdate } from '../../scripts/model-router-catalog.mjs';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const INSTALLER = path.join(ROOT, 'bin', 'install.mjs');
+const MANAGED = JSON.parse(fs.readFileSync(
+  path.join(ROOT, 'config', 'model-router', 'catalog.template.json'), 'utf8',
+));
+// Never a model name from memory or from this test's own opinion: the candidates under test are the
+// managed subscription rows the shipped template actually carries, whatever they are today.
+const MANAGED_SUBSCRIPTION_IDS = MANAGED.candidates
+  .filter((candidate) => (candidate.subscription || []).length > 0)
+  .map((candidate) => candidate.id);
+const temps = [];
+
+function temporary(prefix) {
+  const value = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  temps.push(value);
+  return value;
+}
+
+/** The staged plugin payload `--host-sync-only` converges onto, exactly as the Console runtime
+ *  transaction suite builds it — without it the Stable Spine refuses and the update exits non-zero. */
+function stagedPayload(home) {
+  const version = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')).version;
+  const dir = path.join(home, '.claude', 'plugins', 'cache', 'ruvnet-brain', 'ruvnet-brain', version);
+  for (const relative of ['scripts', 'hooks', '.claude-plugin', 'commands']) {
+    fs.mkdirSync(path.join(dir, relative), { recursive: true });
+  }
+  fs.writeFileSync(path.join(dir, 'scripts', 'body.mjs'), `export default ${JSON.stringify(version)};\n`);
+  fs.writeFileSync(path.join(dir, 'hooks', 'hooks.json'), '{"hooks":{}}\n');
+  fs.writeFileSync(path.join(dir, 'commands', 'rvbc.md'), '# console\n');
+  fs.writeFileSync(path.join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ version }));
+}
+
+/** A user who installed before the new managed model existed, carrying a real override. */
+function oldUserCatalog(routerDir) {
+  fs.mkdirSync(routerDir, { recursive: true });
+  const catalog = {
+    updated: '2026-07-12 (local)',
+    candidates: [
+      { id: 'claude-opus-4-8', provider: 'anthropic', harness: [], subscription: [], tier: 'mid', disabled: true },
+      { id: 'custom/local', provider: 'local', harness: ['claude-code'], subscription: [], tier: 'cheap' },
+    ],
+  };
+  const file = path.join(routerDir, 'catalog.json');
+  fs.writeFileSync(file, `${JSON.stringify(catalog, null, 2)}\n`);
+  return { file, catalog };
+}
+
+afterEach(() => {
+  for (const value of temps.splice(0)) fs.rmSync(value, { recursive: true, force: true });
+});
+
+describe('issue #87 — managed additions reach an existing user', () => {
+  it('adds the managed candidate, preserves overrides, and never auto-enables a metered row', () => {
+    const routerDir = path.join(temporary('brain-issue87-merge-'), '.claude', 'model-router');
+    const { file, catalog } = oldUserCatalog(routerDir);
+
+    const receipt = applyManagedCatalogUpdate({ routerDir, packageRoot: ROOT });
+    expect(receipt.action).toBe('merged');
+
+    const merged = JSON.parse(fs.readFileSync(file, 'utf8'));
+    // Every managed subscription row the template ships is now reachable — including the Claude
+    // model this user's pre-existing catalog predated, which is the whole of #87.
+    const ids = merged.candidates.map((c) => c.id);
+    for (const id of MANAGED_SUBSCRIPTION_IDS) expect(ids).toContain(id);
+    // The user's overlay wins byte-for-byte, disablement and re-tiering included.
+    expect(merged.candidates.find((c) => c.id === 'claude-opus-4-8')).toEqual(catalog.candidates[0]);
+    expect(merged.candidates).toContainEqual(catalog.candidates[1]);
+    // Managed updates may never quietly widen spend authority.
+    expect(merged.candidates.filter((c) => c.provider === 'openrouter')).toEqual([]);
+    // The pre-merge file is kept, so a surprised user can always get their original back.
+    expect(JSON.parse(fs.readFileSync(`${file}.pre-managed-merge`, 'utf8'))).toEqual(catalog);
+  });
+
+  it('is idempotent and leaves no staging debris', () => {
+    const routerDir = path.join(temporary('brain-issue87-idempotent-'), '.claude', 'model-router');
+    const { file } = oldUserCatalog(routerDir);
+    applyManagedCatalogUpdate({ routerDir, packageRoot: ROOT });
+    const once = fs.readFileSync(file);
+
+    expect(applyManagedCatalogUpdate({ routerDir, packageRoot: ROOT }).action).toBe('unchanged');
+    expect(fs.readFileSync(file)).toEqual(once);
+    expect(fs.readdirSync(routerDir).filter((name) => name.includes('.tmp-'))).toEqual([]);
+  });
+
+  it('THE REAL PATH: `--update` converges an existing user catalog, not just a fresh install', () => {
+    const home = temporary('brain-issue87-update-');
+    const kb = path.join(home, '.cache', 'ruvnet-brain', 'kb');
+    fs.mkdirSync(path.join(kb, '.console-runtime', 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(kb, '.console-runtime', 'scripts', 'onboarding-console.mjs'), '// PRIOR\n');
+    stagedPayload(home);
+    const routerDir = path.join(home, '.claude', 'model-router');
+    const { file, catalog } = oldUserCatalog(routerDir);
+
+    const run = spawnSync(process.execPath, [INSTALLER, '--update', '--host-sync-only'], {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        CODEX_HOME: path.join(home, '.codex'),
+        RUVNET_BRAIN_HOME: path.join(home, '.cache', 'ruvnet-brain'),
+        RUVNET_BRAIN_KB: kb,
+        RUVNET_BRAIN_TEST: '1',
+      },
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+    expect(run.status, `${run.stdout}\n${run.stderr}`).toBe(0);
+
+    const after = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const ids = after.candidates.map((c) => c.id);
+    for (const id of MANAGED_SUBSCRIPTION_IDS) expect(ids, `${id} never reached the user's catalog`).toContain(id);
+    expect(after.candidates.find((c) => c.id === 'claude-opus-4-8')).toEqual(catalog.candidates[0]);
+    expect(after.candidates).toContainEqual(catalog.candidates[1]);
+    expect(after.candidates.filter((c) => c.provider === 'openrouter')).toEqual([]);
+  }, 120_000);
+});


### PR DESCRIPTION
The product code for #86/#87 merged in 257cbb0, but its two test files were left untracked — the fix shipped without the tests that prove it.

That includes the packaging guard, which derives its required-asset set from the installer's own `CONSOLE_RUNTIME_SURFACE` and checks it against real `npm pack --dry-run --json` output. Two independently-maintained lists with nothing asserting they agree is exactly what shipped #86; that guard is the only thing between it and its own recurrence. A fix whose proof sits in an untracked file is one regression away from silent.

Verified red by reintroducing the exact regression — removing `data/model-catalog.json` from `package.json#files` — and watching the guard fail. 7 tests green.

**Version:** 4.0.9 was never published, so it does not ship; this is 4.0.10. The version gate is right that a push without a bump is an update nothing can see — satisfying it was cheaper than arguing with it.