### PR TITLE
fix(release): source policy registry from canonical checkout

### DIFF
--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.2",
-  "sourceIdentity": "4288f7d5dde0292c4078fe00ed17d398e2bb5ea55ff1ceda8330fd74c64cb3f3",
+  "sourceIdentity": "9b7a523ae57fceb9de22d457127ea11056c25bf6fcc0609e79c998faaf6a32e3",
   "versionSurfaces": {
     "package.json": "4.3.2",
     "plugin/.claude-plugin/plugin.json": "4.3.2",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1166,
-  "trackedFilesSha256": "f488166a002fc2472c6be5795789f4581d95b61d512e28787899ab0f32296bdc",
+  "trackedFilesSha256": "2114030efc995a58ef648eac6d9af8efcd46e79fc750c5360748e0146bed460c",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -374,6 +374,8 @@ correct: **the strong claim was the defect.**
 
 ## Currency log
 
+| 2026-08-30 | Rechecked bundle assembly after exact-SHA release-QE showed that source-controlled store policy was incorrectly expected inside the corpus seed; the builder now takes it from the canonical checkout. | `scripts/build-bundle.mjs`; `kb/public-store-classes.json`; exact-SHA release-QE. |
+
 | 2026-08-30 | Rechecked the release projection and bundle assembly after the exact-SHA release-QE failure; seed-bound gist evidence is now explicit and the current source observation remains separate. | Commit `f526bab`; `scripts/release-projection.mjs`; `scripts/build-bundle.mjs`; `plugin/scripts/coverage-integrity.mjs`. |
 
 | 2026-08-30 | Release-QE now consumes the committed source-bound coverage snapshot instead of calling the user-gists API with GitHub's restricted Actions token; release projection selects only eligible stores present in the immutable seed and still requires those seeded rows to be CURRENT. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |

--- a/docs/adr/0069-artifact-bound-source-coverage.md
+++ b/docs/adr/0069-artifact-bound-source-coverage.md
@@ -215,6 +215,8 @@ prove the still-Proposed signed enumeration and end-to-end release transaction a
 
 ## Currency log
 
+| 2026-08-30 | Rechecked artifact-bound source coverage after release-QE separated current observation from the immutable seed; projection and bundle assembly now bind the correct evidence plane and source policy registry. | `scripts/release-projection.mjs`; `scripts/build-bundle.mjs`; `data/source-coverage.json`; exact-SHA release-QE. |
+
 | 2026-08-30 | Clarified the two coverage planes: the complete source observation remains immutable evidence, while release `COVERAGE.json` is projected from actual seed RVFs and byte-bound generation records. | Issue #201; `scripts/source-coverage.mjs`; `scripts/release-projection.mjs`; `.github/workflows/ci.yml`. |
 
 | 2026-08-30 | Re-read the governed source-coverage and release-boundary files after the convergence-manifest and public-verification wiring changes. The broader signed coverage projection remains explicitly unbuilt; the manifest records that status instead of implying completion. | `9f3cb36`, `scripts/convergence-manifest.mjs`, `.github/workflows/ci.yml`; no absent coverage command or projection was reintroduced. |

--- a/docs/adr/0070-release-generation-convergence.md
+++ b/docs/adr/0070-release-generation-convergence.md
@@ -186,6 +186,8 @@ Only after those checks may the nightly failure marker be deleted and issues #15
 
 ## Currency log
 
+| 2026-08-30 | Rechecked generation convergence after the seed lacked the source-controlled public-store class registry; bundle assembly now keeps policy metadata on the source plane and corpus bytes on the seed plane. | `scripts/build-bundle.mjs`; `kb/public-store-classes.json`; exact-SHA release-QE. |
+
 | 2026-08-30 | Rechecked generation convergence after the exact-SHA release-QE failure; the immutable seed's legacy gist evidence is carried explicitly into the projected bundle and is not labeled current-source evidence. | Commit `f526bab`; `scripts/release-projection.mjs`; `scripts/build-bundle.mjs`; `data/corpus-seed.json`. |
 
 | 2026-08-30 | Removed the forbidden live gists observation from the release-QE bundle step and made the coverage projection explicitly derive its public generation set from the sealed seed ledger. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`. |

--- a/docs/adr/0072-whole-product-integrity-conformance.md
+++ b/docs/adr/0072-whole-product-integrity-conformance.md
@@ -207,6 +207,8 @@ conformance.
 
 ## Currency log
 
+| 2026-08-30 | Rechecked whole-product integrity after release-QE isolated a missing policy registry in the baseline seed; the final bundle now carries the canonical source-controlled registry explicitly. | `scripts/build-bundle.mjs`; `kb/public-store-classes.json`; exact-SHA release-QE. |
+
 | 2026-08-30 | Rechecked whole-product integrity after release-QE found the seed/source gist-byte mismatch; the projection now preserves the full observation while validating the actual seeded asset plane with an explicit baseline receipt. | Commit `f526bab`; `scripts/release-projection.mjs`; `plugin/scripts/coverage-integrity.mjs`; Issue #201. |
 
 | 2026-08-30 | Reconciled the whole-product release path after exact-SHA CI exposed the Actions-token gists 403: the publisher now uses the prepared source-bound observation and retains fail-closed seeded-row freshness checks. | Issue #201; `.github/workflows/ci.yml`; `scripts/release-projection.mjs`; `tests/unit/corpus-seed.test.mjs`. |

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -299,7 +299,9 @@ if (hasGists) {
   cp('ruv-gists.sources.json', OUT, { required: !PROJECTION });
 }
 // The inventory projection consumes this registry from the assembled bundle, not the checkout.
-cp('public-store-classes.json', OUT, { asset: true });
+// Store-class policy is source-controlled release metadata, not a corpus asset. The baseline
+// seed predates this registry, so sourcing it from ASSETS makes a valid seed fail projection.
+cp('public-store-classes.json', OUT, { required: true });
 
 // capability-cards.md — the FAST LANE's zero-ML answer source (kb/card-lane.mjs, the first
 // responder search_ruvnet consults before the heavy cross-repo search). Ships as its own small


### PR DESCRIPTION
Sources public-store policy metadata from the canonical checkout, preserves seed-bound gist evidence in the release projection, and reconciles all governing ADRs. Canonical QA and integration passed at exact head af9659b; pre-push release/document gate passed with 0 blocking findings.