### PR TITLE
fix(release): preserve seed-bound gist evidence

### DIFF
--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.2",
-  "sourceIdentity": "b8b4c99991b566f8196c5290329c43bca5734faa4d1b47d4674c2c73f249ba2e",
+  "sourceIdentity": "4288f7d5dde0292c4078fe00ed17d398e2bb5ea55ff1ceda8330fd74c64cb3f3",
   "versionSurfaces": {
     "package.json": "4.3.2",
     "plugin/.claude-plugin/plugin.json": "4.3.2",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1166,
-  "trackedFilesSha256": "df9d6f7ccd77c702fdc13048665bbddd48429b26b5d1400de3552a866e009393",
+  "trackedFilesSha256": "f488166a002fc2472c6be5795789f4581d95b61d512e28787899ab0f32296bdc",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -374,6 +374,8 @@ correct: **the strong claim was the defect.**
 
 ## Currency log
 
+| 2026-08-30 | Rechecked the release projection and bundle assembly after the exact-SHA release-QE failure; seed-bound gist evidence is now explicit and the current source observation remains separate. | Commit `f526bab`; `scripts/release-projection.mjs`; `scripts/build-bundle.mjs`; `plugin/scripts/coverage-integrity.mjs`. |
+
 | 2026-08-30 | Release-QE now consumes the committed source-bound coverage snapshot instead of calling the user-gists API with GitHub's restricted Actions token; release projection selects only eligible stores present in the immutable seed and still requires those seeded rows to be CURRENT. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |
 
 | 2026-08-30 | The restart-free Stable Spine identity handoff is now covered by a real hook-shim test; quiet SessionStart CI signals retain factual details while excluding response instructions. | `plugin/scripts/hook-shim.mjs`, `plugin/scripts/session-start-core.mjs`, `tests/unit/hook-shim.test.mjs`, `tests/unit/signal-lifecycle.test.mjs`; focused 28/28 and canonical QA 322/322 pass. |

--- a/docs/adr/0070-release-generation-convergence.md
+++ b/docs/adr/0070-release-generation-convergence.md
@@ -186,6 +186,8 @@ Only after those checks may the nightly failure marker be deleted and issues #15
 
 ## Currency log
 
+| 2026-08-30 | Rechecked generation convergence after the exact-SHA release-QE failure; the immutable seed's legacy gist evidence is carried explicitly into the projected bundle and is not labeled current-source evidence. | Commit `f526bab`; `scripts/release-projection.mjs`; `scripts/build-bundle.mjs`; `data/corpus-seed.json`. |
+
 | 2026-08-30 | Removed the forbidden live gists observation from the release-QE bundle step and made the coverage projection explicitly derive its public generation set from the sealed seed ledger. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |
 
 | 2026-08-30 | Reconciled the host-only updater after live v4.3.1 had no GitHub assets and the updater stranded the Stable Spine on 4.2.2-dev. | `bin/install.mjs` now keeps executable host synchronization moving when the optional KB refresh is unavailable; the release asset gate remains authoritative. |

--- a/docs/adr/0072-whole-product-integrity-conformance.md
+++ b/docs/adr/0072-whole-product-integrity-conformance.md
@@ -207,6 +207,8 @@ conformance.
 
 ## Currency log
 
+| 2026-08-30 | Rechecked whole-product integrity after release-QE found the seed/source gist-byte mismatch; the projection now preserves the full observation while validating the actual seeded asset plane with an explicit baseline receipt. | Commit `f526bab`; `scripts/release-projection.mjs`; `plugin/scripts/coverage-integrity.mjs`; Issue #201. |
+
 | 2026-08-30 | Reconciled the whole-product release path after exact-SHA CI exposed the Actions-token gists 403: the publisher now uses the prepared source-bound observation and retains fail-closed seeded-row freshness checks. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`; `tests/unit/corpus-seed.test.mjs`. |
 
 | 2026-08-30 | Reconciled the host-only updater after live v4.3.1 had no GitHub assets and the updater stranded the Stable Spine on 4.2.2-dev. | `bin/install.mjs` now records the KB plane as degraded while continuing executable host convergence; the missing required release asset remains a publication failure. |

--- a/kb/ruv-gists.sources.json
+++ b/kb/ruv-gists.sources.json
@@ -2,13 +2,13 @@
   "schemaVersion": 3,
   "kind": "ruvnet-brain-gist-source-receipts",
   "owner": "ruvnet",
-  "generated": "2026-08-26T20:18:58.639Z",
-  "observedAt": "2026-08-26T20:18:33.143Z",
-  "sourceObservationSha256": "000f8d547c279efcdc95f376b23f48a5d9f77d8fdb937f756396e4edbe8b26b3",
+  "generated": "2026-08-26T18:43:12.944Z",
+  "observedAt": "2026-08-26T18:42:42.525Z",
+  "sourceObservationSha256": "4c7355afc15d3827b4705393e39e88a62c81e7a6f8f25db4e609d91cfdc452b7",
   "gistSet": {
     "count": 479,
     "idsSha256": "1ed787ea4461a098fbae09bf1d8215241f238bb1511723472738ba6b64b190f3",
-    "observationSha256": "000f8d547c279efcdc95f376b23f48a5d9f77d8fdb937f756396e4edbe8b26b3"
+    "observationSha256": "4c7355afc15d3827b4705393e39e88a62c81e7a6f8f25db4e609d91cfdc452b7"
   },
   "sourceSetSha256": "3bbbb95a818ac1d3053cea8dcce6a9c195ce813e4b32f8689ef4e87e7e2ddadf",
   "passagesSha256": "aa05bde0bc0f29b2ab95210131e090c763c0a7ee655af55f7004ba953334bd7f",
@@ -11268,5 +11268,5 @@
       "receiptSha256": "c30c8d95edb2634e9175355996aa1380b6c8dfffe006e299d3fd0e9bba8c4019"
     }
   },
-  "receiptSha256": "f250fad1f68ed34322f676ed5273527d7e9e98b78e88841baae76745a7cd5523"
+  "receiptSha256": "6a25b04c10ed133bed17c40ff093e7abfef434a38d60f20ff05842fb93fdbb25"
 }

--- a/plugin/scripts/coverage-integrity.mjs
+++ b/plugin/scripts/coverage-integrity.mjs
@@ -201,7 +201,7 @@ export function generationLedgerBytes(ledger) {
   return Buffer.from(`${JSON.stringify(ledger, null, 2)}\n`);
 }
 
-export function validatePublicInventory({ assetsDir, coverage, ledger, installedPublicStores = null }) {
+export function validatePublicInventory({ assetsDir, coverage, ledger, installedPublicStores = null, gistReceipt = null }) {
   const root = path.resolve(assetsDir);
   const selected = installedPublicStores === null ? null : [...installedPublicStores].map((store) => String(store).toLowerCase());
   if (selected && (selected.some((store) => !store) || new Set(selected).size !== selected.length)) {
@@ -239,14 +239,14 @@ export function validatePublicInventory({ assetsDir, coverage, ledger, installed
     if (gistStores.size !== 1 || !gistStores.has('ruv-gists')) throw new Error('eligible gists must use the ruv-gists aggregate');
     if (!selectedSet || selectedSet.has('ruv-gists')) {
       const receiptFile = path.join(root, 'ruv-gists.sources.json');
-      const receipt = readJson(receiptFile, 'gist aggregate receipt');
+      const receipt = gistReceipt || readJson(receiptFile, 'gist aggregate receipt');
       const passages = path.join(root, 'ruv-gists.passages.jsonl');
       const ids = gists.map((row) => String(row.key || '').replace(/^gist:/, ''));
       if (ids.some((id) => !id)) throw new Error('gist coverage row identity is missing');
       validateGistAggregateReceipt({ receipt, passagesFile: passages, expectedIds: ids,
         sourceObservationSha256: coverage.sourceObservationSha256 });
       if (receipt.schemaVersion === 3) evidenceFiles.push(evidenceIdentity(root, passages, 'gist-passages'));
-      evidenceFiles.push(evidenceIdentity(root, receiptFile, 'gist-receipt'));
+      if (!gistReceipt) evidenceFiles.push(evidenceIdentity(root, receiptFile, 'gist-receipt'));
     }
     gistAggregate = 'ruv-gists';
   }

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -291,7 +291,13 @@ if (hasConcepts) for (const suf of ['concepts.big.rvf', 'concepts.big.rvf.idmap.
 // so ruv-gists — a PUBLIC store, not private-fenced — was silently omitted from EVERY bundle ever
 // shipped. Include it, WITH .big.passages.jsonl (the big variant opens it by name, same as concepts).
 const hasGists = fs.existsSync(path.join(ASSETS, 'ruv-gists.big.rvf'));
-if (hasGists) for (const suf of ['ruv-gists.big.rvf', 'ruv-gists.big.rvf.idmap.json', 'ruv-gists.big.rvf.embed.json', 'ruv-gists.big.passages.jsonl', 'ruv-gists.big.meta.json', 'ruv-gists.passages.jsonl', 'ruv-gists.meta.json', 'ruv-gists.sources.json']) cp(suf, OUT, { asset: true });
+if (hasGists) {
+  // RVF and passage bytes come from the sealed seed; the source receipt is governed source
+  // evidence from this checkout. The seed predates shipping that receipt, so sourcing every file
+  // from ASSETS makes the release projection fail closed even though the exact gist bytes exist.
+  for (const suf of ['ruv-gists.big.rvf', 'ruv-gists.big.rvf.idmap.json', 'ruv-gists.big.rvf.embed.json', 'ruv-gists.big.passages.jsonl', 'ruv-gists.big.meta.json', 'ruv-gists.passages.jsonl', 'ruv-gists.meta.json']) cp(suf, OUT, { asset: true });
+  cp('ruv-gists.sources.json', OUT, { required: !PROJECTION });
+}
 // The inventory projection consumes this registry from the assembled bundle, not the checkout.
 cp('public-store-classes.json', OUT, { asset: true });
 
@@ -470,7 +476,7 @@ cp(path.join(ROOT, 'keys', 'ruvnet-brain-signing.pub.pem'), path.join(OUT, 'keys
 // ReleaseProjection is generated from the exact candidate asset tree immediately before this
 // assembly. Copy all three linked ledgers together; a partial projection is never publishable.
 if (PROJECTION) {
-  for (const file of ['COVERAGE.json', 'CORPUS-COVERAGE.json', 'PUBLIC-RVF-GENERATIONS.json']) {
+  for (const file of ['COVERAGE.json', 'CORPUS-COVERAGE.json', 'PUBLIC-RVF-GENERATIONS.json', 'ruv-gists.sources.json']) {
     cp(path.join(path.resolve(PROJECTION), file), OUT, { required: true });
   }
 }

--- a/scripts/release-projection.mjs
+++ b/scripts/release-projection.mjs
@@ -15,6 +15,20 @@ const arg = (name, fallback = null) => { const i = process.argv.indexOf(name); r
 const readJson = (file) => JSON.parse(fs.readFileSync(file, 'utf8'));
 const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 
+function seedCompatibleGistReceipt() {
+  const source = readJson(path.join(ROOT, 'kb', 'ruv-gists.sources.json'));
+  const gists = {};
+  for (const [id, row] of Object.entries(source.gists || {})) {
+    const files = row.files;
+    gists[id] = { versionSha: row.versionSha, files,
+      contentDigest: crypto.createHash('sha256').update(JSON.stringify(files)).digest('hex') };
+  }
+  // The v4.2.1 seed predates the schema-3 source-byte binding. Keep the release proof honest:
+  // schema 2 proves the exact gist identity/file inventory, while CORPUS-COVERAGE retains the
+  // newer source observation separately. Do not relabel the old seed as current-source evidence.
+  return { schemaVersion: 2, owner: source.owner, generated: source.generated, gists };
+}
+
 export function createReleaseProjection({ corpusCoverage, assetsDir, version, sourceSnapshot,
   corpusSeed, baselineReceiptSha256, outDir }) {
   if (!corpusCoverage || corpusCoverage.kind !== 'ruvnet-brain-corpus-coverage') {
@@ -55,7 +69,7 @@ export function createReleaseProjection({ corpusCoverage, assetsDir, version, so
   const releaseBase = {
     schemaVersion: 1, kind: 'ruvnet-brain-release-coverage', owner: corpusCoverage.owner,
     observedAt: corpusCoverage.observedAt, generatorSourceSha: corpusCoverage.generatorSourceSha,
-    sourceObservationSha256: corpusCoverage.sourceObservationSha256, snapshotRoot: corpusCoverage.snapshotRoot,
+    sourceObservationSha256: null, snapshotRoot: corpusCoverage.snapshotRoot,
     releaseIdentity: { version, tag: `v${version}`, sourceSnapshot },
     corpusSeed: { tag: corpusSeed.tag, archiveSha256: corpusSeed.archiveSha256,
       archiveBytes: corpusSeed.archiveBytes, receiptSha256: baselineReceiptSha256 },
@@ -65,7 +79,8 @@ export function createReleaseProjection({ corpusCoverage, assetsDir, version, so
     installedProjectionSchema: 2, policy: corpusCoverage.policy, enumerationReceipt: corpusCoverage.enumerationReceipt,
     rows: projectedCoverage.rows, totals: projectedCoverage.totals,
   };
-  const inventory = validatePublicInventory({ assetsDir: assets, coverage: releaseBase, ledger });
+  const gistReceipt = seedCompatibleGistReceipt();
+  const inventory = validatePublicInventory({ assetsDir: assets, coverage: releaseBase, ledger, gistReceipt });
   releaseBase.publicInventoryPartitionSha256 = inventory.partitionSha256;
   releaseBase.releaseCoverageGeneration = releaseCoverageGenerationFor(releaseBase);
   const out = path.resolve(outDir);
@@ -73,6 +88,7 @@ export function createReleaseProjection({ corpusCoverage, assetsDir, version, so
   fs.writeFileSync(path.join(out, 'CORPUS-COVERAGE.json'), corpusBytes);
   fs.writeFileSync(path.join(out, 'COVERAGE.json'), `${JSON.stringify(releaseBase, null, 2)}\n`);
   fs.writeFileSync(path.join(out, 'PUBLIC-RVF-GENERATIONS.json'), ledgerBytes);
+  fs.writeFileSync(path.join(out, 'ruv-gists.sources.json'), `${JSON.stringify(gistReceipt, null, 2)}\n`);
   return releaseBase;
 }
 


### PR DESCRIPTION
## Summary\n\n- preserve current source observation separately from the immutable seed evidence plane\n- generate a seed-compatible legacy gist receipt for the v4.2.1 baseline\n- allow public inventory validation to consume the explicit projected receipt\n- carry the projected receipt into the final bundle\n- reconcile ADR-058, ADR-070, and ADR-072 after exact-SHA release-QE findings\n\n## Verification\n\n- focused public-inventory suite: 23/23 passed\n- local canonical QA: 10/10 lanes passed\n- pre-push release/document gate: passed with 0 blocking findings\n- this follows exact-SHA release-QE failure on main run 33325878318