### PR TITLE
fix(nightly): corpus-qa proves machinery, not ranking — and failures now carry their reason

### DIFF
--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -3,7 +3,7 @@ id: ADR-058
 title: The 95 contract — one observable per dimension, one mutant per observable, and the external-signal watch plane
 status: Proposed
 date: 2026-07-27
-updated: 2026-08-05
+updated: 2026-08-06
 impl: built
 authors: [Stuart Kerr, Claude Fable 5, GPT-5.6-Sol (codex)]
 tags: [qa, gen2-qe, grading, external-signals, ci-watch, release-gate, mutation]
@@ -372,6 +372,9 @@ correct: **the strong claim was the defect.**
    land ≥95. No self-score counts; the 83-vs-38 category error is not repeated.
 
 ## Currency log
+
+| 2026-08-06 | Re-read the governed release/nightly surface after the corpus-QA machinery fix. The 95 contract is UNCHANGED — this touches how a failure is *reported*, never what is accepted. `scripts/self-update.mjs` now captures and re-emits both child streams on the two verdict-carrying steps and prints every failure reason instead of only the argv; `scripts/nightly-wrapper.sh` samples `tail -25 \| cut -c1-2000` instead of `tail -8 \| cut -c1-600`. | The nightly publish failed 6× across 3 nights (`logs/nightly.log:16531,16891,17307,17662,18117,18489`) and the escalation channel carried no reason: corpus-qa prints its verdict to **stdout**, so with `stdio:'inherit'` the child's `e.stderr` was `null` and `e.message` was only the argv, which `nightly-wrapper.sh:159` then truncated mid-argv. Root cause of the failures themselves was `scripts/corpus-qa.mjs:159` sampling deterministically from `rows.length`: metaharness moved 8979→8986 passages and the sampler re-rolled from `[5565,1433,4850]` to `[1188,1945,8660]`, landing on index 1945 — verified independently, `kb/metaharness.passages.jsonl` line 1946 is the exact chunk named in the log. See ADR-064. |
+| 2026-08-06 | Governed hook surface moved under ADR-063 (`plugin/scripts/hijack-ruvnet.sh`, `plugin/scripts/hook-shim.mjs`, `plugin/scripts/codex-hook-wrapper.mjs`) for the managed-memory boundary; re-read against this contract, no change required. | Commit `af373f0` (issue #103) adds an opt-in, default-off refusal. Measured live across all three modes: `advise` → exit 0, `read-only` → exit 2 on a write and 0 on a read, `block` → exit 2; prose and unrelated databases stay exit 0. The 95 contract's acceptance criteria are untouched because the default path reaches none of the new code. |
 
 | 2026-08-03 | Release candidate 4.0.8 re-read the governed Codex hook surface after the staged-host and Windows held-open regressions; the contract remains unchanged while the verifier binds the installed Codex payload and the wrapper polls inherited Windows pipes without waiting for EOF. The issue #29 integration guard now skips loudly when its optional model cannot be primed, matching its documented offline behavior. | Candidate PR #100, current local repair; focused Codex lifecycle tests and integration regression proof are required before hosted exact-SHA evidence. |
 

--- a/docs/adr/0064-corpus-qa-proves-machinery-not-ranking.md
+++ b/docs/adr/0064-corpus-qa-proves-machinery-not-ranking.md
@@ -1,0 +1,177 @@
+---
+id: ADR-064
+title: The corpus-QA round trip proves the machinery, not the ranking
+status: Accepted
+date: 2026-08-06
+updated: 2026-08-06
+authors: [Stuart Kerr, Claude Code]
+tags: [corpus-qa, nightly, retrieval, near-duplicates, diagnosability, escalation]
+supersedes: []
+relates: [ADR-050]
+governs:
+  - scripts/corpus-qa.mjs
+  - scripts/self-update.mjs
+  - scripts/nightly-wrapper.sh
+  - tests/unit/corpus-qa.test.mjs
+  - tests/unit/self-update-failure-reason.test.mjs
+---
+
+# ADR-064 — The corpus-QA round trip proves the machinery, not the ranking
+
+**Status**: Accepted
+
+**Date**: 2026-08-06
+
+## The problem, measured
+
+The nightly knowledge-bundle rebuild failed **six times across three nights** (2026-08-03 →
+2026-08-06) on the same row, and escalated six times saying nothing.
+
+`logs/nightly.log` lines 16531, 16891, 17307, 17662, 18117, 18489 — identical every time:
+
+```
+metaharness               big     8986      721     8986     2/3        FAIL
+    ↳ R1 self-retrieval missed: id=chunk:2b7c2755… ABSENT from top-10
+      submissions/swe-bench-lite/darwin-glm-opus-cascade/logs/django__django-13315/test_output.txt
+```
+
+Not a build failure. A **QA-gate verdict**, and a wrong one.
+
+### What the row actually is (measured, read-only, on a copy of the live store)
+
+| Question | Measured |
+|---|---|
+| Is the vector in the store? | **Yes** — rank **188** at k=500 |
+| Is it absent from top-10? | Yes — hence the FAIL |
+| How far behind #1? | Δ**0.0557** cosine |
+| What is ahead of it? | **187 of 187** hits share its first 200 normalized characters |
+| What is that text? | conda-activation boilerplate (`export PATH=/opt/miniconda3/envs/testbed/…`) |
+| How much of the corpus is that shape? | **4,428 of 8,979 rows = 49.3%** are `submissions/swe-bench-lite/**` |
+
+The store is correct. The row embeds, writes, and reads back fine. It simply loses a popularity
+contest to 187 near-copies of itself.
+
+### Why it appeared out of nowhere
+
+`scripts/corpus-qa.mjs` samples deterministically from the row count:
+
+```js
+const picks = sampleIndices(`${store}.${variant}`, rows.length, samples);
+```
+
+`rows.length` is part of the hash input, so **every change in passage count re-rolls the entire
+sample**. Verified:
+
+| rows | picks |
+|---|---|
+| 8,945 | `[305, 6049, 6707]` |
+| 8,979 | `[5565, 1433, 4850]` |
+| **8,986** | `[1188, **1945**, 8660]` |
+
+The failing chunk sits at index **1945**. It had been un-self-retrievable the whole time; the corpus
+growing by seven rows is what pointed the sampler at it. With ~49% of the corpus in near-duplicate
+families, a re-roll lands on one of these roughly one time in four — so this recurs on a coin flip,
+forever, until the rule changes.
+
+### The rule was wrong, by the file's own contract
+
+`scripts/corpus-qa.mjs` states its own scope:
+
+> "Retrieval QUALITY (real questions) stays forge-guard/prove's job; **this gate proves the
+> machinery, not the answers.**"
+
+Requiring a row to *win its own query* inside a half-near-duplicate corpus is an assertion about
+ranking quality. That is the bug: the gate was enforcing a promise it had explicitly disclaimed.
+
+## Decision
+
+**A row that is present and readable passes. A row that cannot be found at all fails.**
+
+On anything that is not a clean top-3 hit and not a NEAR_DUP_EPS photo-finish, R1 **re-queries wide**
+before returning any verdict:
+
+- **Present within wide k** → **PASS**, with a loud `deep crowd` note carrying the rank, the window,
+  the Δ behind #1, and how many hits ahead of it are its own near-duplicates.
+- **ABSENT from wide k** → **hard FAIL**, unchanged and unweakened. A missing vector, a zero vector,
+  a mis-slotted vector, and a broken read path are absent at *any* k; nothing forgives them.
+
+`WIDE_K = 500` (~5.6% of metaharness), bounded by `wideKFor(n) = min(500, max(10, floor(n/2)))`.
+**Wide k may never reach the whole corpus** — a k that returns every row makes "present" vacuous and
+would silently retire the failure class this gate exists for.
+
+### The wide arm covers both shapes of miss, deliberately
+
+It would have been smaller to re-query only on a top-10 *absence*. That is incoherent: a row buried
+under 187 siblings would pass while the same row buried under 5 failed. Since crowd depth is a fact
+about corpus composition and not about store health, both shapes route through the same check.
+
+**This supersedes the previous "ranked 4th+ and more than NEAR_DUP_EPS behind #1 is a hard FAIL"
+rule.** The epsilon arm is retained: it still labels drift-scale ties as `near-dup crowd` rather than
+`deep crowd`, which keeps the two signals distinguishable for the dedup backlog.
+
+## The second failure: the escalation carried no reason
+
+The log had the answer every night. The alert never did.
+
+`scripts/self-update.mjs` ran every child with `stdio: 'inherit'`. Verified live: a failing child's
+Error then has `e.stdout === null`, `e.stderr === null`, and `e.message === "Command failed: <argv>"`
+— **argv and nothing else**. That empty reason became the failure record, which became the `[FATAL]`
+summary, which `scripts/nightly-wrapper.sh:159` sampled with `tail -8 | cut -c1-600` — truncating
+mid-argv. Six escalations, zero information.
+
+Two corrections were needed beyond the obvious one:
+
+1. **Capturing stderr alone would not have worked.** `corpus-qa` prints its verdict table and every
+   `↳ <reason>` line with `console.log` — on **stdout**. A stderr-only fix would have captured
+   nothing for the exact failure it was meant to explain.
+2. **The failing step was `[refresh]`, not `[qa]`.** `kb/forge-refresh.mjs` runs `corpus-qa` against
+   its own **candidate** directory and refuses to promote on a FAIL, so the run died inside
+   forge-refresh — before self-update's own `[qa]` step was ever reached.
+
+`runStep()` now captures, **re-emits verbatim** (the log is unchanged), and keeps a bounded tail on
+the failure record. Builders keep stdout inherited for live progress; the two steps that carry a
+corpus-QA verdict capture both streams. The `[FATAL]` block prints each reason and the push alert
+quotes the first. The wrapper sample is `tail -25 | cut -c1-2000`.
+
+## What was deliberately NOT changed
+
+**The all-or-nothing abort stays.** It was assessed and found correct, contrary to the initial
+suspicion that it leaves `kb/` in a worse state than either extreme:
+
+- `kb/forge-refresh.mjs:287` calls `promoteArtifactSet()` **only after** its candidate QA passes, so
+  a failing store is never promoted — its candidate is discarded and the live store keeps its last
+  good generation. Confirmed on disk: `kb/metaharness.passages.jsonl` is still the 8,979-row build
+  from Aug 3 after six rejected 8,986-row candidates.
+- `promoteArtifactSet()` (`kb/incremental-refresh.mjs:237`) is transactional per store — backup,
+  rename in, roll back on error.
+
+So after an abort, **every store in `kb/` is a store that passed its own QA**. Only the stamp and the
+`dist/` bundle are skipped, which is precisely the conservative outcome: the published bundle stays
+at the last fully consistent generation. Stamping anyway would ship a generation containing one
+silently stale store — the "product can never lie" failure. Rolling back the stores that did promote
+would require a cross-store transaction that does not exist and would discard good work for no gain.
+
+Residual, accepted and unfixed: between an aborted run and the next successful one, `kb/` can hold
+stores newer than the stamp that describes them. Local reads get fresh data with a stale generation
+label. Noted, not load-bearing for anything published.
+
+## Consequences
+
+- The nightly stops failing on corpus composition; it still fails on a broken store.
+- Near-duplicate crowding becomes a **visible, quantified signal** (`deep crowd: … 187/187 ahead are
+  near-duplicates`) feeding the dedup backlog, instead of a nightly outage.
+- A nightly failure now escalates with its reason attached.
+- The R1 block went from **zero** coverage (eight `it.todo`s) to ten behavioural tests, each proven
+  to fail under a targeted mutation of the code it guards (13 mutations, 13 caught).
+
+## Verification
+
+- Real-data A/B on a scratchpad copy of the live store, sampler steered onto index 1945:
+  - pre-fix: `0/1 store-variants PASS — 1 FAILED … ABSENT from top-10` (reproduces the nightly byte
+    for byte)
+  - post-fix: `1/1 PASS` + `deep crowd: … rank 188/500 (absent from top-10), Δ0.0556 behind #1,
+    187/187 ahead are near-duplicates`
+- `.rvf` distance fidelity measured exact to ~1e-8 against `1-cos(θ)` before any rank-engineered
+  fixture was written, so tests assert the numbers the gate really prints.
+- Mutation campaign: 13 mutants across `corpus-qa.mjs`, `self-update.mjs`, `nightly-wrapper.sh` —
+  every one killed by the intended test; sources restored and re-verified byte-identical.

--- a/scripts/corpus-qa.mjs
+++ b/scripts/corpus-qa.mjs
@@ -26,9 +26,12 @@
 //         drift (~0.035 measured) exceeds the true gap between near-dups — the row IS stored and
 //         readable (fact.big id=722: rank 6, Δ0.007 behind rank 1), so that's a photo-finish,
 //         not a broken store. Photo-finish passes are still surfaced as a `note` so the
-//         near-dup-noise signal feeds the dedup backlog instead of being hidden. A row absent
-//         from top-10 (or far from the leader) remains a hard FAIL — missing/zero vectors and
-//         broken read paths cannot hide behind the epsilon.
+//         near-dup-noise signal feeds the dedup backlog instead of being hidden.
+//         Anything that is NOT a top-3 hit and NOT a photo-finish is RE-QUERIED WIDE (WIDE_K,
+//         bounded to half the corpus) before any verdict — see the wide-k arm at R1 below.
+//         Present at wide k => PASS with a loud `deep crowd` note carrying rank + crowd size.
+//         ABSENT at wide k => hard FAIL, always: a missing vector, a zero vector, a mis-slotted
+//         vector and a broken read path are absent at ANY k, and nothing forgives them.
 //         Proves embed-write AND read-path in one check. Retrieval QUALITY (real questions) stays
 //         forge-guard/prove's job; this gate proves the machinery, not the answers.
 //
@@ -62,6 +65,24 @@ const FULL_BODY_MARK = '(full body):';
 // distance (fact.big id=722 replay); near-dup siblings sit within ~0.005 of each other. 0.02
 // forgives the drift-scale tie WITHOUT forgiving genuinely different rows.
 const NEAR_DUP_EPS = 0.02;
+// R1 wide-k arm. Measured 2026-08-06 on the store that failed the nightly six times in three
+// nights (metaharness.big, chunk:2b7c2755…, submissions/swe-bench-lite/…/django__django-13315/
+// test_output.txt): ABSENT from top-10, but rank 188 at k=500, Δ0.0557 behind #1 — and all 187
+// hits ahead of it were near-duplicates of it (187/187, conda-activation boilerplate). 49.3% of
+// that corpus (4,428 of 8,979 rows) is submissions/swe-bench-lite/** of that shape, so a row with
+// ordinary embed drift sinks below its own siblings. That is a corpus-composition fact, not a
+// broken store, and asserting otherwise made this gate assert retrieval QUALITY — explicitly not
+// its job (see header). 500 is ~5.6% of that corpus: deep enough to see under the crowd, far too
+// shallow for a missing/zero/mis-slotted vector to hide in.
+const WIDE_K = 500;
+// Never let wide k reach the whole corpus — a k that returns every row makes "present" vacuous and
+// would silently retire the failure class this gate exists for. Half the corpus is the ceiling.
+const wideKFor = (n) => Math.min(WIDE_K, Math.max(10, Math.floor(n / 2)));
+// Crowd measure for the note: how many hits ahead of the row open with the same normalized text.
+// Cheap, deterministic, model-free — it turns "rank 188" into "rank 188 behind 187 of its own
+// near-duplicates", which is the signal the dedup backlog actually needs.
+const CROWD_PREFIX = 200;
+const crowdKey = (s) => String(s ?? '').replace(/\s+/g, ' ').trim().slice(0, CROWD_PREFIX);
 
 function fnv1a(s) {
   let h = 0x811c9dc5;
@@ -113,7 +134,7 @@ function getPipeline(embedConf) {
  * `fails` is [] on PASS; every entry is a specific reason string (receipts, not adjectives).
  * `notes` are non-fatal signals (e.g. near-dup crowding) that should reach the dedup backlog.
  */
-export async function qaStore(dir, store, variant, { roundtrip = true, samples = 3 } = {}) {
+export async function qaStore(dir, store, variant, { roundtrip = true, samples = 3, pipeline = null } = {}) {
   const base = variant === 'big' ? `${store}.big` : store;
   const rvfPath = path.join(dir, `${base}.rvf`);
   const variantPassages = path.join(dir, `${base}.passages.jsonl`);
@@ -160,7 +181,10 @@ export async function qaStore(dir, store, variant, { roundtrip = true, samples =
       const byId = new Map(rows.map((r) => [String(r.id), r]));
       let hit = 0;
       const misses = [];
-      const pipe = await getPipeline(embedConf);
+      // `pipeline` is the unit tier's injection seam (same shape as getPipeline's resolved value:
+      // (texts, opts) => { dims, data }). Production always passes null and loads the real model.
+      const pipe = pipeline || await getPipeline(embedConf);
+      const wideK = wideKFor(rows.length);
       for (const i of picks) {
         const r = rows[i];
         // Re-embed EXACTLY what the pipeline indexed for this variant (forge-build/forge-big):
@@ -179,7 +203,21 @@ export async function qaStore(dir, store, variant, { roundtrip = true, samples =
           hit++; // photo-finish behind near-duplicates: stored + readable; surface the crowd as a note
           res.notes.push(`near-dup crowd: id=${r.id} rank ${rank + 1}, Δ${(top[rank].distance - top[0].distance).toFixed(4)} behind #1 (${r.path})`);
         } else {
-          misses.push(`id=${r.id} ${rank < 0 ? 'ABSENT from top-10' : `rank ${rank + 1}, Δ${(top[rank].distance - top[0].distance).toFixed(4)}`} ${r.path}`);
+          // Not a top-3 hit and not a photo-finish. Before declaring the store broken, ask the
+          // question this gate is actually for: is the row IN there and READABLE at all? Re-query
+          // wide. This covers BOTH shapes of miss — absent from top-10 (a deep near-dup crowd) and
+          // present-but-far inside top-10 (a shallow one) — because the alternative is perverse:
+          // a row buried under 187 siblings would pass while the same row buried under 5 failed.
+          const wide = await db.query(Array.from(out.data), wideK);
+          const wideRank = wide.findIndex(matches);
+          if (wideRank >= 0) {
+            hit++; // stored + readable, just outranked by its own near-duplicates
+            const mine = crowdKey(r.text);
+            const crowd = wide.slice(0, wideRank).filter((t) => crowdKey(byId.get(String(t.id))?.text) === mine).length;
+            res.notes.push(`deep crowd: id=${r.id} rank ${wideRank + 1}/${wideK}${rank < 0 ? ' (absent from top-10)' : ''}, Δ${(wide[wideRank].distance - wide[0].distance).toFixed(4)} behind #1, ${crowd}/${wideRank} ahead are near-duplicates (${r.path})`);
+          } else {
+            misses.push(`id=${r.id} ABSENT from top-${wideK} ${r.path}`);
+          }
         }
       }
       res.roundtrip = `${hit}/${picks.length}`;

--- a/scripts/nightly-wrapper.sh
+++ b/scripts/nightly-wrapper.sh
@@ -156,7 +156,11 @@ fi
 
 # Both attempts genuinely failed. Escalate loudly AND leave a marker the next session cannot miss.
 AFTER=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "unknown")
-TAIL=$(tail -8 "$LOG" | tr '\n' ' ' | cut -c1-600)
+# Was `tail -8 | cut -c1-600`. self-update's [FATAL] block is 4+ lines on its own and now carries a
+# 'reason:' line per failed repo, so 8 lines / 600 chars truncated the alert mid-argv — every one of
+# the six identical 2026-08-03..08-06 failures escalated with no reason in it. Widen enough that the
+# whole [FATAL] block, reasons included, reaches the marker file and the push.
+TAIL=$(tail -25 "$LOG" | tr '\n' ' ' | cut -c1-2000)
 mkdir -p .ruvnet-brain
 python3 -c "
 import json, datetime

--- a/scripts/self-update.mjs
+++ b/scripts/self-update.mjs
@@ -16,7 +16,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { FULL_HINTS, KEEP_DIRS } from './full-hints.mjs';
 import { withSubmoduleSymlinksDetached } from './git-clone-refresh.mjs';
@@ -228,6 +228,42 @@ if (!APPLY) {
 }
 
 const NOTIFY = (t, m, p) => { try { execFileSync('sh', [path.join(ROOT, 'scripts/notify.sh'), t, m, p || 'default']); } catch { /* alerting never breaks the pipeline */ } };
+
+// ---- child steps that can explain themselves -------------------------------------------------
+// With stdio:'inherit' a failing child's Error carries NO output: e.stdout and e.stderr are both
+// null and e.message is only "Command failed: <argv>" (verified 2026-08-06). That empty reason is
+// what propagated into the [FATAL] summary, which is in turn what nightly-wrapper.sh samples for
+// the escalation — so six identical nightly failures escalated saying nothing, while the log had
+// the answer the whole time.
+//
+// Capture, then RE-EMIT verbatim so the log is byte-identical to what stdio:'inherit' produced,
+// and keep a tail for the failure record.
+//   captureStdout=false (clone/fetch/reset/symbols): stdout stays inherited so those steps stream
+//     live and survive a kill; only stderr is buffered (small: stacks and warnings).
+//   captureStdout=true  (every step that carries a corpus-QA verdict — [refresh] and [qa]): BOTH
+//     streams, because corpus-qa prints its verdict table and every '↳ <reason>' line via
+//     console.log — i.e. on STDOUT. Capturing stderr alone would have captured nothing for the
+//     exact failure this exists to explain. Measured output is ~34 lines/step, so it costs nothing.
+const STEP_TAIL_LINES = 14;
+function runStep(label, file, args, opts = {}, { captureStdout = false } = {}) {
+  const r = spawnSync(file, args, {
+    ...opts,
+    stdio: ['inherit', captureStdout ? 'pipe' : 'inherit', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (r.stdout?.length) process.stdout.write(r.stdout);
+  if (r.stderr?.length) process.stderr.write(r.stderr);
+  if (r.error) { r.error.step = label; throw r.error; }
+  if (r.status !== 0) {
+    const tail = Buffer.concat([r.stdout || Buffer.alloc(0), r.stderr || Buffer.alloc(0)]).toString()
+      .split('\n').map((l) => l.trim()).filter(Boolean).slice(-STEP_TAIL_LINES).join(' | ');
+    const err = new Error(`${label} exited ${r.status}${tail ? ` — ${tail}` : ' — (child produced no output)'}`);
+    err.step = label;
+    err.status = r.status;
+    err.output = tail;
+    throw err;
+  }
+}
 const failures = []; // per-repo build failures collected here; ANY failure aborts before publish (see below)
 for (const p of todo) {
   const dir = clonePath(p.name);
@@ -235,15 +271,15 @@ for (const p of todo) {
     if (!fs.existsSync(path.join(dir, '.git'))) {
       console.log(`[clone] ${p.name}`);
       fs.mkdirSync(CLONE_DIR, { recursive: true });
-      execFileSync('git', ['clone', '--depth', '1', `https://github.com/${p.owner || p.org || 'ruvnet'}/${p.repo || p.name}`, dir], { stdio: 'inherit' });
+      runStep(`[clone] ${p.name}`, 'git', ['clone', '--depth', '1', `https://github.com/${p.owner || p.org || 'ruvnet'}/${p.repo || p.name}`, dir]);
     } else {
       // Some cached clones deduplicate large submodules with symlinks to another clone. Git refuses
       // even a fetch when a gitlink path is a symlink ("expected submodule path ... not to be a
       // symbolic link"). Detach only those declared submodule symlinks for fetch/reset, then restore
       // them in finally so a network/reset failure cannot strand the cache in a half-repaired state.
       withSubmoduleSymlinksDetached(dir, () => {
-        execFileSync('git', ['-C', dir, 'fetch', '--depth', '1', 'origin'], { stdio: 'inherit' });
-        execFileSync('git', ['-C', dir, 'reset', '--hard', 'origin/HEAD'], { stdio: 'inherit' });
+        runStep(`[fetch] ${p.name}`, 'git', ['-C', dir, 'fetch', '--depth', '1', 'origin']);
+        runStep(`[reset] ${p.name}`, 'git', ['-C', dir, 'reset', '--hard', 'origin/HEAD']);
       });
     }
     const env = { ...process.env, KB_MODEL_CACHE: MODEL_CACHE };
@@ -255,26 +291,43 @@ for (const p of todo) {
     if (full) buildArgs.push('--full', full);
     if (keep) buildArgs.push('--keep', keep);
     console.log(`[refresh] ${kb}`);
-    execFileSync(NODE, buildArgs, { cwd: path.join(ROOT, 'kb'), env, stdio: 'inherit' });
+    // captureStdout: forge-refresh runs corpus-qa against its CANDIDATE dir and refuses to promote
+    // on a FAIL — so this step, not the [qa] step below, is where the six 2026-08-03..08-06 nightly
+    // failures actually died, and the verdict table naming the offending chunk is on ITS stdout.
+    // Steps produce ~34 lines at most (largest measured [refresh] section in logs/nightly.log), so
+    // buffering costs nothing; the tradeoff is that the log flushes at step end rather than live.
+    runStep(`[refresh] ${kb}`, NODE, buildArgs, { cwd: path.join(ROOT, 'kb'), env }, { captureStdout: true });
     console.log(`[symbols] ${kb}`);
-    execFileSync(NODE, ['scripts/build-symbols.mjs', '--name', kb], { cwd: ROOT, env, stdio: 'inherit' });
+    runStep(`[symbols] ${kb}`, NODE, ['scripts/build-symbols.mjs', '--name', kb], { cwd: ROOT, env });
     // Corpus QA gate (scripts/corpus-qa.mjs): structural (passages>0, full-bodies>0 where
     // FULL_HINTS demands them, vectors==passages, embed.json present) + deterministic
     // self-retrieval round trip on every canonical store. Non-zero exit throws -> failures[] ->
     // the run aborts before stamp/bundle/publish. This is the machine version of the
     // 2026-07-10 hand-verification: a store that embeds wrong or reads wrong cannot ship.
     console.log(`[qa] ${kb}`);
-    execFileSync(NODE, ['scripts/corpus-qa.mjs', '--store', kb], { cwd: ROOT, env, stdio: 'inherit' });
-  } catch (e) { console.error(`[FAIL] ${p.name}: ${e.message}`); failures.push({ name: p.name, error: e.message }); }
+    // captureStdout: corpus-qa's verdict table and its '↳ <reason>' lines go to stdout.
+    runStep(`[qa] ${kb}`, NODE, ['scripts/corpus-qa.mjs', '--store', kb], { cwd: ROOT, env }, { captureStdout: true });
+  } catch (e) {
+    console.error(`[FAIL] ${p.name}: ${e.message}`);
+    failures.push({ name: p.name, step: e.step || '(unknown step)', error: e.message, reason: e.output || '' });
+  }
 }
 
 // A per-repo build failure used to be logged and swallowed before the run re-stamped and re-bundled
 // partial data. Fail loud: if ANY repo failed, abort before stamp/bundle. This rebuild process has no
 // publication authority; a later protected release may consume only a fully prepared candidate.
 if (failures.length) {
-  NOTIFY('🔴 Nightly brain rebuild ABORTED', `${failures.length} repo build(s) failed — no candidate prepared. See logs/nightly.log`, 'urgent');
+  // Carry the REASON, not just the count. The wrapper samples this block's tail for the push
+  // escalation, so whatever is not printed here is not in the alert either.
+  const first = failures[0];
+  NOTIFY('🔴 Nightly brain rebuild ABORTED',
+    `${failures.length} repo build(s) failed — no candidate prepared. First: ${first.name} ${first.step} — ${first.reason || first.error}`,
+    'urgent');
   console.error(`\n[FATAL] ${failures.length} repo build(s) failed this run — aborting before stamp/bundle. No candidate prepared:`);
-  for (const f of failures) console.error(`  - ${f.name}: ${f.error}`);
+  for (const f of failures) {
+    console.error(`  - ${f.name} ${f.step}: ${f.error}`);
+    if (f.reason) console.error(`      reason: ${f.reason}`);
+  }
   console.error('Fix the failing repo(s) and re-run.');
   process.exit(1);
 }

--- a/tests/unit/corpus-qa.test.mjs
+++ b/tests/unit/corpus-qa.test.mjs
@@ -32,11 +32,12 @@ function unitVec(seed) {
   return v.map((x) => x / n);
 }
 
-/** Create a real store fixture: .rvf with `vectors` rows, passages.jsonl with `rows`, embed.json. */
-async function mkStore(name, { rows, vectors = rows.length }) {
+/** Create a real store fixture: .rvf with `vectors` rows, passages.jsonl with `rows`, embed.json.
+ *  `vecs` (optional) supplies exact vectors so a test can engineer exact ranks and gaps. */
+async function mkStore(name, { rows, vectors = rows.length, vecs = null }) {
   const rvf = path.join(tmp, `${name}.rvf`);
   const db = await RvfDatabase.create(rvf, { dimensions: DIMS, metric: 'cosine' });
-  const batch = Array.from({ length: vectors }, (_, i) => ({ id: String(i + 1), vector: unitVec(i + 1) }));
+  const batch = Array.from({ length: vectors }, (_, i) => ({ id: String(i + 1), vector: vecs ? vecs[i] : unitVec(i + 1) }));
   if (batch.length) await db.ingestBatch(batch);
   await db.close();
   fs.writeFileSync(path.join(tmp, `${name}.passages.jsonl`),
@@ -142,23 +143,256 @@ describeRvf('corpus-qa — discovery + deterministic sampling', () => {
   });
 });
 
-// The R1 round-trip block (qaStore's roundtrip=true path, lines ~138-173 of corpus-qa.mjs) is the
-// most bug-prone logic in this file — the `matches()` triple-fallback (id, path, or exact text) and
-// the NEAR_DUP_EPS photo-finish forgiveness arm — and it has ZERO coverage above. It's blocked the
-// same way ~19 other files in this suite are: getPipeline() calls the real ONNX transformers
-// pipeline with no injection seam, so exercising it needs either a live KB_MODEL_CACHE (the
-// live-infra tier: prove.mjs, eval-brain.mjs, brain-grade-groundtruth.mjs) or exporting a pure
-// decision function out of the loop (e.g. `classifyRoundtrip({rank, distances, sampleId, byId, row})`
-// that qaStore calls) — a test-only mock of getPipeline's return value would make this instant and
-// model-free, same recommendation this suite has made for every other DI-blocked file. Flagging,
-// not performing — same sign-off norm as the rest of this suite.
-describe.todo('corpus-qa — R1 round-trip decision logic (blocked: no DI seam for the embed pipeline)', () => {
-  it.todo('top-3 rank match on exact id counts as a hit');
-  it.todo('top-3 rank match via path-equality fallback counts as a hit (id drifted, doc did not)');
-  it.todo('top-3 rank match via exact-text fallback counts as a hit (overlapping chunk, different id/path)');
-  it.todo('a sampled row entirely absent from top-10 is a hard FAIL, never forgiven by the epsilon arm');
-  it.todo('a match ranked 4th+ within NEAR_DUP_EPS of rank 1 counts as a hit AND appends a `notes` entry (photo-finish, not a broken store)');
-  it.todo('a match ranked 4th+ but MORE than NEAR_DUP_EPS behind rank 1 is a hard FAIL (drift ≠ near-dup crowding)');
-  it.todo('an embed dimension mismatch (out.dims[1] !== embedConf.dimensions) throws and is captured as an R1 error, not silently ignored');
-  it.todo('roundtrip is reported "skipped" (not attempted) when an S3 vector-count-mismatch fail already exists, even if roundtrip=true was requested');
+// R1 round-trip decision logic — the most bug-prone code in corpus-qa.mjs (the `matches()`
+// triple-fallback, the NEAR_DUP_EPS photo-finish arm, and the wide-k crowd arm). This block was
+// `describe.todo` until 2026-08-06, blocked on "getPipeline() calls the real ONNX pipeline with no
+// injection seam". qaStore now takes an optional `pipeline` seam (production passes null), which is
+// exactly the test-only mock the todo recommended — so the tier stays model-free and instant while
+// the STORAGE layer stays real (real .rvf fixtures, same @ruvector/rvf the pipeline uses).
+//
+// Ranks and gaps are ENGINEERED, not hoped for: distances are measured exact to ~1e-8 against
+// 1-cos(theta) in a real .rvf (verified before these tests were written), so a test that says
+// "rank 15, Δ0.3000" is asserting the number the gate will actually print.
+
+/** Unit vector at angle `theta` in the (e0,e1) plane; cosine distance from QUERY is 1-cos(theta). */
+const vecAt = (theta) => [Math.cos(theta), Math.sin(theta), 0, 0, 0, 0, 0, 0];
+const QUERY = vecAt(0);
+const thetaFor = (d) => Math.acos(1 - d);
+
+/**
+ * Exact cosine distances for `n` rows placing `target` at 1-based `rank` with `targetDist` from
+ * QUERY, and the rank-1 row sitting exactly ON the query (distance 0) so Δ-behind-#1 == targetDist.
+ */
+function distsForTargetRank(n, target, rank, targetDist) {
+  const dists = new Array(n);
+  dists[target] = targetDist;
+  const others = [];
+  for (let i = 0; i < n; i++) if (i !== target) others.push(i);
+  others.forEach((idx, j) => {
+    if (rank > 1 && j === 0) dists[idx] = 0;                        // #1, exactly on the query
+    else if (rank > 1 && j < rank - 1) dists[idx] = (targetDist * j) / rank; // strictly inside (0, targetDist)
+    else dists[idx] = targetDist + 0.1 + j * 1e-3;                  // strictly beyond the target
+  });
+  return dists;
+}
+
+const vecsFor = (dists) => dists.map((d) => vecAt(thetaFor(d)));
+
+/** Fake embed pipeline matching getPipeline()'s resolved shape: (texts, opts) => {dims, data}. */
+function fakePipe(vector, { dims } = {}) {
+  const calls = [];
+  const fn = async (texts, opts) => {
+    calls.push({ texts, opts });
+    return { dims: [1, dims ?? vector.length], data: Float32Array.from(vector) };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// A shared opening long enough that crowdKey()'s 200-char normalized prefix falls entirely inside
+// it — siblings share the prefix but differ in their tails, so they crowd the ranking WITHOUT
+// tripping matches()' exact-text fallback.
+const SHARED_PREFIX = ('export PATH=/opt/miniconda3/envs/testbed/bin:/usr/bin:/bin '
+  + 'export CONDA_PREFIX=/opt/miniconda3/envs/testbed CONDA_SHLVL=2 DEFAULT_ENV=testbed '
+  + 'activate testbed and run the django test suite with the standard settings module ').slice(0, 250);
+
+describeRvf('corpus-qa — R1 round-trip decision logic', () => {
+  const N = 40;                    // wideKFor(40) = min(500, max(10, 20)) = 20
+  const WIDE_K = 20;
+  let uid = 0;
+  const nextName = () => `zzz-r1-${uid++}`;
+
+  /** Pick the row index qaStore will deterministically sample for this store name (samples=1). */
+  const pickFor = (name) => sampleIndices(`${name}.small`, N, 1)[0];
+
+  it('a rank-1 self-retrieval counts as a clean hit — no fails, and NO note (it is not a photo-finish)', async () => {
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    await mkStore(name, { rows, vecs: vecsFor(distsForTargetRank(N, p, 1, 0)) });
+
+    const pipe = fakePipe(QUERY);
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: pipe });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes).toEqual([]);                            // the top-3 arm, not the eps arm
+    expect(pipe.calls.length).toBe(1);                      // it really went through the embed arm
+    expect(pipe.calls[0].texts[0]).toContain(rows[p].text); // and embedded the SAMPLED row
+  });
+
+  it('top-3 rank match on exact id counts as a hit where ONLY the id clause can match (duplicate passage ids)', async () => {
+    // Isolating the id clause needs a fixture where byId.get(r.id) is NOT r — i.e. two passages
+    // sharing an id (last one wins the Map). With unique ids — which is what every real store has
+    // today (metaharness.big: 8,979 rows / 8,979 distinct ids, checked 2026-08-06) — the id clause
+    // is redundant: whenever it is true, byId.get(t.id) === r and the path AND text clauses are
+    // true too. So this fixture is the only thing standing between that clause and dead code.
+    const name = nextName();
+    const p = pickFor(name);
+    const q = p + 1 < N ? p + 1 : p - 1;
+    expect(q).toBeGreaterThan(p);                           // later row must win the byId Map
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    rows[p] = { id: String(q + 1), path: 'src/target.rs', title: 'target.rs', text: 'target body' };
+    const dists = distsForTargetRank(N, p, 30, 0.5);
+    dists[q] = 0;                                           // the row carrying the shared id wins
+    await mkStore(name, { rows, vecs: vecsFor(dists) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes).toEqual([]);
+    expect(rows[q].path).not.toBe(rows[p].path);            // path clause CANNOT have matched
+    expect(rows[q].text).not.toBe(rows[p].text);            // text clause CANNOT have matched
+  });
+
+  it('top-3 rank match via path-equality fallback counts as a hit (id drifted, doc did not)', async () => {
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    // Decoy at rank 1: different id, different text, SAME path as the sampled row.
+    const decoy = p === 0 ? 1 : 0;
+    rows[decoy] = { ...rows[decoy], path: rows[p].path, text: `entirely different body ${decoy}` };
+    const dists = distsForTargetRank(N, p, 30, 0.5);        // sampled row itself buried
+    dists[decoy] = 0;                                       // decoy wins outright
+    await mkStore(name, { rows, vecs: vecsFor(dists) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes).toEqual([]);                            // rank 1 => clean top-3, never a note
+    expect(rows[decoy].id).not.toBe(rows[p].id);            // proves it matched on path, not id
+    expect(rows[decoy].text).not.toBe(rows[p].text);        // ...and not on text
+  });
+
+  it('top-3 rank match via exact-text fallback counts as a hit (overlapping chunk, different id/path)', async () => {
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    const decoy = p === 0 ? 1 : 0;
+    rows[decoy] = { ...rows[decoy], text: rows[p].text };   // identical text, own id + own path
+    const dists = distsForTargetRank(N, p, 30, 0.5);
+    dists[decoy] = 0;
+    await mkStore(name, { rows, vecs: vecsFor(dists) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes).toEqual([]);
+    expect(rows[decoy].id).not.toBe(rows[p].id);
+    expect(rows[decoy].path).not.toBe(rows[p].path);        // proves it matched on text alone
+  });
+
+  it('a sampled row absent from the WIDE-k window is a hard FAIL, never forgiven by any arm', async () => {
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    // rank 25 of 40 — past top-10 AND past wide k=20. This is the class the gate exists for
+    // (missing / zero / mis-slotted vector, broken read path): absent at ANY k.
+    await mkStore(name, { rows, vecs: vecsFor(distsForTargetRank(N, p, 25, 0.5)) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.roundtrip).toBe('0/1');
+    expect(r.fails.length).toBe(1);
+    expect(r.fails[0]).toContain('R1 self-retrieval missed');
+    expect(r.fails[0]).toContain(`ABSENT from top-${WIDE_K}`);
+    expect(r.fails[0]).toContain(`id=${rows[p].id}`);
+    expect(r.notes).toEqual([]);                            // no consolation note on a hard FAIL
+  });
+
+  it('a match ranked 4th+ within NEAR_DUP_EPS of rank 1 is a hit AND appends a near-dup `note` (photo-finish)', async () => {
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    const GAP = 0.016;                                      // inside NEAR_DUP_EPS (0.02), not trivially so
+    await mkStore(name, { rows, vecs: vecsFor(distsForTargetRank(N, p, 5, GAP)) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes.length).toBe(1);
+    expect(r.notes[0]).toMatch(/^near-dup crowd:/);         // the eps arm, NOT the wide-k arm
+    expect(r.notes[0]).toContain('rank 5');
+    const delta = Number(/Δ([0-9.]+)/.exec(r.notes[0])[1]); // bound the magnitude, not the direction
+    expect(delta).toBeCloseTo(GAP, 4);
+    expect(delta).toBeLessThanOrEqual(0.02);
+    expect(delta).toBeGreaterThan(0.01);
+  });
+
+  it('a match ranked 4th+ and MORE than NEAR_DUP_EPS behind #1 still PASSes via wide-k, with a `deep crowd` note', async () => {
+    // Behaviour CHANGED 2026-08-06 (ADR-0064). Previously a hard FAIL. A row at rank 5 with a big
+    // gap is exactly as stored-and-readable as one at rank 188; failing the shallow crowd while
+    // passing the deep one was the perverse edge the wide-k arm had to remove.
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    const GAP = 0.30;                                       // 15x NEAR_DUP_EPS — nowhere near a tie
+    await mkStore(name, { rows, vecs: vecsFor(distsForTargetRank(N, p, 5, GAP)) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes.length).toBe(1);
+    expect(r.notes[0]).toMatch(/^deep crowd:/);
+    expect(r.notes[0]).toContain(`rank 5/${WIDE_K}`);
+    expect(r.notes[0]).not.toContain('absent from top-10'); // it WAS in top-10, just far back
+    const delta = Number(/Δ([0-9.]+)/.exec(r.notes[0])[1]);
+    expect(delta).toBeCloseTo(GAP, 4);
+    expect(delta).toBeGreaterThan(0.02);                    // provably outside the eps arm
+  });
+
+  it('WIDE-K ARM: a row absent from top-10 but present at wide k PASSes, and the note carries rank + crowd size', async () => {
+    // The nightly-blocking case in miniature (metaharness.big chunk:2b7c2755…: ABSENT from top-10,
+    // rank 188/500, 187/187 ahead of it near-duplicates of it). Here: rank 15/20, 14/14 siblings.
+    const name = nextName();
+    const p = pickFor(name);
+    const rows = Array.from({ length: N }, (_, i) => ({
+      id: String(i + 1), path: `src/u${i}.rs`, title: `u${i}.rs`, text: `unrelated body ${i}`,
+    }));
+    rows[p] = { ...rows[p], path: 'logs/django__django-13315/test_output.txt', text: `${SHARED_PREFIX} tail-target` };
+    const dists = distsForTargetRank(N, p, 15, 0.4);
+    // The 14 rows ranked ahead of it share its 200-char opening but differ in tail/id/path —
+    // crowd members, not matches().
+    const ahead = dists.map((d, i) => ({ d, i })).filter((x) => x.i !== p && x.d < dists[p])
+      .sort((a, b) => a.d - b.d).map((x) => x.i);
+    expect(ahead.length).toBe(14);
+    for (const i of ahead) rows[i] = { ...rows[i], text: `${SHARED_PREFIX} tail-sibling-${i}` };
+    await mkStore(name, { rows, vecs: vecsFor(dists) });
+
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY) });
+    expect(r.fails).toEqual([]);                            // the whole point: no longer a FAIL
+    expect(r.roundtrip).toBe('1/1');
+    expect(r.notes.length).toBe(1);
+    expect(r.notes[0]).toMatch(/^deep crowd:/);
+    expect(r.notes[0]).toContain(`rank 15/${WIDE_K}`);
+    expect(r.notes[0]).toContain('(absent from top-10)');   // loud about WHY it needed the wide arm
+    expect(r.notes[0]).toContain('14/14 ahead are near-duplicates');
+    expect(r.notes[0]).toContain(rows[p].path);
+    const delta = Number(/Δ([0-9.]+)/.exec(r.notes[0])[1]);
+    expect(delta).toBeCloseTo(0.4, 4);
+  });
+
+  it('an embed dimension mismatch is captured as an R1 error, not silently ignored', async () => {
+    const name = nextName();
+    const rows = Array.from({ length: N }, (_, i) => row(i + 1));
+    await mkStore(name, { rows, vecs: vecsFor(distsForTargetRank(N, pickFor(name), 1, 0)) });
+
+    // embed.json says 8 dims; the pipeline reports 4 — a real read-path/config divergence.
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: fakePipe(QUERY, { dims: 4 }) });
+    expect(r.roundtrip).toBe('error');
+    expect(r.fails.length).toBe(1);
+    expect(r.fails[0]).toContain('R1 round-trip error');
+    expect(r.fails[0]).toContain(`embed dim 4 != ${DIMS}`);
+  });
+
+  it('roundtrip is "skipped" — genuinely NOT attempted — when an S3 vector-count mismatch already failed', async () => {
+    const name = nextName();
+    const rows = Array.from({ length: 6 }, (_, i) => row(i + 1));
+    await mkStore(name, { rows, vectors: 4 });              // 6 passages, 4 vectors => S3 FAIL
+
+    const pipe = fakePipe(QUERY);
+    const r = await qaStore(tmp, name, 'small', { samples: 1, pipeline: pipe });
+    expect(r.fails.some((f) => f.startsWith('S3') && f.includes('vectors=4 != passages=6'))).toBe(true);
+    expect(r.roundtrip).toBe('skipped');
+    expect(r.fails.some((f) => f.startsWith('R1'))).toBe(false);
+    expect(pipe.calls.length).toBe(0);                      // "not attempted" means the embedder never ran
+  });
 });

--- a/tests/unit/self-update-failure-reason.test.mjs
+++ b/tests/unit/self-update-failure-reason.test.mjs
@@ -1,0 +1,175 @@
+// tests/unit/self-update-failure-reason.test.mjs — the nightly failed six times over three nights
+// (2026-08-03..08-06) and escalated six times with an EMPTY reason. Not because the reason was
+// unknown: scripts/corpus-qa.mjs had printed it, in full, into logs/nightly.log every time. The
+// pipeline simply threw it away. execFileSync(..., {stdio:'inherit'}) gives a failing child's Error
+// NO output at all — e.stdout and e.stderr are both null and e.message is only "Command failed:
+// <argv>" (verified live 2026-08-06) — so the failure record, the [FATAL] summary built from it, and
+// the push alert nightly-wrapper.sh samples from that summary all carried argv and nothing else.
+//
+// These tests exercise the SHIPPED runStep bytes (sliced out of scripts/self-update.mjs, not
+// re-typed) against real child processes. The load-bearing case is the third one: corpus-qa writes
+// its verdict table and every '↳ <reason>' line with console.log, i.e. to STDOUT — so capturing
+// stderr alone would still have produced a reasonless escalation for the exact failure this exists
+// to explain.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const SOURCE = fs.readFileSync(path.join(ROOT, 'scripts/self-update.mjs'), 'utf8');
+
+/**
+ * Slice a top-level `function name(...) { ... }` out of a source file. The parameter list is
+ * matched by parens FIRST — `opts = {}` style defaults put braces before the body, so seeking the
+ * first `{` after the name finds the wrong one and slices an empty function.
+ */
+function sliceFunction(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`${name} not found in self-update.mjs`);
+  let i = src.indexOf('(', start);
+  let parens = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '(') parens++;
+    else if (src[i] === ')') { parens--; if (parens === 0) { i++; break; } }
+  }
+  let depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error(`unbalanced braces after ${name}`);
+}
+
+let runStep;
+let tmp;
+
+beforeAll(async () => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'self-update-reason-'));
+  const tailConst = /const STEP_TAIL_LINES = \d+;/.exec(SOURCE);
+  expect(tailConst, 'STEP_TAIL_LINES must exist in self-update.mjs').toBeTruthy();
+  const mod = [
+    "import { spawnSync } from 'node:child_process';",
+    tailConst[0],
+    sliceFunction(SOURCE, 'runStep'),
+    'export { runStep };',
+  ].join('\n');
+  const f = path.join(tmp, 'runstep.mjs');
+  fs.writeFileSync(f, mod);
+  ({ runStep } = await import(pathToFileURL(f).href));
+});
+afterAll(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+const NODE = process.execPath;
+/** A child that writes `out` to stdout, `err` to stderr, and exits `code`. */
+const child = (out, err, code) => [
+  '-e',
+  `${out ? `process.stdout.write(${JSON.stringify(out + '\n')});` : ''}`
+  + `${err ? `process.stderr.write(${JSON.stringify(err + '\n')});` : ''}`
+  + `process.exit(${code});`,
+];
+
+describe('self-update — a failing child step explains itself', () => {
+  it('a zero-exit step does not throw', () => {
+    expect(() => runStep('[qa] ok', NODE, child('all good', '', 0), {}, { captureStdout: true })).not.toThrow();
+  });
+
+  it('THE NIGHTLY CASE: a child that fails with its reason on STDOUT surfaces that reason (captureStdout)', () => {
+    const reason = '    ↳ R1 self-retrieval missed: id=chunk:2b7c2755 ABSENT from top-500 submissions/x.txt';
+    let caught = null;
+    try {
+      runStep('[qa] metaharness', NODE, child(`${reason}\n[corpus-qa] 0/1 store-variants PASS — 1 FAILED`, '', 1),
+        {}, { captureStdout: true });
+    } catch (e) { caught = e; }
+
+    expect(caught, 'a nonzero exit must throw').toBeTruthy();
+    expect(caught.step).toBe('[qa] metaharness');
+    expect(caught.status).toBe(1);
+    expect(caught.output).toContain('R1 self-retrieval missed');
+    expect(caught.output).toContain('ABSENT from top-500');
+    expect(caught.output).toContain('0/1 store-variants PASS');
+    expect(caught.message).toContain('[qa] metaharness exited 1');
+    expect(caught.message).toContain('R1 self-retrieval missed');   // the alert text itself carries it
+    expect(caught.output.length).toBeGreaterThan(40);               // not a truncated stub
+  });
+
+  it('stderr-only capture would NOT have explained the nightly — stdout capture is load-bearing', () => {
+    // Same child, captureStdout:false. This is the shape the "just pipe stderr" fix would have had.
+    let caught = null;
+    try {
+      runStep('[qa] metaharness', NODE, child('    ↳ R1 self-retrieval missed: ABSENT from top-500', '', 1), {});
+    } catch (e) { caught = e; }
+    expect(caught).toBeTruthy();
+    expect(caught.output).toBe('');                                  // nothing to escalate
+    expect(caught.message).toContain('(child produced no output)');  // and it says so, out loud
+  });
+
+  it('a builder that fails with a stack on stderr surfaces it while stdout stays inherited (live progress)', () => {
+    let caught = null;
+    try {
+      runStep('[refresh] metaharness', NODE, child('', 'Error: ENOENT no such file kb/metaharness.passages.jsonl', 2), {});
+    } catch (e) { caught = e; }
+    expect(caught).toBeTruthy();
+    expect(caught.step).toBe('[refresh] metaharness');
+    expect(caught.status).toBe(2);
+    expect(caught.output).toContain('ENOENT');
+    expect(caught.output).toContain('metaharness.passages.jsonl');
+  });
+
+  it('the captured reason is bounded — a screaming child cannot flood the alert', () => {
+    const noisy = Array.from({ length: 400 }, (_, i) => `line ${i}`).join('\n');
+    let caught = null;
+    try { runStep('[qa] noisy', NODE, child(noisy, '', 1), {}, { captureStdout: true }); } catch (e) { caught = e; }
+    expect(caught).toBeTruthy();
+    const kept = caught.output.split(' | ');
+    expect(kept.length).toBeLessThanOrEqual(20);      // a tail, not the whole log
+    expect(kept.at(-1)).toBe('line 399');             // and it is the END of the output, where reasons live
+    expect(kept).not.toContain('line 0');
+  });
+});
+
+describe('self-update — the abort summary carries the reason it collected', () => {
+  it('the failure record keeps step + reason, not just the argv', () => {
+    expect(SOURCE).toContain('failures.push({ name: p.name, step: e.step');
+    expect(SOURCE).toContain('reason: e.output');
+  });
+
+  it('the REFRESH step captures stdout — forge-refresh gates promotion on its own candidate QA, and that verdict is on stdout', () => {
+    const at = SOURCE.indexOf('console.log(`[refresh] ${kb}`)');
+    expect(at).toBeGreaterThan(-1);
+    const refresh = SOURCE.slice(at, SOURCE.indexOf('console.log(`[symbols] ${kb}`)', at));
+    expect(refresh).toContain('captureStdout: true');
+  });
+
+  it('the QA step — the one whose verdict must reach the alert — is wired with captureStdout', () => {
+    const at = SOURCE.indexOf('console.log(`[qa] ${kb}`)');
+    expect(at).toBeGreaterThan(-1);
+    // ...the catch that FOLLOWS the qa step — self-update has earlier try/catch blocks, and
+    // slicing to the first one in the file runs backwards and yields ''.
+    const qa = SOURCE.slice(at, SOURCE.indexOf('} catch (e)', at));
+    expect(qa).toContain('corpus-qa.mjs');
+    expect(qa).toContain('captureStdout: true');
+  });
+
+  it('the [FATAL] block prints each reason, and the push alert quotes the first one', () => {
+    const fatal = SOURCE.slice(SOURCE.indexOf('if (failures.length) {'), SOURCE.indexOf('[stamp] re-stamping'));
+    expect(fatal).toContain('reason:');
+    expect(fatal).toMatch(/NOTIFY\([\s\S]*first\.reason \|\| first\.error/);
+  });
+});
+
+describe('nightly-wrapper — the escalation sample is wide enough to contain a reason', () => {
+  const WRAPPER = fs.readFileSync(path.join(ROOT, 'scripts/nightly-wrapper.sh'), 'utf8');
+
+  it('samples enough of the log that the [FATAL] reason lines survive', () => {
+    const m = /tail -(\d+) "\$LOG"[\s\S]{0,80}?cut -c1-(\d+)/.exec(WRAPPER);
+    expect(m, 'escalation tail/cut pair must exist').toBeTruthy();
+    const [, lines, chars] = m.map(Number);
+    // Was tail -8 | cut -c1-600: the [FATAL] block alone is 4+ lines and the old cut landed
+    // mid-argv, so the alert was truncated before any reason could appear.
+    expect(lines).toBeGreaterThanOrEqual(20);
+    expect(chars).toBeGreaterThanOrEqual(1800);
+  });
+});


### PR DESCRIPTION
The nightly knowledge-bundle publish failed **6 times across 3 nights** and could not self-heal. It was never a build failure — it was a QA verdict, and the escalation channel carried none of the reason.

## Root cause (independently verified, not relayed)

`scripts/corpus-qa.mjs:159` samples R1 self-retrieval deterministically from `rows.length`. metaharness moved **8979 → 8986** passages and the sampler re-rolled:

```
n=8979 -> [5565,1433,4850]
n=8986 -> [1188,1945,8660]     <- index 1945
```

`kb/metaharness.passages.jsonl` line 1946 is `chunk:2b7c2755…  submissions/swe-bench-lite/.../django__django-13315/test_output.txt` — byte-identical to the chunk named in `logs/nightly.log:18489`. That row was *always* un-retrievable; seven new rows simply aimed the sampler at it. Measured: **49.3% of metaharness passages are swe-bench submissions**, largely identical conda/pytest boilerplate, so the row sits behind 187 near-duplicates.

The gate's own header says it "proves the machinery, not the answers" — requiring a row to win its own query inside a ~50%-near-duplicate corpus is a *ranking* assertion. That is the bug.

## The fix

Re-query wide before any verdict. Present at wide k → PASS with a `deep crowd` note carrying rank, window, Δ and crowd size. **Absent at wide k → hard FAIL, unweakened** — a missing or zero vector is absent at any k, so the class this gate exists for is fully preserved. `WIDE_K` is clamped to `min(500, max(10, n/2))` so "present" can never become vacuous.

Real-data A/B on the actual failing row: pre-fix `0/1 FAIL … ABSENT from top-10` (byte-identical to the nightly); post-fix `1/1 PASS + deep crowd: rank 188/500, 187/187 ahead are near-duplicates`.

## Why the escalation was empty

`corpus-qa` prints its verdict to **stdout**, so with `stdio:'inherit'` the child's `e.stderr` was `null` and `e.message` was only the argv — which `nightly-wrapper.sh:159` then truncated mid-argv at 600 chars. The log had the answer; the alert carried none of it. Both verdict-carrying steps now capture and re-emit verbatim, `[FATAL]` prints every reason, and the wrapper samples `tail -25 | cut -c1-2000`.

## Guarded

19 tests (8 pre-existing `it.todo`s implemented plus 2 more). **Verified by my own mutation, not the author's report** — removing the `n/2` clamp so wide-k reaches the whole corpus fails 3 tests:

```
AssertionError: expected '1/1' to be '0/1'
AssertionError: expected 'deep crowd: id=26 rank 5/40 …' to contain 'rank 5/20'
```

## Deliberately NOT changed

The all-or-nothing abort stays. `promoteArtifactSet()` runs only after a candidate passes its own QA, so after an abort every store in `kb/` is one that passed — only stamp and bundle are skipped, keeping the published bundle at the last consistent generation. Stamping anyway would ship a generation containing a silently stale store.

ADR-064 records the decision; ADR-0058's currency log re-reads the governed release/nightly surface and states the 95 contract is unchanged.