### PR TITLE
feat(enforcement): bind Brain knowledge to execution policy

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -2811,7 +2811,16 @@ function runUpdate() {
     console.error(`      If you believe a newer build exists, check:  ${c.bold('node forge-update.mjs --check')}  in ${kbDir}`);
     process.exit(outcome.exitCode);
   }
-  if (outcome.fallback) {
+  if (outcome.fallback && FLAG_HOST_SYNC_ONLY) {
+    // Host synchronization has a narrower contract than a full update: it must converge the
+    // executable plugin/spine to the published package even when an optional large KB asset is
+    // missing. The old path fell through to a fresh install here, which required the same missing
+    // zip and stranded every host on its previous generation. Keep the KB failure visible, but
+    // continue to the host-sync transaction; the published-surface/release gates still fail the
+    // release until the signed KB asset exists.
+    warn("the knowledge bundle could not refresh; continuing with executable host synchronization only");
+    updateStatus = 0;
+  } else if (outcome.fallback) {
     warn("\nthe bundle's own updater couldn't complete — falling back to a fresh install of the latest Release (this always works)…\n");
     const self = fileURLToPath(import.meta.url);
     const fr = spawnSync(process.execPath, [self, '--force'], { stdio: 'inherit',

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.2",
-  "sourceIdentity": "7608e3ad48877891d5d12b94a3fead6f1ecd42527fed1061d5153b4adc631409",
+  "sourceIdentity": "b90c29258d811a2e0ee15b9b264fc0ebec8d5669000f3b0a2c1fd7c69ff1cc88",
   "versionSurfaces": {
     "package.json": "4.3.2",
     "plugin/.claude-plugin/plugin.json": "4.3.2",
@@ -87,10 +87,11 @@
     "0072-whole-product-integrity-conformance.md",
     "0073-agentdb-perennial-project-continuity.md",
     "0074-ruvnet-capability-claim-integrity.md",
+    "0075-knowledge-to-execution-enforcement.md",
     "README.md"
   ],
-  "trackedFileCount": 1162,
-  "trackedFilesSha256": "ce2fc30c4b4cca0d30e396e8cc8b3691aab78ebe67f7b4f3fcca433d7e2ed3f5",
+  "trackedFileCount": 1165,
+  "trackedFilesSha256": "7c871154a2982a250a14c56e39ec47c17aa70a9167945d45237d8453abbb3295",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0070-release-generation-convergence.md
+++ b/docs/adr/0070-release-generation-convergence.md
@@ -186,6 +186,8 @@ Only after those checks may the nightly failure marker be deleted and issues #15
 
 ## Currency log
 
+| 2026-08-30 | Reconciled the host-only updater after live v4.3.1 had no GitHub assets and the updater stranded the Stable Spine on 4.2.2-dev. | `bin/install.mjs` now keeps executable host synchronization moving when the optional KB refresh is unavailable; the release asset gate remains authoritative. |
+
 | 2026-08-30 | Automatic PR checks now converge through one bounded canonical runner; the older matrix is manual diagnostic coverage. | `.github/workflows/ci.yml`, `.github/workflows/qe-4-3.yml`, and `scripts/qa-runner.mjs` reduce duplicate observations while leaving protected publication authority unchanged. |
 
 | 2026-08-30 | Version propagation is now a single source edit followed by consistency verification, and release QA binds the candidate to one SHA. | `scripts/set-version.mjs`, `scripts/sync-version.mjs`, and `scripts/qa-runner.mjs` remove the emergency publish path that let public and source versions diverge. |

--- a/docs/adr/0072-whole-product-integrity-conformance.md
+++ b/docs/adr/0072-whole-product-integrity-conformance.md
@@ -207,6 +207,8 @@ conformance.
 
 ## Currency log
 
+| 2026-08-30 | Reconciled the host-only updater after live v4.3.1 had no GitHub assets and the updater stranded the Stable Spine on 4.2.2-dev. | `bin/install.mjs` now records the KB plane as degraded while continuing executable host convergence; the missing required release asset remains a publication failure. |
+
 | 2026-08-30 | Whole-product PR evidence now has one bounded canonical entrypoint; the full legacy QE matrix is manual-only and cannot create competing release claims. | `scripts/qa-runner.mjs`, `.github/workflows/ci.yml`, and `.github/workflows/qe-4-3.yml` preserve protected publication checks while simplifying automatic evidence collection. |
 
 | 2026-08-30 | Product integrity now has a bounded exact-SHA canonical gate and a separate release-authority assertion. | `scripts/qa-runner.mjs`, `scripts/release-authority.mjs`, and `docs/QA-RELEASE-PROCESS.md` make the boundary executable and auditable. |

--- a/docs/adr/0075-knowledge-to-execution-enforcement.md
+++ b/docs/adr/0075-knowledge-to-execution-enforcement.md
@@ -1,0 +1,177 @@
+---
+id: ADR-075
+title: Knowledge-to-execution enforcement is a mandatory policy boundary
+status: Accepted
+date: 2026-08-30
+updated: 2026-08-30
+impl: unbuilt
+authors: [Stuart Kerr, Codex]
+tags: [architecture, enforcement, routing, swarms, adr, ddd, qa, release]
+supersedes: []
+relates: [ADR-009, ADR-012, ADR-020, ADR-034, ADR-055, ADR-061, ADR-067, ADR-070, ADR-072, ADR-074]
+governs:
+  - plugin/skills/ruvnet-brain/SKILL.md
+  - plugin/skills/ruvnet-brain/PLAYBOOK.md
+  - plugin/hooks/hooks.json
+  - plugin/hooks/codex-hooks.json
+  - plugin/scripts/ground-ruvnet.sh
+  - plugin/scripts/ground-before-write.sh
+  - plugin/scripts/route-dispatch.sh
+  - plugin/scripts/decision-gate.mjs
+  - scripts/qa-runner.mjs
+  - bin/install.mjs
+  - scripts/doc-currency.mjs
+  - scripts/convergence-manifest.mjs
+  - docs/ddd/0017-release-convergence-context.md
+  - tests/unit/execution-policy.test.mjs
+  - tests/integration/execution-policy.test.mjs
+---
+
+# ADR-075 — Knowledge-to-execution enforcement is a mandatory policy boundary
+
+## Context
+
+RuvNet Brain exists to turn current RuvNet knowledge, project decisions, and user constraints
+into correct development behavior. The current repository contains the right instructions, but
+they are not all executable obligations. A live audit exposed the failure mode: the Brain knew
+that Ruflo coordinates while native Claude/Codex subscription agents execute, yet a caller could
+still select Ruflo's API-backed `agent_execute` endpoint. The guidance was correct; the action
+selection was not bound to it.
+
+This is not solved by adding more prompt text. The system currently has several distinct layers:
+
+| Area | Current behavior | Failure exposed |
+|---|---|---|
+| Source grounding | Retrieves and cites source for recognized RuvNet questions | Retrieval does not create an action precondition |
+| Host routing | `route-dispatch.sh` records dispatches | It is advisory because some hosts consume the result after dispatch |
+| Swarm use | Skills recommend parallel Ruflo swarms | No deterministic rule classifies when a swarm is required |
+| Provider choice | ADR-061 documents native subscription execution | No single preflight binds a registered role to that executor |
+| ADR currency | `doc-currency.mjs` detects governed-file drift | DDDs lack equivalent machine-readable lifecycle metadata; semantic agreement remains manual |
+| QA | `qa-runner.mjs` provides PR/release lanes | The architecture-to-test graph is split across scripts and workflows |
+
+The consequence is a knowledge/behavior split: a capable host can know the correct rule and still
+take a different path. That is precisely the class of failure this product must eliminate.
+
+## Decision
+
+Create one executable `ExecutionPolicy` boundary shared by hooks, CLI orchestration, and release
+receipts. It does not replace Ruflo, host CLIs, or the existing gates. It decides whether an
+action is eligible and which existing executor is allowed.
+
+### 1. Every consequential action receives a policy decision
+
+The policy classifies actions as `read`, `write`, `delegate`, `release`, or `external`. It records
+the task fingerprint, source-grounding receipt, project memory recall status, selected host,
+executor, swarm requirement, ADR/DDD scope, and QA lane. Missing required evidence yields
+`UNKNOWN` or `REFUSE`; it never silently becomes an allow.
+
+### 2. Delegation is host-aware and spend-safe
+
+For ordinary swarm work, Ruflo `swarm_init` and `agent_spawn` remain the coordination ledger.
+Execution must use the active host's native subscription executor: Claude Code Task or Codex
+collaboration agents. `agent_execute`, SDK/API calls, and OpenRouter are provider-backed paths
+and require explicit metered-spend authorization. Grok remains unsupported until an equivalent
+host adapter and final-answer boundary exist.
+
+The policy must refuse an API-backed executor when a native host is available but was not selected,
+and must refuse a native claim when no native host is actually authenticated. It must expose the
+reason and the allowed next executor in a machine-readable receipt.
+
+### 3. Parallelizable development defaults to a Ruflo swarm
+
+The policy marks a task `swarm-required` when it has independent workstreams, crosses three or
+more files, changes architecture/QA/release behavior, or explicitly requests a swarm. A task may
+be `single-agent` only when the policy records a deterministic reason such as one-file sequential
+work or a host capability limitation. The decision is auditable; it is not a prose suggestion.
+
+### 4. ADR and DDD state is part of the action precondition
+
+Every action touching governed code must resolve the governing ADR/DDD set before execution. Each
+document must have machine-readable status, date, updated, implementation state, and governed
+paths. A governed code change without a same-change reconciliation receipt is refused at the
+earliest available boundary. Superseded decisions remain historical but cannot continue to govern
+active code. Unbuilt decisions remain explicit and cannot be reported as implemented.
+
+### 5. Architecture decisions require a live dual-seat adversarial review
+
+Any new or materially changed ADR/DDD must first have a source-research receipt, then two
+independent adversarial reviews: one from the current authenticated Anthropic/Claude seat and one
+from the current authenticated OpenAI/Codex seat. The system resolves the best available model on
+each seat at run time and records the exact model IDs, dates, source inputs, disagreements, and
+final synthesis. Names such as “Fable 5” or “GPT-5.6-Sol” are historical labels, not permanent
+configuration.
+
+If only one seat is available, the result is `DEGRADED` and may inform implementation but cannot be
+represented as a completed dual review. A provider API call is never substituted for a native seat
+without explicit metered-spend authorization. The final ADR must distinguish research evidence,
+adversarial objections, synthesized decision, and unresolved disagreement.
+
+### 6. QA is generated from the same policy inventory
+
+The canonical QA runner owns the release graph. Every test directory and workflow must declare
+whether it is required, conditional, manual, held, or retired, with a reason and an owner. A test
+that is present but absent from the graph is a failure; a test that is intentionally not required
+must be represented as an explicit non-pass state. PR and release lanes may differ in cost, but
+the release receipt must enumerate every omitted lane and why it is not release-blocking.
+
+### 7. Receipts are the durable bridge between knowing and doing
+
+The policy decision, source-grounding identity, memory recall key, executor, test evidence, and
+result are appended to the project AgentDB memory and bound to the source identity manifest.
+Receipts are evidence, not authority: publication still requires the protected release workflow.
+
+### 8. One published generation is the only version presented as current
+
+The published npm/GitHub release is the canonical generation. Host plugin caches, the Stable Spine,
+MCP runtime, status markers, and user-facing version claims must converge to that exact version; a
+development checkout is an explicit, temporary exception and must never be presented as the
+published current version. A missing optional KB asset may degrade knowledge refresh, but it may not
+strand executable host behavior on an older generation. The updater must report the degraded KB
+plane and continue the executable host-sync transaction, while the release gate keeps publication
+red until all required assets exist.
+
+## Failure semantics
+
+- Missing source grounding for a RuvNet-shaped consequential action: `UNKNOWN`/refuse before write.
+- API-backed executor selected for ordinary native-host work: `REFUSE` with native route.
+- Parallelizable task without a swarm decision: `REFUSE` until classified.
+- ADR/DDD governed code moved without reconciliation: `REFUSE` at edit or push, whichever is first.
+- Test outside the QA graph: `FAIL` in canonical QA.
+- Native host unavailable: `DEGRADED`, never an invented provider or fake agent result.
+- Policy implementation unavailable: preserve the existing safe hook behavior and emit a diagnostic;
+  never claim enforcement that did not run.
+
+## Acceptance criteria
+
+1. A fixture that requests a Ruflo swarm with authenticated native Claude/Codex state produces a
+   `swarm-required` decision and names the native executor; selecting API-backed `agent_execute`
+   produces a refusal without making a provider call.
+2. A three-file architecture task, a one-file sequential fix, and an explicit swarm request each
+   produce deterministic decisions with reasons and no prompt interpretation.
+3. Mutating a governed ADR, DDD, or source file without its reconciliation receipt makes the
+   earliest available gate fail and identifies the exact document/path pair.
+4. The QA inventory detects a newly added test file and a newly added workflow that are absent
+   from the canonical graph; intentional manual/held/retired entries remain visible and non-green.
+5. Packed Claude and Codex hook paths preserve the same policy decision and receipt shape; an
+   unsupported host is reported as unsupported rather than silently treated as native.
+6. A complete policy receipt round-trips through the project `.swarm/memory.db` at the exact path
+   and binds to the convergence manifest source identity.
+7. A changed ADR/DDD cannot receive a `dual-review-complete` receipt unless both native seats
+   produced independently identifiable review outputs from the same source-research input; a
+   one-seat or provider-backed run is visibly `DEGRADED`.
+8. A host-only update with a missing KB asset still converges the executable plugin/spine to the
+   exact published npm version, records `kb-refresh: DEGRADED`, and never reports the older active
+   version as current.
+
+## Current implementation status
+
+`Accepted, partially implemented.` The deterministic execution classifier is implemented and in the
+canonical PR gate, and host-only update now has a defined degraded-KB path that can still converge
+the executable plugin/spine. Existing grounding, currency, wiring, convergence, and release gates
+remain active. The cross-host dispatch, ADR/DDD reconciliation receipt, dual-seat receipt, and
+architecture-to-test graph remain unbuilt until their acceptance criteria pass on both supported
+host paths.
+
+## Currency log
+
+| 2026-08-30 | Created after a live audit showed that correct Brain guidance could still be bypassed by selecting Ruflo's API-backed executor instead of the native subscription executor. | `plugin/skills/ruvnet-brain/SKILL.md`, `docs/adr/0061-subscription-only-dual-host-deliberation.md`, `plugin/scripts/route-dispatch.sh`, and the failed Ruflo execution receipt in the session record. |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "version:sync": "node scripts/sync-version.mjs",
     "convergence:write": "node scripts/convergence-manifest.mjs --write",
     "convergence:check": "node scripts/convergence-manifest.mjs",
+    "execution-policy:check": "node scripts/execution-policy.mjs '{\"action\":\"delegate\",\"description\":\"architecture audit\",\"nativeHosts\":[\"codex\"]}'",
     "test:unit": "vitest run tests/unit",
     "test:mesh": "vitest run tests/mesh",
     "test:mutation": "vitest run tests/mutation",

--- a/scripts/execution-policy.mjs
+++ b/scripts/execution-policy.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// One deterministic boundary between Brain knowledge and consequential execution.
+// This module is deliberately pure: it never loads credentials, calls a provider, or mutates state.
+
+const NATIVE_HOSTS = new Set(['claude', 'codex']);
+const API_EXECUTORS = new Set(['agent_execute', 'sdk', 'openrouter', 'api']);
+const ARCHITECTURE_TERMS = /\b(adr|ddd|architecture|release|deploy|qa|security|schema|migration)\b/i;
+
+export function classifyExecutionPolicy(input = {}) {
+  const action = String(input.action || 'read');
+  const description = String(input.description || '');
+  const changedFiles = [...new Set((input.changedFiles || []).map(String).filter(Boolean))];
+  const nativeHosts = [...new Set((input.nativeHosts || []).map(String).filter((h) => NATIVE_HOSTS.has(h)))];
+  const requestedExecutor = String(input.requestedExecutor || '');
+  const explicitSwarm = input.explicitSwarm === true;
+  const multiFile = changedFiles.length >= 3;
+  const architectureTask = ARCHITECTURE_TERMS.test(description) || ['release', 'external'].includes(action);
+  const swarmRequired = explicitSwarm || multiFile || architectureTask;
+  const swarmReason = explicitSwarm
+    ? 'explicit-swarm-request'
+    : multiFile
+      ? 'three-or-more-independent-file-surfaces'
+      : architectureTask
+        ? 'architecture-or-consequential-action'
+        : 'single-sequential-surface';
+
+  if (action !== 'delegate') {
+    return {
+      schema: 'ruvnet-brain.execution-policy.v1',
+      verdict: 'ALLOW', action, swarmRequired, swarmReason,
+      executor: 'current-agent', reason: 'delegation-not-requested',
+    };
+  }
+
+  const nativeHost = NATIVE_HOSTS.has(input.activeHost) && nativeHosts.includes(input.activeHost)
+    ? input.activeHost : nativeHosts[0] || null;
+  if (API_EXECUTORS.has(requestedExecutor)) {
+    return {
+      schema: 'ruvnet-brain.execution-policy.v1',
+      verdict: nativeHost ? 'REFUSE' : 'DEGRADED', action, swarmRequired, swarmReason,
+      executor: nativeHost ? `native:${nativeHost}` : 'unknown',
+      reason: nativeHost
+        ? 'api-backed-executor-is-not-the-native-subscription-route'
+        : 'no-authenticated-native-host-is-available',
+    };
+  }
+  if (!nativeHost) {
+    return {
+      schema: 'ruvnet-brain.execution-policy.v1',
+      verdict: 'DEGRADED', action, swarmRequired, swarmReason, executor: 'unknown',
+      reason: 'no-authenticated-native-host-is-available',
+    };
+  }
+  return {
+    schema: 'ruvnet-brain.execution-policy.v1',
+    verdict: 'ALLOW', action, swarmRequired, swarmReason,
+    executor: `native:${nativeHost}`, reason: 'native-subscription-route-selected',
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const raw = process.argv[2] || '{}';
+  let input;
+  try { input = JSON.parse(raw); } catch { process.stderr.write('execution-policy: input must be JSON\n'); process.exit(2); }
+  process.stdout.write(`${JSON.stringify(classifyExecutionPolicy(input))}\n`);
+}

--- a/scripts/qa-runner.mjs
+++ b/scripts/qa-runner.mjs
@@ -12,6 +12,7 @@ const timeoutMs = Number(process.env.QA_TIMEOUT_MS || (release ? 15 * 60_000 : 8
 const lanes = [
   ['version', 'npm', ['run', 'version:check']],
   ['convergence', 'npm', ['run', 'convergence:check']],
+  ['execution-policy', 'npm', ['run', 'execution-policy:check']],
   ['docs', 'npm', ['run', 'doc:currency']],
   ['wiring', 'npm', ['run', 'wired:check']],
   ['substitution', 'npm', ['run', 'substitution:check']],

--- a/tests/unit/execution-policy.test.mjs
+++ b/tests/unit/execution-policy.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { classifyExecutionPolicy } from '../../scripts/execution-policy.mjs';
+
+describe('knowledge-to-execution policy', () => {
+  it('requires a swarm for an explicit swarm request', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', explicitSwarm: true, nativeHosts: ['codex'] }))
+      .toMatchObject({ verdict: 'ALLOW', swarmRequired: true, executor: 'native:codex' });
+  });
+
+  it('requires a swarm for three or more changed file surfaces', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', changedFiles: ['a', 'b', 'c'], nativeHosts: ['claude'] }))
+      .toMatchObject({ swarmRequired: true, swarmReason: 'three-or-more-independent-file-surfaces' });
+  });
+
+  it('classifies one sequential read as single-agent', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', changedFiles: ['a'], nativeHosts: ['codex'] }))
+      .toMatchObject({ swarmRequired: false, swarmReason: 'single-sequential-surface' });
+  });
+
+  it('refuses API-backed execution when a native host is available', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', requestedExecutor: 'agent_execute', nativeHosts: ['claude'] }))
+      .toMatchObject({ verdict: 'REFUSE', executor: 'native:claude' });
+  });
+
+  it('does not invent a native route when no host is authenticated', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', requestedExecutor: 'agent_execute' }))
+      .toMatchObject({ verdict: 'DEGRADED', executor: 'unknown' });
+  });
+
+  it('treats ADR and QA work as swarm-required', () => {
+    expect(classifyExecutionPolicy({ action: 'delegate', description: 'reconcile ADR and QA architecture', nativeHosts: ['codex'] }))
+      .toMatchObject({ swarmRequired: true, swarmReason: 'architecture-or-consequential-action' });
+  });
+});


### PR DESCRIPTION
Implements ADR-075 knowledge-to-execution enforcement.

- deterministic host/provider/swarm policy classifier
- canonical QA lane and unit coverage
- host-only updater continues executable convergence when optional KB asset is missing
- reconciles ADR-070 and ADR-072 in the same commit

Validation: doc-currency 0 blockers, targeted 35/35 tests, syntax, convergence manifest, diff check.