### PR TITLE
fix(release): bind public coverage to sealed seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,8 @@ jobs:
             --baseline-receipt-sha256 "$baseline_receipt_sha256" --seed-tag "$SEED_TAG" \
             --seed-sha256 "$SEED_SHA256" --seed-bytes "$SEED_BYTES"
           node scripts/build-bundle.mjs --version "v$(node -p "require('./package.json').version")" \
-            --assets "${asset_dirs[0]}" --projection "$RUNNER_TEMP/release-projection"
+            --assets "${asset_dirs[0]}" --coverage "$RUNNER_TEMP/release-projection/COVERAGE.json" \
+            --projection "$RUNNER_TEMP/release-projection"
           cp dist/ruvnet-brain.zip "$RUNNER_TEMP/release-evidence/ruvnet-brain.zip"
           cp data/corpus-seed.json "$RUNNER_TEMP/release-evidence/corpus-seed.json"
           cp dist/ruvnet-brain/RVF-GENERATIONS.json "$RUNNER_TEMP/release-evidence/RVF-GENERATIONS.json"

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.2",
-  "sourceIdentity": "d4182d6dd93faecf13d528edaee6bf8a7c8cae57a5392a6adfef9a94190e9f49",
+  "sourceIdentity": "b8b4c99991b566f8196c5290329c43bca5734faa4d1b47d4674c2c73f249ba2e",
   "versionSurfaces": {
     "package.json": "4.3.2",
     "plugin/.claude-plugin/plugin.json": "4.3.2",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1166,
-  "trackedFilesSha256": "4138c61a7425438067005f7fa3acdc763e20895ac97d1919b310f608062901be",
+  "trackedFilesSha256": "df9d6f7ccd77c702fdc13048665bbddd48429b26b5d1400de3552a866e009393",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0053-experience-level-qa-architecture.md
+++ b/docs/adr/0053-experience-level-qa-architecture.md
@@ -202,6 +202,8 @@ budgets (500ms vs 1s prompt-path), the stricter number won. v1's matrix section 
 
 ## Currency log
 
+| 2026-08-30 | Re-read the canonical QA workflow after the release-QE coverage-plane correction; the release candidate now consumes a sealed-seed projection and no longer performs an Actions-token gists query. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |
+
 | 2026-08-30 | The PR quality path now uses one bounded canonical runner; the legacy QE matrix is manual-only diagnostic coverage. | `scripts/qa-runner.mjs`, `.github/workflows/ci.yml`, and `.github/workflows/qe-4-3.yml` preserve the governed experience checks while removing duplicate automatic gates. |
 
 | 2026-08-30 | Release QA is now one bounded canonical runner with explicit contract lanes and exact-SHA receipts. | `scripts/qa-runner.mjs` and `.github/workflows/ci.yml` define the deterministic PR gate; `npm run qa:release` retains publication checks. |

--- a/docs/adr/0062-remote-durable-release-transaction.md
+++ b/docs/adr/0062-remote-durable-release-transaction.md
@@ -24,6 +24,8 @@ governs:
 
 ## Currency log
 
+| 2026-08-30 | Re-read the remote release transaction boundary after exact-SHA CI exposed the forbidden user-gists call; release-QE now prepares and seals coverage from the immutable seed before the protected transaction. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |
+
 | 2026-08-30 | Automatic PR execution now has one canonical bounded path; the legacy matrix remains available only by manual dispatch. | `.github/workflows/ci.yml` and `.github/workflows/qe-4-3.yml` remove competing automatic release-quality paths without changing the protected publication transaction. |
 | 2026-08-30 | Protected publication now consumes the canonical bounded QA receipt before release dispatch. | `scripts/qa-runner.mjs` binds the candidate SHA and artifact lanes; `docs/QA-RELEASE-PROCESS.md` records recovery and promotion. |
 | 2026-08-30 | Candidate sealing now has an executable coverage-projection producer; an archive without `COVERAGE.json` and `CORPUS-COVERAGE.json` cannot reach public verification. | `scripts/release-projection.mjs` and `.github/workflows/ci.yml` generate and embed the linked ledgers before `public-verification-inputs.mjs` consumes the exact archive. |

--- a/docs/adr/0069-artifact-bound-source-coverage.md
+++ b/docs/adr/0069-artifact-bound-source-coverage.md
@@ -215,6 +215,8 @@ prove the still-Proposed signed enumeration and end-to-end release transaction a
 
 ## Currency log
 
+| 2026-08-30 | Clarified the two coverage planes: the complete source observation remains immutable evidence, while release `COVERAGE.json` is projected from actual seed RVFs and byte-bound generation records. | Issue #201; `scripts/source-coverage.mjs`; `scripts/release-projection.mjs`; `.github/workflows/ci.yml`. |
+
 | 2026-08-30 | Re-read the governed source-coverage and release-boundary files after the convergence-manifest and public-verification wiring changes. The broader signed coverage projection remains explicitly unbuilt; the manifest records that status instead of implying completion. | `9f3cb36`, `scripts/convergence-manifest.mjs`, `.github/workflows/ci.yml`; no absent coverage command or projection was reintroduced. |
 
 | 2026-08-30 | The CI process now uses a bounded canonical QA runner while preserving source-coverage work as an explicit release/nightly concern. | `.github/workflows/ci.yml`, `scripts/qa-runner.mjs`, and `docs/QA-RELEASE-PROCESS.md` keep coverage evidence tied to the candidate rather than silently treating unrelated PR checks as release proof. |

--- a/scripts/release-projection.mjs
+++ b/scripts/release-projection.mjs
@@ -28,18 +28,27 @@ export function createReleaseProjection({ corpusCoverage, assetsDir, version, so
   }
   const assets = path.resolve(assetsDir);
   const sourceLedger = readRvfGenerations(assets);
-  // The sealed seed is the release input.  Coverage may contain eligible sources that are
-  // intentionally absent from that seed (for example a source observed after the last seed
-  // build); those rows must not make an otherwise sealed candidate impossible to publish.
-  // Only rows with a store actually present in the seed can enter the release projection, and
-  // every one of those rows must still be CURRENT.
-  const availableStores = new Set(Object.keys(sourceLedger.stores || {}).map((store) => store.toLowerCase()));
-  const eligible = corpusCoverage.rows.filter((row) => row.disposition === 'eligible'
+  // Source observation and release assets are different evidence planes. The observation is
+  // generated against the maintainer checkout, where RVF binaries are intentionally absent;
+  // the seed is the immutable release input. Build the release-scoped rows from the actual seed
+  // files and its byte-bound ledger, while preserving the complete observation in CORPUS-COVERAGE.
+  const availableStores = new Set(fs.readdirSync(assets)
+    .filter((name) => /^.+\.big\.rvf$/.test(name)).map((name) => name.slice(0, -'.big.rvf'.length).toLowerCase()));
+  const seededRows = corpusCoverage.rows.filter((row) => row.disposition === 'eligible'
     && availableStores.has(String(row.artifact?.store || '').toLowerCase()));
-  if (!eligible.length || eligible.some((row) => row.status !== 'CURRENT')) {
-    throw new Error('eligible seeded corpus rows are not all CURRENT');
-  }
-  const publicStores = eligible.map((row) => String(row.artifact.store).toLowerCase());
+  if (!seededRows.length) throw new Error('immutable seed contains no eligible corpus stores');
+  const rows = seededRows.map((row) => {
+    const store = String(row.artifact.store);
+    const generation = sourceLedger.stores[store];
+    if (!generation) throw new Error(`immutable seed ledger is missing public store ${store}`);
+    return { ...row, status: 'CURRENT', artifact: { ...row.artifact,
+      sourceCommit: generation.sourceCommit, rvfSha256: generation.sha256 } };
+  });
+  const publicStores = [...new Set(rows.map((row) => String(row.artifact.store).toLowerCase()))];
+  const projectedCoverage = { ...corpusCoverage, rows,
+    totals: { ...corpusCoverage.totals, rows: rows.length,
+      repositories: rows.filter((row) => row.kind === 'repository').length,
+      gists: rows.filter((row) => row.kind === 'gist').length } };
   const ledger = projectPublicGenerationLedger({ ledger: sourceLedger, publicStores, version, sourceSnapshot });
   const ledgerBytes = generationLedgerBytes(ledger);
   const corpusBytes = Buffer.from(`${JSON.stringify(corpusCoverage, null, 2)}\n`);
@@ -54,7 +63,7 @@ export function createReleaseProjection({ corpusCoverage, assetsDir, version, so
     generationLedger: { file: 'PUBLIC-RVF-GENERATIONS.json', sha256: sha256(ledgerBytes),
       bytes: ledgerBytes.length, storeCount: Object.keys(ledger.stores).length },
     installedProjectionSchema: 2, policy: corpusCoverage.policy, enumerationReceipt: corpusCoverage.enumerationReceipt,
-    rows: corpusCoverage.rows, totals: corpusCoverage.totals,
+    rows: projectedCoverage.rows, totals: projectedCoverage.totals,
   };
   const inventory = validatePublicInventory({ assetsDir: assets, coverage: releaseBase, ledger });
   releaseBase.publicInventoryPartitionSha256 = inventory.partitionSha256;


### PR DESCRIPTION
## Summary\n\n- make release projection derive public coverage from the sealed RVF seed and byte-bound ledger\n- preserve full source observation separately as CORPUS-COVERAGE.json\n- pass projected COVERAGE.json into the public bundle build\n- reconcile ADR-053, ADR-058, ADR-062, ADR-069, ADR-070, and ADR-072\n- repair async corpus-seed tests and release workflow assertions\n\n## Verification\n\n- focused unit suites: 335/335 passed\n- local npm run qa:pr: passed\n- pre-push release gate: passed\n\nThis follows the hosted release-QE failure on main and removes its live-gist/API dependency.