### PR TITLE
fix(ci): bound Linux integration runtime

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -24,6 +24,10 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    # A blocked child process must fail the workflow instead of consuming GitHub's six-hour default.
+    # The full suite normally completes in under two minutes; fifteen minutes leaves room for cold
+    # dependency/model setup while keeping a runner wedge observable.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Issue #179: the integration job had no workflow-level timeout and wedged for hours twice.

Adds a 15-minute job ceiling. The suite normally completes in under two minutes; a blocked child now fails visibly instead of consuming the six-hour GitHub default.