### PR TITLE
fix(release): collapse evidence handoff into one cycle

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -1,0 +1,110 @@
+name: release-cycle
+
+# The single release-control entrypoint. It coordinates evidence; it never publishes bytes itself.
+# The protected-release workflow remains the only publisher. This removes the previous manual
+# sequence of copying ci/aggregate/review run IDs between three unrelated dispatches.
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact 40-character SHA already on origin/main
+        required: true
+        type: string
+      signed_review_bundle_b64:
+        description: Base64 JSON containing the signed Fable 5 and GPT-5.6-Sol review receipts
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ruvnet-brain-release-cycle
+  cancel-in-progress: false
+
+jobs:
+  coordinate:
+    name: coordinate-exact-candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Resolve one exact-SHA evidence set
+        id: evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$CANDIDATE_SHA"
+          find_run() {
+            gh run list --repo "$GITHUB_REPOSITORY" --workflow "$1" --commit "$CANDIDATE_SHA" \
+              --limit 50 --json databaseId,status,conclusion,headSha \
+              --jq 'map(select(.headSha == env.CANDIDATE_SHA and .status == "completed" and .conclusion == "success"))[0].databaseId // empty'
+          }
+          ci_run="$(find_run ci.yml)"
+          aggregate_run="$(find_run release-aggregate.yml)"
+          test -n "$ci_run" || { echo "no successful ci run for $CANDIDATE_SHA" >&2; exit 1; }
+          test -n "$aggregate_run" || { echo "no successful release-aggregate run for $CANDIDATE_SHA" >&2; exit 1; }
+          printf 'ci_run=%s\naggregate_run=%s\n' "$ci_run" "$aggregate_run" >> "$GITHUB_OUTPUT"
+          echo "exact candidate: $CANDIDATE_SHA"
+          echo "ci run: $ci_run"
+          echo "aggregate run: $aggregate_run"
+      - name: Start the signed independent review stage
+        id: review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CI_RUN: ${{ steps.evidence.outputs.ci_run }}
+          AGGREGATE_RUN: ${{ steps.evidence.outputs.aggregate_run }}
+          REVIEW_BUNDLE: ${{ inputs.signed_review_bundle_b64 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run product-integrity-review.yml --repo "$GITHUB_REPOSITORY" \
+            -f candidate_sha="$CANDIDATE_SHA" \
+            -f release_qe_run_id="$CI_RUN" \
+            -f aggregate_run_id="$AGGREGATE_RUN" \
+            -f signed_review_bundle_b64="$REVIEW_BUNDLE"
+          for _ in $(seq 1 30); do
+            run="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow product-integrity-review.yml \
+              --limit 20 --json databaseId,status,conclusion,headSha,createdAt \
+              --jq 'map(select(.headSha == env.CANDIDATE_SHA)) | sort_by(.createdAt) | reverse | .[0]')"
+            id="$(jq -r '.databaseId // empty' <<<"$run")"
+            if [ -n "$id" ] && [ "$(jq -r '.status' <<<"$run")" = completed ]; then
+              test "$(jq -r '.conclusion' <<<"$run")" = success || { gh run view "$id" --repo "$GITHUB_REPOSITORY"; exit 1; }
+              echo "review_run=$id" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo 'product-integrity-review did not complete within 5 minutes' >&2
+          exit 1
+      - name: Dispatch the only publisher with derived IDs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CI_RUN: ${{ steps.evidence.outputs.ci_run }}
+          AGGREGATE_RUN: ${{ steps.evidence.outputs.aggregate_run }}
+          REVIEW_RUN: ${{ steps.review.outputs.review_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          gh workflow run protected-release.yml --repo "$GITHUB_REPOSITORY" \
+            -f candidate_sha="$CANDIDATE_SHA" \
+            -f version="$version" \
+            -f release_qe_run_id="$CI_RUN" \
+            -f aggregate_run_id="$AGGREGATE_RUN" \
+            -f independent_review_run_id="$REVIEW_RUN"
+          echo "protected publisher dispatched for $version at $CANDIDATE_SHA"

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.3",
-  "sourceIdentity": "f0969e54c6a9e07bf14cd3a01421e2bee02df53579272d1abf7f32b7a1a23012",
+  "sourceIdentity": "8c23fdadbb846f2e1dd41fadea2fa692f0ddadff6ddda669481a64e43c8d066f",
   "versionSurfaces": {
     "package.json": "4.3.3",
     "plugin/.claude-plugin/plugin.json": "4.3.3",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1170,
-  "trackedFilesSha256": "cedcb4b7304df16837818b330732504d47fbef94de9df165d601fa948eca477a",
+  "trackedFilesSha256": "95f609c54a0e5a04a2a5028fbd22508bd73ab96121ceac41323046c0562df724",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.3",
-  "sourceIdentity": "14cea718519c34a5b6a9fce4ff548746e1f8179001685dc2a00b8d0aad9fa296",
+  "sourceIdentity": "f0969e54c6a9e07bf14cd3a01421e2bee02df53579272d1abf7f32b7a1a23012",
   "versionSurfaces": {
     "package.json": "4.3.3",
     "plugin/.claude-plugin/plugin.json": "4.3.3",
@@ -90,8 +90,8 @@
     "0075-knowledge-to-execution-enforcement.md",
     "README.md"
   ],
-  "trackedFileCount": 1169,
-  "trackedFilesSha256": "b8e0ec43b22ba398438433e10d1f0360458edae2057e3727ffce238351ef45ea",
+  "trackedFileCount": 1170,
+  "trackedFilesSha256": "cedcb4b7304df16837818b330732504d47fbef94de9df165d601fa948eca477a",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/docs/adr/0051-codex-host-wiring.md
+++ b/docs/adr/0051-codex-host-wiring.md
@@ -3,7 +3,7 @@ id: ADR-051
 title: Codex host wiring — register MCP and adapt the full lifecycle without version-pinned commands
 status: Accepted
 date: 2026-07-24
-updated: 2026-08-30
+updated: 2026-08-31
 authors: [Stuart Kerr, Claude Code]
 tags: [codex, mcp, install, doctor, honesty, portability]
 supersedes: []
@@ -271,6 +271,7 @@ native Windows.
   `/hooks` review procedure while definitions are pending.
 
 ## Currency log
+| 2026-08-31 | Re-read after the release-control cutover; the release-proof skill now routes operators through `release-cycle.yml`, while `protected-release.yml` remains an internal publisher boundary. Codex host wiring is unchanged. | `plugin/skills/release-proof/SKILL.md`; `.github/workflows/release-cycle.yml`; `scripts/release-convergence-watchdog.mjs`. |
 | 2026-08-30 | **`codex-hook-adapter.mjs`'s CONTEXT_EVENTS moved to a new pure sibling, `codex-hook-events.mjs`, so its own parity test can finally import it.** | Dream Cycle 2026-08-30 (cross-host-conformance / codex-parity, DEEP+SCAN): `tests/unit/codex-claude-hook-parity.test.mjs`'s "per event" proof carried its own hand-copied `CONTEXT_EVENTS`/`NO_CONTEXT_EVENTS` arrays rather than reading the adapter's real 6-item set, because importing the adapter directly executes its side-effecting top level (`fs.readFileSync(0, 'utf8')`, a synchronous stdin read) — the same import-time hazard the 2026-08-26 `brain-stamp.mjs` finding named. That hand-copy had already drifted: it listed 4 of the 6 real CONTEXT_EVENTS (missing `PermissionRequest`, `SubagentStart`) and 2 of the 4 real no-context, non-Stop events (missing `PostCompact`, `SubagentStop`), so this file's own "per event" claim was never once checked for those four — latent, since `codex-hooks.json` wires none of them today (see the 2026-08-19 row below for Codex's complete event set). `CONTEXT_EVENTS` and a new `ALL_HOST_EVENTS` catalogue now live in `codex-hook-events.mjs` (no imports, no I/O at module load), imported by both the adapter and the test; the test's two event lists are derived from them instead of hand-copied. Registration, wrapper, doctor lines and the adapter's actual behavior are unchanged — this closes a test-coverage gap in the parity proof, it does not change what ships. |
 | 2026-08-10 | **The Codex host's dependency copy is now DERIVED from server.mjs, and this ADR's contract is strengthened.** | The wiring hand-listed `managed-cli-interface.mjs` and `runtime-preferences.mjs` — a second copy of the server's own import graph. ADR-067 added one import and the Codex host shipped a server whose sibling was absent: `tests/unit/npm-tarball-codex.test.mjs` caught it on the packaging boundary as "no reply to initialize in 15s". `serverDependencies()` now walks the real imports transitively and preserves each specifier so `./x` and `../scripts/y` both land where the server looks. Registration, wrapper, adapter and doctor lines unchanged; what changed is that a future import cannot silently break this host. |
 | 2026-08-03 | Re-read Codex wrapper behavior against the packed 4.0.8 host proof; no contract change. | PR #100 exact-SHA release evidence is green; Windows unit remains the sole required red lane. |

--- a/docs/adr/0062-remote-durable-release-transaction.md
+++ b/docs/adr/0062-remote-durable-release-transaction.md
@@ -13,6 +13,7 @@ governs:
   - .github/workflows/stranger-matrix.yml
   - .github/workflows/protected-release.yml
   - .github/workflows/release-aggregate.yml
+  - .github/workflows/release-cycle.yml
   - scripts/release.mjs
   - scripts/release-transaction.mjs
   - scripts/release-transaction-provider.mjs
@@ -23,6 +24,7 @@ governs:
 # ADR-062 — Remote-durable staged release transaction
 
 ## Currency log
+| 2026-08-31 | Replaced the manual cross-workflow handoff with one release-cycle controller. It derives the exact successful CI and aggregate runs for one candidate SHA, dispatches the mandatory signed independent review, waits for its exact-SHA result, and dispatches the protected publisher with all IDs. The protected publisher remains the only code allowed to publish. | `.github/workflows/release-cycle.yml`; manual run-ID copying is removed from the normal path while exact-SHA and signed-review requirements remain. |
 | 2026-08-31 | Added an external per-step watchdog and machine-readable receipt to the long hosted release and cross-platform stages. Job-level timeouts remain the outer fence; named stage budgets now fail a wedged operation at its actual boundary instead of leaving an opaque compound step in progress. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; `tests/unit/step-watchdog.test.mjs` |
 | 2026-08-31 | Reconciled after removing the duplicate canonical QA workflow job from the release candidate path. | `.github/workflows/ci.yml` now leaves the bounded QA contract to its single authoritative workflow; protected release transaction, exact-SHA, and durable receipt rules remain unchanged. |
 

--- a/docs/adr/0064-corpus-qa-proves-machinery-not-ranking.md
+++ b/docs/adr/0064-corpus-qa-proves-machinery-not-ranking.md
@@ -3,7 +3,7 @@ id: ADR-064
 title: The corpus-QA round trip proves the machinery, not the ranking
 status: Accepted
 date: 2026-08-06
-updated: 2026-08-22
+updated: 2026-08-31
 authors: [Stuart Kerr, Claude Code]
 tags: [corpus-qa, nightly, retrieval, near-duplicates, diagnosability, escalation]
 supersedes: []
@@ -177,6 +177,7 @@ label. Noted, not load-bearing for anything published.
   every one killed by the intended test; sources restored and re-verified byte-identical.
 
 ## Currency log
+| 2026-08-31 | Re-read after the release-control cutover; nightly convergence is now report-only and cannot dispatch a publisher, so it cannot bypass the signed review coordinator. Corpus-QA behavior is unchanged. | `scripts/nightly-wrapper.sh`; `scripts/release-convergence-watchdog.mjs`; `.github/workflows/release-cycle.yml`. |
 
 | Date | What changed | Why (with referents) |
 |---|---|---|

--- a/docs/adr/0069-artifact-bound-source-coverage.md
+++ b/docs/adr/0069-artifact-bound-source-coverage.md
@@ -214,6 +214,7 @@ prove the still-Proposed signed enumeration and end-to-end release transaction a
   are mutation-tested. These scenarios remain unimplemented until a failing-then-passing test exists.
 
 ## Currency log
+| 2026-08-31 | Re-read after the release-control cutover; the nightly wrapper still runs convergence checks, but the watchdog is now report-only and cannot dispatch a publisher or bypass the signed release coordinator. | `scripts/nightly-wrapper.sh`; `scripts/release-convergence-watchdog.mjs`; `.github/workflows/release-cycle.yml`; commit `e2e83c0`. |
 | 2026-08-31 | Reconciled the watchdog's Windows command boundary after hosted PR evidence showed shell:false cannot assume an `npx` shim; the unit lane now invokes Vitest through Node while retaining the same full suite. | `.github/workflows/ci.yml`; `scripts/ci/step-watchdog.mjs`; PR #211. |
 | 2026-08-31 | Reconciled after the main-branch merge and CI watchdog change; source coverage remains bound to the exact candidate artifact, while hosted long stages now emit bounded receipts. | `scripts/ci/step-watchdog.mjs`; `.github/workflows/ci.yml`; exact-SHA CI run `33358984585`. |
 

--- a/plugin/skills/release-proof/SKILL.md
+++ b/plugin/skills/release-proof/SKILL.md
@@ -30,11 +30,12 @@ green.
 ## Candidate seal
 
 Generate the receipt from commands in the protected candidate workflow. Do not hand-author it.
-Dispatch `.github/workflows/protected-release.yml` only with the full candidate SHA, the exact
-current version, and the successful exact-SHA CI run ID whose named `release-qe` job produced
-`release-evidence-<sha>`. The workflow derives the artifact digest from those sealed bytes and checks
-every binding before creating its handoff and again at the Production boundary. Missing artifacts,
-pending/red jobs, malformed inputs, version splits, and byte mismatches stop before the publisher.
+Dispatch `.github/workflows/release-cycle.yml` only with the full candidate SHA and the signed
+Fable 5/GPT-5.6-Sol review bundle. The coordinator derives the successful exact-SHA CI and
+aggregate IDs, runs the independent review, and dispatches `protected-release.yml` only after
+that review succeeds. Do not dispatch `protected-release.yml` directly. The protected workflow
+derives the artifact digest from sealed bytes and checks every binding before creating its handoff
+and again at the Production boundary.
 Validate it from the repository with:
 
 ```bash

--- a/scripts/nightly-wrapper.sh
+++ b/scripts/nightly-wrapper.sh
@@ -199,9 +199,9 @@ sh scripts/memdb-health.sh "$RUVNET_PROJECT_MEMORY_DB" >> "$LOG" 2>&1 \
 # maintainer away for a month. So the last step is handed to the nightly, which is already the thing
 # that runs unattended.
 #
-# It does NOT publish. self-update.mjs:56 refuses --publish and only protected-release.yml may ship;
-# this DISPATCHES that workflow, so every gate (exact-SHA evidence, clean worktree, release-proof,
-# host verification, post-publication seal) still runs exactly as designed. It stands down on any
+# It does NOT publish or dispatch a publisher. The watchdog is report-only because it cannot supply
+# the signed review bundle required by release-cycle.yml. The sole coordinator derives exact-SHA
+# evidence, runs independent review, and dispatches protected-release only after all gates pass. It stands down on any
 # unexpected state — dirty tree, open PRs, no green exact-SHA evidence, a -dev version, a stalled
 # Actions plane — because a watchdog acting on a partial picture is worse than no watchdog.
 # ── GITHUB HEALTH (2026-08-08). Stuart: "You should never ever let it be in a situation where

--- a/scripts/release-convergence-watchdog.mjs
+++ b/scripts/release-convergence-watchdog.mjs
@@ -11,18 +11,16 @@
  * for a month.
  *
  * WHAT IT WILL NOT DO. It does not publish. `scripts/self-update.mjs:56` refuses `--publish` and
- * only `protected-release.yml` may create a release, publish npm, or move a dist-tag. This script
- * DISPATCHES that workflow — the sanctioned path — and never substitutes for it. Every safety gate
- * (exact-SHA evidence, clean worktree, release-proof, host verification, post-publication seal)
- * still runs inside the workflow exactly as designed. Bypassing them to "get it done while nobody
- * is looking" would be the worst possible reading of an instruction to finish the job.
+ * `release-cycle.yml` is the sole release-control entrypoint. This watchdog is report-only: it
+ * never dispatches `protected-release.yml` directly and cannot manufacture the signed independent
+ * review bundle required by the coordinator.
  *
  * IT IS A NO-OP UNLESS EVERY PRECONDITION HOLDS. It runs from the nightly, unattended, for weeks.
  * A watchdog that acts on a partial picture is worse than no watchdog, so it refuses on anything
  * unexpected and says why. The default outcome is "nothing happened, here is the reason".
  *
  *   node scripts/release-convergence-watchdog.mjs           # report only, never acts
- *   node scripts/release-convergence-watchdog.mjs --dispatch # act, but only if ALL gates pass
+ *   node scripts/release-convergence-watchdog.mjs --dispatch # compatibility flag; still reports only
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -104,16 +102,9 @@ if (!ci) stand_down(`no successful exact-SHA \`ci\` run at ${originMain.slice(0,
 if (!aggregate) stand_down(`no successful exact-SHA \`release-aggregate\` run at ${originMain.slice(0, 7)} yet`);
 
 log(`ALL GATES PASS — candidate=${originMain.slice(0, 7)} version=${version} ci=${ci.databaseId} aggregate=${aggregate.databaseId}`);
-if (!DISPATCH) {
-  log('report-only mode; pass --dispatch to actually invoke the protected release workflow.');
-  process.exit(0);
-}
-
-// ── 6. Dispatch THE SANCTIONED PUBLISHER. Nothing here publishes; the workflow does. ─────────────
-sh('gh', ['workflow', 'run', 'protected-release.yml', '--repo', REPO,
-  '-f', `candidate_sha=${originMain}`,
-  '-f', `version=${version}`,
-  '-f', `release_qe_run_id=${ci.databaseId}`,
-  '-f', `aggregate_run_id=${aggregate.databaseId}`]);
-log(`DISPATCHED protected-release for ${version}. The workflow owns every safety gate from here.`);
-log('Verify afterwards with: node scripts/published-surface-probe.mjs (D-version-coherence must PASS).');
+// ── 6. Never dispatch a publisher from the watchdog. ───────────────────────────────────────────
+// A signed Fable/GPT review bundle is an explicit input to release-cycle.yml. This unattended
+// process cannot author or safely discover that authorization, so even --dispatch must stand down.
+log(`READY FOR release-cycle, but no action taken for ${version} at ${originMain}`);
+log('Dispatch only .github/workflows/release-cycle.yml with candidate_sha and the signed review bundle.');
+log('The coordinator is the only workflow allowed to dispatch protected-release.');


### PR DESCRIPTION
## What changed
- adds one release-cycle controller that derives exact-SHA CI and aggregate runs
- dispatches mandatory signed Fable 5/GPT-5.6-Sol review and waits for its result
- dispatches protected-release with all derived IDs
- preserves protected-release as the only publisher
- documents the authority in ADR-062

## Verification
- actionlint: PASS
- release transaction tests: 30/30 PASS
- pre-push version/channel/secrets/document gates: PASS

This removes manual cross-workflow run-ID copying without weakening exact-SHA or signed-review gates.