### PR TITLE
release(4.3.5): publish the corrected release rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.5-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.5--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.5 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.5-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
-  "version": "4.3.5-dev",
-  "sourceIdentity": "7e7687e33520d2aac7afb5599a81b0630de79393d52d1631b570f5255906d786",
+  "version": "4.3.5",
+  "sourceIdentity": "f40c4c14e4cbb5e37de0281f561191bf0566387ccdf677785c63f86403f7dcda",
   "versionSurfaces": {
-    "package.json": "4.3.5-dev",
-    "plugin/.claude-plugin/plugin.json": "4.3.5-dev",
-    "plugin/.codex-plugin/plugin.json": "4.3.5-dev",
-    "data/manifest.json": "4.3.5-dev",
-    "kb/RVF-GENERATIONS.json": "4.3.5-dev",
-    "explainer/index.html": "4.3.5-dev",
-    "primer/ruvnet-primer.md": "4.3.5-dev"
+    "package.json": "4.3.5",
+    "plugin/.claude-plugin/plugin.json": "4.3.5",
+    "plugin/.codex-plugin/plugin.json": "4.3.5",
+    "data/manifest.json": "4.3.5",
+    "kb/RVF-GENERATIONS.json": "4.3.5",
+    "explainer/index.html": "4.3.5",
+    "primer/ruvnet-primer.md": "4.3.5"
   },
   "adrInventory": [
     "0001-verified-bundle-not-single-file.md",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1170,
-  "trackedFilesSha256": "9e36b97fc0994097118504984acfa5205ae7848cce68d8e8aeec25b63faa08ec",
+  "trackedFilesSha256": "de69d086daff2228ec3e3e53ec8744fcb9d1ec137b0f7b527ddf6c232d43ae35",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.5-dev",
+  "brainVersion": "4.3.5",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.5-dev",
+    "softwareVersion": "4.3.5",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.5-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.5</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.5-dev",
-  "releaseTag": "v4.3.5-dev",
+  "brainVersion": "4.3.5",
+  "releaseTag": "v4.3.5",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.5-dev",
+  "version": "4.3.5",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5-dev",
+  "version": "4.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.5-dev",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5-dev",
+  "version": "4.3.5",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.5-dev",
+  "version": "4.3.5",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5-dev",
+  "version": "4.3.5",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.5-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.5 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real


### PR DESCRIPTION
Release 4.3.5 carries the corrected single release rail and synchronized version surfaces.\n\nPre-push evidence: version lockstep, convergence manifest current, release authority PASS, document currency 0 blockers, diff check clean.\n\nThe protected release-cycle workflow remains the sole publisher.