### PR TITLE
fix(replay): isolate post-task fixture from AgentDB opt-in

### DIFF
--- a/data/learning-replay-post-task-result.json
+++ b/data/learning-replay-post-task-result.json
@@ -1,9 +1,9 @@
 {
   "invariant": "LEARNING-REPLAY",
-  "verdict": "UNKNOWN",
-  "why": "3/3 run(s) could not be measured; 0/3 passed",
-  "sha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
-  "at": "2026-08-19T13:11:48.716Z",
+  "verdict": "PASS",
+  "why": "3/3 runs passed (bar 2/3)",
+  "sha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "at": "2026-08-20T05:46:53.482Z",
   "host": "codex",
   "model": "gpt-5.6-sol",
   "modelResolved": "gpt-5.6-sol",
@@ -11,9 +11,9 @@
   "trap": "hooks-post-task-persistence",
   "taskHash": "33b60b9f4540abd180a07e75e42de9e040dc0c217539f48c8c34ededc597f4a0",
   "n": 3,
-  "passes": 0,
+  "passes": 3,
   "fails": 0,
-  "unknowns": 3,
+  "unknowns": 0,
   "controlTokenRuns": 0,
   "controlWorkedRuns": 0,
   "treatedTokenRuns": 3,
@@ -22,10 +22,10 @@
     "treatedExecutedRuns": 3,
     "treatedRetrievedRuns": 3
   },
-  "rate": 0,
+  "rate": 1,
   "threshold": ">=2/3",
   "costUsd": 0,
-  "wallSeconds": 107.5,
+  "wallSeconds": 78.7,
   "premise": {
     "verified": true,
     "evidence": "live help names all flags; success/task-id-only persisted nothing"
@@ -52,8 +52,8 @@
     "ok": true
   },
   "refresh": {
-    "generation": "d4-refresh-1787144999478",
-    "codeRoot": ".ruvnet-brain/learning-replay/run-oPrYbJ/brain-home/versions/d4-refresh-1787144999478",
+    "generation": "d4-refresh-1787204731851",
+    "codeRoot": ".ruvnet-brain/learning-replay/run-hNScT2/brain-home/versions/d4-refresh-1787204731851",
     "distillExit": 0,
     "backupExit": 0,
     "lessonSurvived": true
@@ -61,13 +61,13 @@
   "runs": [
     {
       "i": 1,
-      "verdict": "UNKNOWN",
-      "why": "the control arm produced no ruflo invocation at all — there is no comparable artifact to difference against",
+      "verdict": "PASS",
+      "why": "treated \"flagged\" vs control \"partial\"; the produced command executed and returned the required outcome",
       "error": null,
       "treated": {
         "class": "flagged",
         "subcommandCorrect": true,
-        "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --store-results",
+        "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success --store-results",
         "exec": {
           "ran": true,
           "argv": [
@@ -78,13 +78,14 @@
             "release retry-budget investigation",
             "--agent",
             "tester",
+            "--success",
             "--store-results"
           ],
           "exit": 0,
           "exitOk": true,
           "retrieved": true,
-          "why": "exit 0; routing outcome and routing-decision:task_1787145018807_grejqj persisted",
-          "output": "[INFO] Recording outcome for task: task_1787145018807_grejqj\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178714"
+          "why": "exit 0; routing outcome and routing-decision:task_1787204744438_r8hos6 persisted",
+          "output": "[INFO] Recording outcome for task: task_1787204744438_r8hos6\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
         },
         "model": "gpt-5.6-sol",
         "forcedCommand": false,
@@ -92,44 +93,56 @@
         "firstToolIndex": 1,
         "lessonBeforeFirstToolCall": true,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/a5ba0346001bf2c0365f9b982b5fa14dc7766459a02c3d63174768fbf6398dff.json",
-          "sha256": "a5ba0346001bf2c0365f9b982b5fa14dc7766459a02c3d63174768fbf6398dff",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/e2e5bed3ad28f57bac52d02fb62eaa5214442f81197dfe23178bc84833074bef.json",
+          "sha256": "e2e5bed3ad28f57bac52d02fb62eaa5214442f81197dfe23178bc84833074bef",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       },
       "control": {
-        "class": "none",
-        "subcommandCorrect": false,
-        "command": "",
+        "class": "partial",
+        "subcommandCorrect": true,
+        "command": "ruflo hooks post-task --task-id release-retry-budget-investigation --success true --agent tester --store-memory true",
         "exec": {
-          "ran": false,
-          "argv": null,
-          "exit": null,
-          "exitOk": false,
+          "ran": true,
+          "argv": [
+            "ruflo",
+            "hooks",
+            "post-task",
+            "--task-id",
+            "release-retry-budget-investigation",
+            "--success",
+            "true",
+            "--agent",
+            "tester",
+            "--store-memory",
+            "true"
+          ],
+          "exit": 0,
+          "exitOk": true,
           "retrieved": false,
-          "why": "no Ruflo invocation to execute",
-          "output": ""
+          "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+          "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
         },
         "model": "gpt-5.6-sol",
         "lessonDelivered": false,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/e2d224bc51ab8030fde2cc0f1e2cd95e344729d9f4be6d9418c178c248cd90d0.json",
-          "sha256": "e2d224bc51ab8030fde2cc0f1e2cd95e344729d9f4be6d9418c178c248cd90d0",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9d0ea56abff4350add53bb2934ef570926630a110fb4dcb5f441a40828dee0c6.json",
+          "sha256": "9d0ea56abff4350add53bb2934ef570926630a110fb4dcb5f441a40828dee0c6",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       }
     },
     {
       "i": 2,
-      "verdict": "UNKNOWN",
-      "why": "the control arm produced no ruflo invocation at all — there is no comparable artifact to difference against",
+      "verdict": "PASS",
+      "why": "treated \"flagged\" vs control \"partial\"; the produced command executed and returned the required outcome",
       "error": null,
       "treated": {
         "class": "flagged",
         "subcommandCorrect": true,
-        "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --store-results",
+        "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success true --store-results",
         "exec": {
           "ran": true,
           "argv": [
@@ -140,13 +153,15 @@
             "release retry-budget investigation",
             "--agent",
             "tester",
+            "--success",
+            "true",
             "--store-results"
           ],
           "exit": 0,
           "exitOk": true,
           "retrieved": true,
-          "why": "exit 0; routing outcome and routing-decision:task_1787145065035_obl7u9 persisted",
-          "output": "[INFO] Recording outcome for task: task_1787145065035_obl7u9\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178714"
+          "why": "exit 0; routing outcome and routing-decision:task_1787204773076_u5nua5 persisted",
+          "output": "[INFO] Recording outcome for task: task_1787204773076_u5nua5\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
         },
         "model": "gpt-5.6-sol",
         "forcedCommand": false,
@@ -154,44 +169,56 @@
         "firstToolIndex": 1,
         "lessonBeforeFirstToolCall": true,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/2192de8ec5ef9d644ffbb4745b273fe5955dc7a2f0989651b0f94b8d977eae5a.json",
-          "sha256": "2192de8ec5ef9d644ffbb4745b273fe5955dc7a2f0989651b0f94b8d977eae5a",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/910b06c645fe3e4d15f06d18760223a4e09e32ca3cb5eef42db83002b18938bc.json",
+          "sha256": "910b06c645fe3e4d15f06d18760223a4e09e32ca3cb5eef42db83002b18938bc",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       },
       "control": {
-        "class": "none",
-        "subcommandCorrect": false,
-        "command": "",
+        "class": "partial",
+        "subcommandCorrect": true,
+        "command": "ruflo hooks post-task --task-id release-retry-budget-investigation --success true --agent tester --persist-routing true",
         "exec": {
-          "ran": false,
-          "argv": null,
-          "exit": null,
-          "exitOk": false,
+          "ran": true,
+          "argv": [
+            "ruflo",
+            "hooks",
+            "post-task",
+            "--task-id",
+            "release-retry-budget-investigation",
+            "--success",
+            "true",
+            "--agent",
+            "tester",
+            "--persist-routing",
+            "true"
+          ],
+          "exit": 0,
+          "exitOk": true,
           "retrieved": false,
-          "why": "no Ruflo invocation to execute",
-          "output": ""
+          "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+          "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  1 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
         },
         "model": "gpt-5.6-sol",
         "lessonDelivered": false,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/41e75ddb21d8deee5b200e65affa7c8702dc91aebdbdffa4e0e033b8a7413cdb.json",
-          "sha256": "41e75ddb21d8deee5b200e65affa7c8702dc91aebdbdffa4e0e033b8a7413cdb",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/8619abf0ae209c42611cd444f4a2467910b297c8513e15c2d432e45f231a3a32.json",
+          "sha256": "8619abf0ae209c42611cd444f4a2467910b297c8513e15c2d432e45f231a3a32",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       }
     },
     {
       "i": 3,
-      "verdict": "UNKNOWN",
-      "why": "the control arm produced no ruflo invocation at all — there is no comparable artifact to difference against",
+      "verdict": "PASS",
+      "why": "treated \"flagged\" vs control \"partial\"; the produced command executed and returned the required outcome",
       "error": null,
       "treated": {
         "class": "flagged",
         "subcommandCorrect": true,
-        "command": "ruflo hooks post-task --task 'release retry-budget investigation' --agent tester --store-results --success",
+        "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success --store-results",
         "exec": {
           "ran": true,
           "argv": [
@@ -202,14 +229,14 @@
             "release retry-budget investigation",
             "--agent",
             "tester",
-            "--store-results",
-            "--success"
+            "--success",
+            "--store-results"
           ],
           "exit": 0,
           "exitOk": true,
           "retrieved": true,
-          "why": "exit 0; routing outcome and routing-decision:task_1787145094122_6urs51 persisted",
-          "output": "[INFO] Recording outcome for task: task_1787145094122_6urs51\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178714"
+          "why": "exit 0; routing outcome and routing-decision:task_1787204799858_oedf84 persisted",
+          "output": "[INFO] Recording outcome for task: task_1787204799858_oedf84\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
         },
         "model": "gpt-5.6-sol",
         "forcedCommand": false,
@@ -217,31 +244,43 @@
         "firstToolIndex": 1,
         "lessonBeforeFirstToolCall": true,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/90f5c517dc74f9b034c7a9877ad24bdcc5676a3922ece79ad1627c990d505685.json",
-          "sha256": "90f5c517dc74f9b034c7a9877ad24bdcc5676a3922ece79ad1627c990d505685",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/86742a93054ae2898c5593566e6e70ac84b3c065dcea378f094f8ea22401bd75.json",
+          "sha256": "86742a93054ae2898c5593566e6e70ac84b3c065dcea378f094f8ea22401bd75",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       },
       "control": {
-        "class": "none",
-        "subcommandCorrect": false,
-        "command": "",
+        "class": "partial",
+        "subcommandCorrect": true,
+        "command": "ruflo hooks post-task --task-id \"release-retry-budget-investigation\" --success true --agent \"tester\" --store-results true",
         "exec": {
-          "ran": false,
-          "argv": null,
-          "exit": null,
-          "exitOk": false,
+          "ran": true,
+          "argv": [
+            "ruflo",
+            "hooks",
+            "post-task",
+            "--task-id",
+            "release-retry-budget-investigation",
+            "--success",
+            "true",
+            "--agent",
+            "tester",
+            "--store-results",
+            "true"
+          ],
+          "exit": 0,
+          "exitOk": true,
           "retrieved": false,
-          "why": "no Ruflo invocation to execute",
-          "output": ""
+          "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+          "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  1 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
         },
         "model": "gpt-5.6-sol",
         "lessonDelivered": false,
         "transcript": {
-          "path": "data/learning-replay-transcripts/5841feb2ef09eca7c8231b738b11eba5e2d73cb7/b946e6282dddbc73b5cac6b60a00162ffc11562a79be90264c58033b50450e3b.json",
-          "sha256": "b946e6282dddbc73b5cac6b60a00162ffc11562a79be90264c58033b50450e3b",
-          "sourceSha": "5841feb2ef09eca7c8231b738b11eba5e2d73cb7",
+          "path": "data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9139f2d5ceaa436ba2c2df5e6802816dd98acb1447af3a0beaf6e1380536aba8.json",
+          "sha256": "9139f2d5ceaa436ba2c2df5e6802816dd98acb1447af3a0beaf6e1380536aba8",
+          "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
           "mutant": null
         }
       }

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/8619abf0ae209c42611cd444f4a2467910b297c8513e15c2d432e45f231a3a32.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/8619abf0ae209c42611cd444f4a2467910b297c8513e15c2d432e45f231a3a32.json
@@ -1,0 +1,36 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 2,
+  "arm": "control",
+  "record": {
+    "class": "partial",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task-id release-retry-budget-investigation --success true --agent tester --persist-routing true",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task-id",
+        "release-retry-budget-investigation",
+        "--success",
+        "true",
+        "--agent",
+        "tester",
+        "--persist-routing",
+        "true"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": false,
+      "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+      "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  1 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
+    },
+    "model": "gpt-5.6-sol",
+    "lessonDelivered": false
+  }
+}

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/86742a93054ae2898c5593566e6e70ac84b3c065dcea378f094f8ea22401bd75.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/86742a93054ae2898c5593566e6e70ac84b3c065dcea378f094f8ea22401bd75.json
@@ -1,0 +1,37 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 3,
+  "arm": "treated",
+  "record": {
+    "class": "flagged",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success --store-results",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task",
+        "release retry-budget investigation",
+        "--agent",
+        "tester",
+        "--success",
+        "--store-results"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": true,
+      "why": "exit 0; routing outcome and routing-decision:task_1787204799858_oedf84 persisted",
+      "output": "[INFO] Recording outcome for task: task_1787204799858_oedf84\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
+    },
+    "model": "gpt-5.6-sol",
+    "forcedCommand": false,
+    "lessonIndex": 0,
+    "firstToolIndex": 1,
+    "lessonBeforeFirstToolCall": true
+  }
+}

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/910b06c645fe3e4d15f06d18760223a4e09e32ca3cb5eef42db83002b18938bc.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/910b06c645fe3e4d15f06d18760223a4e09e32ca3cb5eef42db83002b18938bc.json
@@ -1,0 +1,38 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 2,
+  "arm": "treated",
+  "record": {
+    "class": "flagged",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success true --store-results",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task",
+        "release retry-budget investigation",
+        "--agent",
+        "tester",
+        "--success",
+        "true",
+        "--store-results"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": true,
+      "why": "exit 0; routing outcome and routing-decision:task_1787204773076_u5nua5 persisted",
+      "output": "[INFO] Recording outcome for task: task_1787204773076_u5nua5\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
+    },
+    "model": "gpt-5.6-sol",
+    "forcedCommand": false,
+    "lessonIndex": 0,
+    "firstToolIndex": 1,
+    "lessonBeforeFirstToolCall": true
+  }
+}

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9139f2d5ceaa436ba2c2df5e6802816dd98acb1447af3a0beaf6e1380536aba8.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9139f2d5ceaa436ba2c2df5e6802816dd98acb1447af3a0beaf6e1380536aba8.json
@@ -1,0 +1,36 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 3,
+  "arm": "control",
+  "record": {
+    "class": "partial",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task-id \"release-retry-budget-investigation\" --success true --agent \"tester\" --store-results true",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task-id",
+        "release-retry-budget-investigation",
+        "--success",
+        "true",
+        "--agent",
+        "tester",
+        "--store-results",
+        "true"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": false,
+      "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+      "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  1 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
+    },
+    "model": "gpt-5.6-sol",
+    "lessonDelivered": false
+  }
+}

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9d0ea56abff4350add53bb2934ef570926630a110fb4dcb5f441a40828dee0c6.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/9d0ea56abff4350add53bb2934ef570926630a110fb4dcb5f441a40828dee0c6.json
@@ -1,0 +1,36 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 1,
+  "arm": "control",
+  "record": {
+    "class": "partial",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task-id release-retry-budget-investigation --success true --agent tester --store-memory true",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task-id",
+        "release-retry-budget-investigation",
+        "--success",
+        "true",
+        "--agent",
+        "tester",
+        "--store-memory",
+        "true"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": false,
+      "why": "exit 0; command lacked --task, --agent, --store-results, or a task id",
+      "output": "[INFO] Recording outcome for task: release-retry-budget-investigation\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | tr"
+    },
+    "model": "gpt-5.6-sol",
+    "lessonDelivered": false
+  }
+}

--- a/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/e2e5bed3ad28f57bac52d02fb62eaa5214442f81197dfe23178bc84833074bef.json
+++ b/data/learning-replay-transcripts/85837f7346d82a9cdb9861cf430cdae270177e5d/e2e5bed3ad28f57bac52d02fb62eaa5214442f81197dfe23178bc84833074bef.json
@@ -1,0 +1,37 @@
+{
+  "schema": 2,
+  "sourceSha": "85837f7346d82a9cdb9861cf430cdae270177e5d",
+  "trap": "hooks-post-task-persistence",
+  "mutant": null,
+  "run": 1,
+  "arm": "treated",
+  "record": {
+    "class": "flagged",
+    "subcommandCorrect": true,
+    "command": "ruflo hooks post-task --task \"release retry-budget investigation\" --agent tester --success --store-results",
+    "exec": {
+      "ran": true,
+      "argv": [
+        "ruflo",
+        "hooks",
+        "post-task",
+        "--task",
+        "release retry-budget investigation",
+        "--agent",
+        "tester",
+        "--success",
+        "--store-results"
+      ],
+      "exit": 0,
+      "exitOk": true,
+      "retrieved": true,
+      "why": "exit 0; routing outcome and routing-decision:task_1787204744438_r8hos6 persisted",
+      "output": "[INFO] Recording outcome for task: task_1787204744438_r8hos6\n\n[OK] Task outcome recorded: SUCCESS\n\nLearning Updates\n+------------------+--------------------+\n| Metric           |              Value |\n+------------------+--------------------+\n| Patterns Updated |                  2 |\n| New Patterns     |                  1 |\n| Duration         |               0.2s |\n| Trajectory ID    | traj-178720"
+    },
+    "model": "gpt-5.6-sol",
+    "forcedCommand": false,
+    "lessonIndex": 0,
+    "firstToolIndex": 1,
+    "lessonBeforeFirstToolCall": true
+  }
+}

--- a/scripts/learning-replay-cli.mjs
+++ b/scripts/learning-replay-cli.mjs
@@ -132,9 +132,14 @@ export async function main(argv = process.argv.slice(2)) {
   const dirs = buildFixtures(base);
   process.once('exit', () => cleanupFixtureDaemons(dirs));
   const record = recordInProjectA(dirs, { trap });
-  const seed = trap === TRAP.MEMORY_SEARCH
-    ? seedProjectBMemory(dirs)
-    : { key: null, storeExit: null, ok: true, skipped: 'not required' };
+  // Every target fixture needs a real AgentDB file before Codex starts. The global SessionStart
+  // contract otherwise injects an opt-in question and requires the model to wait for an answer,
+  // which prevents both post-task arms from producing the command this trap is meant to compare.
+  // Only the memory-search trap needs the independent cache note; post-task needs an initialized,
+  // otherwise empty store so its control differs solely on the lesson under test.
+  const seed = seedProjectBMemory(dirs, {
+    includeFixtureRecord: trap === TRAP.MEMORY_SEARCH,
+  });
   const refresh = nightlyRefresh(dirs);
   console.log(`  record: ${record.projectCount} sources; promoted=${record.promoted}; ok=${record.ok}`);
   console.log(`  seed: ${seed.skipped || `ok=${seed.ok}`}`);

--- a/scripts/learning-replay-fixture.mjs
+++ b/scripts/learning-replay-fixture.mjs
@@ -23,11 +23,16 @@ import {
 const CLAUDE_BIN = process.env.RUVNET_CLAUDE_BIN
   || path.join(os.homedir(), '.npm-global', 'bin', 'claude');
 const CODEX_BIN = process.env.RUVNET_CODEX_BIN || 'codex';
-const sh = (cmd, args, options = {}) => spawnSync(cmd, args, {
-  encoding: 'utf8',
-  timeout: 120_000,
-  ...options,
-});
+const sh = (cmd, args, options = {}) => {
+  const [binary, argv] = /\.[cm]?js$/i.test(cmd)
+    ? [process.execPath, [cmd, ...args]]
+    : [cmd, args];
+  return spawnSync(binary, argv, {
+    encoding: 'utf8',
+    timeout: 120_000,
+    ...options,
+  });
+};
 const remove = (target) => {
   try { fs.rmSync(target, { recursive: true, force: true }); } catch { /* already gone */ }
 };
@@ -143,9 +148,23 @@ export function recordInProjectA(dirs, {
   };
 }
 
-export function seedProjectBMemory(dirs, { ruflo = RUFLO_BIN } = {}) {
+export function seedProjectBMemory(dirs, {
+  ruflo = RUFLO_BIN,
+  includeFixtureRecord = true,
+} = {}) {
   const db = path.join(dirs.projectB, '.swarm', 'memory.db');
   const init = initMemoryDb(ruflo, db, dirs.projectB);
+  if (!includeFixtureRecord) {
+    return {
+      db,
+      key: null,
+      initExit: init.status,
+      storeExit: null,
+      exactReadExit: null,
+      ok: init.status === 0 && fs.existsSync(db),
+      skipped: 'AgentDB initialized; memory-search record not required',
+    };
+  }
   const store = sh(ruflo, [
     'memory', 'store', '-k', PROJECT_B_MEMORY_KEY,
     '--value', PROJECT_B_MEMORY_VALUE, '-n', 'default', '--path', db,

--- a/tests/unit/learning-replay.test.mjs
+++ b/tests/unit/learning-replay.test.mjs
@@ -25,7 +25,7 @@ import {
   TRAP, classifyPostTaskCommand, postTaskSubcommandCorrect, verifyPostTaskContract,
   assertPostTaskPersisted,
   cleanupFixtureDaemons,
-  buildFixtures, nightlyRefresh,
+  buildFixtures, nightlyRefresh, seedProjectBMemory,
 } from '../../scripts/learning-replay.mjs';
 import { spawn, spawnSync } from 'node:child_process';
 
@@ -228,6 +228,13 @@ function writePostTaskFixtureBinary(dir) {
 const fs = require('node:fs');
 const path = require('node:path');
 const args = process.argv.slice(2);
+if (args[0] === 'memory' && args[1] === 'init') {
+  const i = args.indexOf('--path');
+  const db = args[i + 1];
+  fs.mkdirSync(path.dirname(db), { recursive: true });
+  fs.writeFileSync(db, 'fixture AgentDB');
+  process.exit(0);
+}
 if (args.includes('--help')) {
   console.log('--task Task description. Without this + --agent, no routing outcome is recorded.');
   console.log('--agent Agent that executed the task');
@@ -267,6 +274,22 @@ if (task && agent) {
 }
 
 describe('the independent hooks post-task persistence trap', () => {
+  it('materializes project-B AgentDB without seeding the memory-search note', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'd4-post-task-agentdb-'));
+    try {
+      const dirs = buildFixtures(base);
+      const initialized = seedProjectBMemory(dirs, {
+        ruflo: writePostTaskFixtureBinary(base),
+        includeFixtureRecord: false,
+      });
+      expect(initialized.ok).toBe(true);
+      expect(initialized.key).toBeNull();
+      expect(fs.existsSync(path.join(dirs.projectB, '.swarm', 'memory.db'))).toBe(true);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it('scores the token only when task, agent, and store-results are all present', () => {
     const full = 'ruflo hooks post-task -i d4-one --success true --task "stabilize retry budget" --agent tester --store-results';
     expect(classifyPostTaskCommand(full)).toBe('flagged');

--- a/tests/unit/learning-replay.test.mjs
+++ b/tests/unit/learning-replay.test.mjs
@@ -228,26 +228,48 @@ function writePostTaskFixtureBinary(dir) {
 const fs = require('node:fs');
 const path = require('node:path');
 const args = process.argv.slice(2);
+const option = (short, long) => {
+  const i = args.findIndex((arg) => arg === short || arg === long);
+  return i >= 0 ? args[i + 1] : null;
+};
 if (args[0] === 'memory' && args[1] === 'init') {
-  const i = args.indexOf('--path');
-  const db = args[i + 1];
+  const db = option('--path', '--db');
   fs.mkdirSync(path.dirname(db), { recursive: true });
   fs.writeFileSync(db, 'fixture AgentDB');
   process.exit(0);
 }
+if (args[0] === 'memory' && args[1] === 'store') {
+  const db = option('--path', '--db');
+  const rowsFile = db + '.rows.json';
+  let rows = {};
+  try { rows = JSON.parse(fs.readFileSync(rowsFile, 'utf8')); } catch {}
+  rows[option('-k', '--key')] = option('--value', '--value');
+  fs.writeFileSync(rowsFile, JSON.stringify(rows));
+  process.exit(0);
+}
+if (args[0] === 'memory' && args[1] === 'retrieve') {
+  const db = option('--path', '--db');
+  let rows = {};
+  try { rows = JSON.parse(fs.readFileSync(db + '.rows.json', 'utf8')); } catch {}
+  const found = rows[option('-k', '--key')];
+  if (found == null) process.exit(1);
+  console.log(found);
+  process.exit(0);
+}
+if (args[0] === 'memory' && args[1] === 'search') {
+  console.log('[INFO] Found 1 result');
+  process.exit(0);
+}
+if (args[0] === 'memory' && ['distill', 'backup'].includes(args[1])) process.exit(0);
 if (args.includes('--help')) {
   console.log('--task Task description. Without this + --agent, no routing outcome is recorded.');
   console.log('--agent Agent that executed the task');
   console.log('--store-results Also persist the routing decision');
   process.exit(0);
 }
-const value = (short, long) => {
-  const i = args.findIndex((arg) => arg === short || arg === long);
-  return i >= 0 ? args[i + 1] : null;
-};
-const id = value('-i', '--task-id') || 'fixture-auto';
-const task = value('-t', '--task');
-const agent = value('-a', '--agent');
+const id = option('-i', '--task-id') || 'fixture-auto';
+const task = option('-t', '--task');
+const agent = option('-a', '--agent');
 console.log('[INFO] Recording outcome for task: ' + id);
 console.log('[OK] Task outcome recorded: SUCCESS');
 if (task && agent) {
@@ -286,6 +308,41 @@ describe('the independent hooks post-task persistence trap', () => {
       expect(initialized.key).toBeNull();
       expect(fs.existsSync(path.join(dirs.projectB, '.swarm', 'memory.db'))).toBe(true);
     } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('the post-task CLI dry-run enters Codex with project-B AgentDB already materialized', () => {
+    const repo = path.resolve(import.meta.dirname, '../..');
+    const archive = path.join(repo, '.ruvnet-brain', 'learning-replay');
+    fs.mkdirSync(archive, { recursive: true });
+    const before = new Set(fs.readdirSync(archive));
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'd4-post-task-cli-'));
+    const out = path.join(base, 'result.json');
+    const fixture = writePostTaskFixtureBinary(base);
+    let created = [];
+    try {
+      const result = spawnSync(process.execPath, [
+        'scripts/learning-replay.mjs', '--trap', TRAP.POST_TASK,
+        '--dry-run', '--keep-fixtures', '--out', out,
+      ], {
+        cwd: repo,
+        encoding: 'utf8',
+        timeout: 120_000,
+        env: { ...process.env, RUVNET_RUFLO_BIN: fixture },
+      });
+      created = fs.readdirSync(archive).filter((entry) => !before.has(entry));
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(EXIT.UNKNOWN);
+      expect(created).toHaveLength(1);
+      const db = path.join(
+        archive, created[0], 'fixture-project-b', '.swarm', 'memory.db',
+      );
+      expect(fs.existsSync(db)).toBe(true);
+      expect(fs.existsSync(`${db}.rows.json`)).toBe(false);
+    } finally {
+      for (const entry of created) {
+        fs.rmSync(path.join(archive, entry), { recursive: true, force: true });
+      }
       fs.rmSync(base, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Fixes #144

## Root cause

The post-task replay fixture skipped Project B AgentDB initialization. The global SessionStart hook therefore injected its AgentDB opt-in prompt and required Codex to wait for approval. Raw treated/control streams confirm that Codex asked for permission and emitted no Ruflo tool call; the parser was correctly reporting the absence.

## Fix

- Initialize Project B AgentDB for both replay traps.
- Seed the unrelated memory-search cache record only for the memory-search trap.
- Assert at the behavior boundary that post-task CLI startup materializes a real AgentDB while leaving the memory-search fixture record absent.
- Record a source-bound canonical N=3 replay receipt and proof envelopes.

## Verification

- TDD RED: the new materialization test failed with `expected true, received false` before the production fix.
- Mutation: restoring the old post-task conditional makes the CLI behavior test fail.
- Mutation: omitting `includeFixtureRecord: false` makes the empty-DB assertion fail.
- Focused: `npx vitest run tests/unit/learning-replay.test.mjs` — 42/42 passed.
- Unit: `npm run test:unit` — 256 files passed, 13 skipped; 3,344 tests passed, 4 expected-fail, 4 skipped, 161 todo.
- Plugin: `npm test` — 60/60 checks passed.
- Regression: `npm run test:regression` — 16/16 passed.
- Live replay on source `85837f7346d82a9cdb9861cf430cdae270177e5d`: 3/3 PASS.
- Proof verifier: `node scripts/learning-replay.mjs --trap hooks-post-task-persistence --check` — PASS, 3/3 recomputed runs.
- Pre-push policy gate passed; privacy scan found no local paths, API keys, private keys, or GitHub tokens in the receipt/proofs.

## Boundary

Issue #144 remains open until this PR is merged. The repository's referenced `~/.Codex/docs/qa-gates.md` was absent on this host, so verification used the package-defined focused, unit, plugin, regression, replay, and pre-push gates above. Full integration/mesh/mutation suites were not run because this repair is scoped to the replay fixture and CLI wiring.