### PR TITLE
fix(ci): bound every long release stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,9 @@ jobs:
       - name: Install root deps
         run: npm ci --no-audit --no-fund
       - name: Unit tests (full tests/unit — zero files excluded, per the audit note above)
-        run: npx vitest run tests/unit --reporter=dot
+        # Invoke Vitest through Node so the watchdog is independent of npm's Windows shim
+        # resolution (`npx` is not a portable executable name when spawn uses shell:false).
+        run: node scripts/ci/step-watchdog.mjs --name windows-unit --timeout-ms 1200000 -- node node_modules/vitest/vitest.mjs run tests/unit --reporter=dot
       - name: Installer smoke on Windows (REAL bin/install.mjs — --help / --doctor / --update / syntax+signing wiring)
         # First cross-platform run of the stranger's-first-contact path. The --enable-nightly
         # LaunchAgent test self-skips off-macOS via its node:test skip option (launchd is
@@ -399,7 +401,7 @@ jobs:
       - name: Core capability battery — REQUIRE_BRAIN=1 (a skipped battery is now a hard failure)
         env:
           REQUIRE_BRAIN: '1'
-        run: npm test
+        run: node scripts/ci/step-watchdog.mjs --name warm-brain-capability --timeout-ms 900000 -- npm test
 
   release-qe:
     needs: candidate-preflight
@@ -528,14 +530,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/candidate-host-evidence.mjs \
+          node scripts/ci/step-watchdog.mjs --name candidate-host-evidence --timeout-ms 900000 -- \
+            node scripts/candidate-host-evidence.mjs \
             --manifest "$RUNNER_TEMP/release-evidence/payload-manifest.json" \
             --package "$RUVNET_SEALED_PACKAGE" \
             --bundle "$RUNNER_TEMP/release-evidence/ruvnet-brain.zip" \
             --out "$RUNNER_TEMP/release-evidence/candidate-host-evidence.json"
       - name: Exact-artifact release QE
         run: |
-          npm exec -- vitest run \
+          node scripts/ci/step-watchdog.mjs --name exact-artifact-release-qe --timeout-ms 900000 -- \
+            npm exec -- vitest run \
             --config tests/qe/release/vitest.config.mjs \
             --reporter=json \
             --outputFile="$RUNNER_TEMP/release-evidence/release-qe.json" \

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.3",
-  "sourceIdentity": "5537dca4e70a6cbf64199c446df6726fb1356b439e368202c5f002a40a871900",
+  "sourceIdentity": "7388f0aa30266a21482fc67f781545e24dc9a6b1bff89b914159d787720d00ee",
   "versionSurfaces": {
     "package.json": "4.3.3",
     "plugin/.claude-plugin/plugin.json": "4.3.3",
@@ -90,8 +90,8 @@
     "0075-knowledge-to-execution-enforcement.md",
     "README.md"
   ],
-  "trackedFileCount": 1167,
-  "trackedFilesSha256": "473c52c879d512578615425b9c73d6ef99df3e265c055c7d7f3cdaf7595a9393",
+  "trackedFileCount": 1169,
+  "trackedFilesSha256": "0896c439c55815f20994d96eff759dfca75e01e032aa40f6ddfa9d1d6dfd2768",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0053-experience-level-qa-architecture.md
+++ b/docs/adr/0053-experience-level-qa-architecture.md
@@ -19,6 +19,9 @@ governs:
 
 # ADR-053: Experience-level QA
 
+## Currency log
+| 2026-08-31 | Reconciled the Windows unit lane after the hosted process fix added a cross-platform external watchdog; the complete unit surface remains unchanged and now invokes Vitest through Node for shell-independent execution. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; PR #211. |
+
 **Status**: Accepted (adversarially duel-verified 2026-07-26 — record below)
 **Date**: 2026-07-26
 **Related**: ADR-028 (test classes), ADR-050 (issue pipeline), ADR-051 (Codex wiring)

--- a/docs/adr/0058-the-95-contract.md
+++ b/docs/adr/0058-the-95-contract.md
@@ -51,6 +51,9 @@ governs:
 
 # ADR-058: The 95 contract
 
+## Currency log
+| 2026-08-31 | Reconciled the hosted process boundary after PR #211 added named per-step watchdog receipts and corrected Windows executable resolution; the 95-contract observations and release gates remain unchanged. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; `tests/unit/step-watchdog.test.mjs`. |
+
 **Status**: Proposed
 **Date**: 2026-07-27 · **Last updated**: 2026-08-02 · **Why**: the public 4.0.1 artifact exposed
 that QE-BRN-001 existed in the written master plan but was absent from the executable critical-risk

--- a/docs/adr/0062-remote-durable-release-transaction.md
+++ b/docs/adr/0062-remote-durable-release-transaction.md
@@ -23,6 +23,7 @@ governs:
 # ADR-062 — Remote-durable staged release transaction
 
 ## Currency log
+| 2026-08-31 | Added an external per-step watchdog and machine-readable receipt to the long hosted release and cross-platform stages. Job-level timeouts remain the outer fence; named stage budgets now fail a wedged operation at its actual boundary instead of leaving an opaque compound step in progress. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; `tests/unit/step-watchdog.test.mjs` |
 | 2026-08-31 | Reconciled after removing the duplicate canonical QA workflow job from the release candidate path. | `.github/workflows/ci.yml` now leaves the bounded QA contract to its single authoritative workflow; protected release transaction, exact-SHA, and durable receipt rules remain unchanged. |
 
 

--- a/docs/adr/0069-artifact-bound-source-coverage.md
+++ b/docs/adr/0069-artifact-bound-source-coverage.md
@@ -3,7 +3,7 @@ id: ADR-069
 title: Source coverage is artifact-bound, complete, and release-blocking
 status: Proposed
 date: 2026-08-21
-updated: 2026-08-30
+updated: 2026-08-31
 authors: [Stuart Kerr]
 tags: [coverage, corpus, rvf, github, gists, freshness, release]
 supersedes: []
@@ -214,6 +214,8 @@ prove the still-Proposed signed enumeration and end-to-end release transaction a
   are mutation-tested. These scenarios remain unimplemented until a failing-then-passing test exists.
 
 ## Currency log
+| 2026-08-31 | Reconciled the watchdog's Windows command boundary after hosted PR evidence showed shell:false cannot assume an `npx` shim; the unit lane now invokes Vitest through Node while retaining the same full suite. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; PR #211. |
+| 2026-08-31 | Reconciled after the main-branch merge and CI watchdog change; source coverage remains bound to the exact candidate artifact, while hosted long stages now emit bounded receipts. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; exact-SHA CI run `33358984585`. |
 
 | 2026-08-30 | Re-read after `abc1731` changed oracle source binding for squash-merged candidates; source coverage remains artifact-bound and the fetched source commit must still match its content digest. | `scripts/retrieval-canary.mjs`, `scripts/public-verification-inputs.mjs`, `.github/workflows/ci.yml`. |
 

--- a/docs/adr/0070-release-generation-convergence.md
+++ b/docs/adr/0070-release-generation-convergence.md
@@ -3,7 +3,7 @@ id: ADR-070
 title: One release generation across corpus, package, hosts, and retained state
 status: Accepted
 date: 2026-08-21
-updated: 2026-08-30
+updated: 2026-08-31
 authors: [Stuart Kerr, Codex]
 tags: [release, generation, corpus, update, synchronization, retention, proof]
 supersedes: []
@@ -185,6 +185,9 @@ Only after those checks may the nightly failure marker be deleted and issues #15
 7. Coverage documentation is generated from the sealed manifest, source ledger, and gist inventory.
 
 ## Currency log
+| 2026-08-31 | Regenerated the convergence manifest after the portable watchdog correction; the manifest now binds the actual PR tip rather than an earlier rebased commit. | `data/convergence-manifest.json`; PR #211. |
+| 2026-08-31 | Reconciled the watchdog's Windows command boundary after hosted PR evidence showed shell:false cannot assume an `npx` shim; the unit lane now invokes Vitest through Node while retaining the same exact candidate test surface. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; PR #211. |
+| 2026-08-31 | Reconciled after the 4.3.3 main-branch merge and CI watchdog change; generation identity remains exact-SHA bound and long release stages now fail at named boundaries with receipts. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; exact-SHA CI run `33358984585`. |
 
 | 2026-08-30 | The two-stage candidate build now validates against the same projection evidence it later packages: seed-compatible gist receipts, class registry, derived receipts, excluded stores, and the projected generation ledger are all present at validation time. | `scripts/release-projection.mjs`, `scripts/build-bundle.mjs`, `plugin/scripts/coverage-integrity.mjs` |
 | 2026-08-30 | The projected validation input now receives the canonical private-store fence from the checkout before inventory validation, closing the remaining seed-versus-policy input mismatch. | `scripts/build-bundle.mjs`; `kb/PRIVATE-STORES.json`; exact-SHA release-QE. |

--- a/docs/adr/0072-whole-product-integrity-conformance.md
+++ b/docs/adr/0072-whole-product-integrity-conformance.md
@@ -3,7 +3,7 @@ id: ADR-072
 title: Whole-product integrity is one executable contract
 status: Accepted
 date: 2026-08-21
-updated: 2026-08-30 15:52:52 EDT
+updated: 2026-08-31 01:18:00 EDT
 authors: [Stuart Kerr, Codex]
 tags: [architecture, quality, corpus, lifecycle, release, traceability, smart, sparc]
 supersedes: []
@@ -206,6 +206,8 @@ is now the documentation authority; implementation must still change before the 
 conformance.
 
 ## Currency log
+| 2026-08-31 | Reconciled the watchdog's Windows command boundary after hosted PR evidence localized the failure to executable resolution, not the test suite; the product contract is unchanged and the boundary is now portable. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; PR #211. |
+| 2026-08-31 | Reconciled after the 4.3.3 main-branch merge and CI watchdog change; whole-product conformance still requires every exact-SHA lane, and long hosted stages now expose named timeout receipts instead of opaque job progress. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; exact-SHA CI run `33358984585`. |
 
 | 2026-08-30 | Re-read after `abc1731` repaired the squash-merge provenance boundary; whole-product conformance is unchanged except that release-QE now fetches and validates the pre-candidate oracle source explicitly. | `scripts/retrieval-canary.mjs`, `.github/workflows/ci.yml`; focused suite passed 11/11. |
 

--- a/scripts/ci/step-watchdog.mjs
+++ b/scripts/ci/step-watchdog.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Run one CI operation with an explicit wall-clock budget and visible progress.
+// GitHub Actions has job timeouts, but no per-step timeout. This wrapper makes a
+// stalled operation fail locally at its named boundary and leaves a receipt.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const argv = process.argv.slice(2);
+const value = (flag, fallback = null) => {
+  const index = argv.indexOf(flag);
+  return index >= 0 && argv[index + 1] ? argv[index + 1] : fallback;
+};
+const separator = argv.indexOf('--');
+const command = separator >= 0 ? argv.slice(separator + 1) : [];
+const name = value('--name', command[0] || 'ci-step');
+const timeoutMs = Number(value('--timeout-ms', '600000'));
+const heartbeatMs = Number(value('--heartbeat-ms', '30000'));
+const receiptDir = value('--receipt-dir', process.env.RUNNER_TEMP ? path.join(process.env.RUNNER_TEMP, 'step-receipts') : path.join(os.tmpdir(), 'ruvnet-brain-step-receipts'));
+
+if (!command.length || !Number.isFinite(timeoutMs) || timeoutMs <= 0 || !Number.isFinite(heartbeatMs) || heartbeatMs <= 0) {
+  console.error('usage: node step-watchdog.mjs --name <name> --timeout-ms <ms> [--heartbeat-ms <ms>] [--receipt-dir <dir>] -- <command> [args...]');
+  process.exit(2);
+}
+
+fs.mkdirSync(receiptDir, { recursive: true });
+const startedAt = new Date().toISOString();
+const started = Date.now();
+const receiptPath = path.join(receiptDir, `${name}.json`);
+const child = spawn(command[0], command.slice(1), {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: 'inherit',
+  shell: false,
+  detached: process.platform !== 'win32',
+});
+let timedOut = false;
+let heartbeat;
+const writeReceipt = (status, exitCode = null, signal = null) => {
+  const receipt = {
+    schema: 'ruvnet-brain.ci.step-receipt',
+    name,
+    command,
+    startedAt,
+    endedAt: new Date().toISOString(),
+    elapsedMs: Date.now() - started,
+    timeoutMs,
+    status,
+    exitCode,
+    signal,
+  };
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  return receipt;
+};
+
+console.log(`[watchdog] START ${name} budget=${timeoutMs}ms command=${command.join(' ')}`);
+heartbeat = setInterval(() => {
+  console.log(`[watchdog] HEARTBEAT ${name} elapsed=${Date.now() - started}ms budget=${timeoutMs}ms`);
+}, heartbeatMs);
+const timeout = setTimeout(() => {
+  timedOut = true;
+  console.error(`[watchdog] TIMEOUT ${name} after ${timeoutMs}ms; terminating process`);
+  if (process.platform === 'win32') child.kill('SIGTERM');
+  else try { process.kill(-child.pid, 'SIGTERM'); } catch { child.kill('SIGTERM'); }
+  setTimeout(() => {
+    if (!child.killed) {
+      if (process.platform === 'win32') child.kill('SIGKILL');
+      else try { process.kill(-child.pid, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
+    }
+  }, 2000).unref();
+}, timeoutMs);
+
+child.on('error', (error) => {
+  clearTimeout(timeout); clearInterval(heartbeat);
+  writeReceipt('ERROR', null, error.code || error.name);
+  console.error(`[watchdog] ERROR ${name}: ${error.message}`);
+  process.exit(1);
+});
+child.on('close', (code, signal) => {
+  clearTimeout(timeout); clearInterval(heartbeat);
+  const status = timedOut ? 'TIMEOUT' : code === 0 ? 'PASS' : 'FAIL';
+  const receipt = writeReceipt(status, code, signal);
+  console.log(`[watchdog] ${status} ${name} elapsed=${receipt.elapsedMs}ms receipt=${receiptPath}`);
+  process.exit(status === 'PASS' ? 0 : 1);
+});

--- a/tests/unit/step-watchdog.test.mjs
+++ b/tests/unit/step-watchdog.test.mjs
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const watchdog = path.join(root, 'scripts/ci/step-watchdog.mjs');
+
+describe('CI step watchdog', () => {
+  it('fails a hung child and writes a named timeout receipt', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ruvnet-watchdog-'));
+    let error;
+    try {
+      execFileSync(process.execPath, [watchdog, '--name', 'hung-fixture', '--timeout-ms', '100', '--heartbeat-ms', '25', '--receipt-dir', dir, '--', process.execPath, '-e', 'setTimeout(() => {}, 10000)'], { encoding: 'utf8', timeout: 5000 });
+    } catch (caught) { error = caught; }
+    expect(error?.status).toBe(1);
+    const receipt = JSON.parse(fs.readFileSync(path.join(dir, 'hung-fixture.json'), 'utf8'));
+    expect(receipt.status).toBe('TIMEOUT');
+    expect(receipt.name).toBe('hung-fixture');
+  });
+
+  it('preserves a successful child result', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ruvnet-watchdog-'));
+    execFileSync(process.execPath, [watchdog, '--name', 'quick-fixture', '--timeout-ms', '1000', '--heartbeat-ms', '25', '--receipt-dir', dir, '--', process.execPath, '-e', ''], { encoding: 'utf8' });
+    const receipt = JSON.parse(fs.readFileSync(path.join(dir, 'quick-fixture.json'), 'utf8'));
+    expect(receipt.status).toBe('PASS');
+    expect(receipt.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What changed
- add an external per-step watchdog with heartbeats and machine-readable receipts
- apply named budgets to Windows unit, warm-brain, host evidence, and exact-artifact release QE
- add regression tests for timeout and success behavior
- reconcile ADR-062, ADR-069, ADR-070, and ADR-072 currency

This is a process fix: a stalled operation now fails at its named boundary instead of consuming the job timeout as an opaque compound step.