### PR TITLE
fix(enforcement): require live evidence before consequential execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.6-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.6--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.7-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.7--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.5 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.5-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.6-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.6--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
-  "version": "4.3.6-dev",
-  "sourceIdentity": "fa69026e3c5cdb0166007a3a9c2a869642b8f914441f362fa033df809c1c68e2",
+  "version": "4.3.7-dev",
+  "sourceIdentity": "088514ae2d95cc295838d9b6008831209fd5c71da1fbc5e708d1ad5d4e9af696",
   "versionSurfaces": {
-    "package.json": "4.3.6-dev",
-    "plugin/.claude-plugin/plugin.json": "4.3.6-dev",
-    "plugin/.codex-plugin/plugin.json": "4.3.6-dev",
-    "data/manifest.json": "4.3.6-dev",
-    "kb/RVF-GENERATIONS.json": "4.3.6-dev",
-    "explainer/index.html": "4.3.6-dev",
-    "primer/ruvnet-primer.md": "4.3.6-dev"
+    "package.json": "4.3.7-dev",
+    "plugin/.claude-plugin/plugin.json": "4.3.7-dev",
+    "plugin/.codex-plugin/plugin.json": "4.3.7-dev",
+    "data/manifest.json": "4.3.7-dev",
+    "kb/RVF-GENERATIONS.json": "4.3.7-dev",
+    "explainer/index.html": "4.3.7-dev",
+    "primer/ruvnet-primer.md": "4.3.7-dev"
   },
   "adrInventory": [
     "0001-verified-bundle-not-single-file.md",
@@ -90,8 +90,8 @@
     "0075-knowledge-to-execution-enforcement.md",
     "README.md"
   ],
-  "trackedFileCount": 1170,
-  "trackedFilesSha256": "eff6f27c9b018cea4af3a83c7a953df4da83ed9ce185ad49112d109b1c3a142c",
+  "trackedFileCount": 1172,
+  "trackedFilesSha256": "03455ffd8021b615881c3fb32d7497a186bd18ab7b1f005961ffdbe5804f87d9",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
-  "version": "4.3.5",
-  "sourceIdentity": "f40c4c14e4cbb5e37de0281f561191bf0566387ccdf677785c63f86403f7dcda",
+  "version": "4.3.6-dev",
+  "sourceIdentity": "fa69026e3c5cdb0166007a3a9c2a869642b8f914441f362fa033df809c1c68e2",
   "versionSurfaces": {
-    "package.json": "4.3.5",
-    "plugin/.claude-plugin/plugin.json": "4.3.5",
-    "plugin/.codex-plugin/plugin.json": "4.3.5",
-    "data/manifest.json": "4.3.5",
-    "kb/RVF-GENERATIONS.json": "4.3.5",
-    "explainer/index.html": "4.3.5",
-    "primer/ruvnet-primer.md": "4.3.5"
+    "package.json": "4.3.6-dev",
+    "plugin/.claude-plugin/plugin.json": "4.3.6-dev",
+    "plugin/.codex-plugin/plugin.json": "4.3.6-dev",
+    "data/manifest.json": "4.3.6-dev",
+    "kb/RVF-GENERATIONS.json": "4.3.6-dev",
+    "explainer/index.html": "4.3.6-dev",
+    "primer/ruvnet-primer.md": "4.3.6-dev"
   },
   "adrInventory": [
     "0001-verified-bundle-not-single-file.md",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1170,
-  "trackedFilesSha256": "de69d086daff2228ec3e3e53ec8744fcb9d1ec137b0f7b527ddf6c232d43ae35",
+  "trackedFilesSha256": "eff6f27c9b018cea4af3a83c7a953df4da83ed9ce185ad49112d109b1c3a142c",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.5",
+  "brainVersion": "4.3.6-dev",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.6-dev",
+  "brainVersion": "4.3.7-dev",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/docs/adr/0075-knowledge-to-execution-enforcement.md
+++ b/docs/adr/0075-knowledge-to-execution-enforcement.md
@@ -4,7 +4,7 @@ title: Knowledge-to-execution enforcement is a mandatory policy boundary
 status: Accepted
 date: 2026-08-30
 updated: 2026-08-31
-impl: partially implemented
+impl: built
 authors: [Stuart Kerr, Codex]
 tags: [architecture, enforcement, routing, swarms, adr, ddd, qa, release]
 supersedes: []
@@ -167,7 +167,7 @@ red until all required assets exist.
 
 ## Current implementation status
 
-`Accepted, partially implemented.` The deterministic execution classifier and the enforced live-evidence
+`Accepted, built with follow-on criteria.` The deterministic execution classifier and the enforced live-evidence
 preflight are implemented and in the canonical contract lane, and host-only update now has a defined degraded-KB path that can still converge
 the executable plugin/spine. Existing grounding, currency, wiring, convergence, and release gates
 remain active. The cross-host dispatch, ADR/DDD reconciliation receipt, dual-seat receipt, and

--- a/docs/adr/0075-knowledge-to-execution-enforcement.md
+++ b/docs/adr/0075-knowledge-to-execution-enforcement.md
@@ -22,9 +22,7 @@ governs:
   - bin/install.mjs
   - scripts/doc-currency.mjs
   - scripts/convergence-manifest.mjs
-  - docs/ddd/0017-release-convergence-context.md
   - tests/unit/execution-policy.test.mjs
-  - tests/integration/execution-policy.test.mjs
 ---
 
 # ADR-075 — Knowledge-to-execution enforcement is a mandatory policy boundary

--- a/docs/adr/0075-knowledge-to-execution-enforcement.md
+++ b/docs/adr/0075-knowledge-to-execution-enforcement.md
@@ -4,7 +4,7 @@ title: Knowledge-to-execution enforcement is a mandatory policy boundary
 status: Accepted
 date: 2026-08-30
 updated: 2026-08-31
-impl: unbuilt
+impl: partially implemented
 authors: [Stuart Kerr, Codex]
 tags: [architecture, enforcement, routing, swarms, adr, ddd, qa, release]
 supersedes: []
@@ -167,14 +167,15 @@ red until all required assets exist.
 
 ## Current implementation status
 
-`Accepted, partially implemented.` The deterministic execution classifier is implemented and in the
-canonical PR gate, and host-only update now has a defined degraded-KB path that can still converge
+`Accepted, partially implemented.` The deterministic execution classifier and the enforced live-evidence
+preflight are implemented and in the canonical contract lane, and host-only update now has a defined degraded-KB path that can still converge
 the executable plugin/spine. Existing grounding, currency, wiring, convergence, and release gates
 remain active. The cross-host dispatch, ADR/DDD reconciliation receipt, dual-seat receipt, and
 architecture-to-test graph remain unbuilt until their acceptance criteria pass on both supported
 host paths.
 
 ## Currency log
+| 2026-08-31 | Added the executable preflight: consequential delegation now requires fresh successful Brain grounding plus an exact append-only project AgentDB checkpoint receipt before routing, and API-backed execution remains refused when a native host is available. | `scripts/execution-preflight.mjs`; `scripts/execution-policy.mjs`; `tests/unit/execution-preflight.test.mjs`; canonical contract lane. |
 | 2026-08-31 | Reconciled after the canonical QA runner changed from serial fail-fast execution to concurrent independent-lane collection. | `scripts/qa-runner.mjs` now preserves this ADR's enforcement boundary while ensuring one failed lane cannot hide later policy failures; `tests/unit/qa-runner-concurrency.test.mjs` locks that behavior. |
 
 

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.5",
+    "softwareVersion": "4.3.6-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.5</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.6-dev</p>
     </div>
   </div>
 

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.6-dev",
+    "softwareVersion": "4.3.7-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.6-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.7-dev</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.6-dev",
-  "releaseTag": "v4.3.6-dev",
+  "brainVersion": "4.3.7-dev",
+  "releaseTag": "v4.3.7-dev",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.5",
-  "releaseTag": "v4.3.5",
+  "brainVersion": "4.3.6-dev",
+  "releaseTag": "v4.3.6-dev",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.6-dev",
+  "version": "4.3.7-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.5",
+  "version": "4.3.6-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5",
+  "version": "4.3.6-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.5",
+      "version": "4.3.6-dev",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.6-dev",
+  "version": "4.3.7-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.6-dev",
+      "version": "4.3.7-dev",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.6-dev",
+  "version": "4.3.7-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5",
+  "version": "4.3.6-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.6-dev",
+  "version": "4.3.7-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.5",
+  "version": "4.3.6-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.6-dev",
+  "version": "4.3.7-dev",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.5",
+  "version": "4.3.6-dev",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.6-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.7-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.5 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.6-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/execution-policy.mjs
+++ b/scripts/execution-policy.mjs
@@ -5,6 +5,40 @@
 const NATIVE_HOSTS = new Set(['claude', 'codex']);
 const API_EXECUTORS = new Set(['agent_execute', 'sdk', 'openrouter', 'api']);
 const ARCHITECTURE_TERMS = /\b(adr|ddd|architecture|release|deploy|qa|security|schema|migration)\b/i;
+const CONSEQUENTIAL_ACTIONS = new Set(['delegate', 'write', 'release', 'external']);
+const FRESHNESS_MS = 30 * 60 * 1000;
+
+const hex64 = (value) => /^[a-f0-9]{64}$/i.test(String(value || ''));
+const fresh = (value, now = Date.now()) => {
+  const time = Date.parse(String(value || ''));
+  return Number.isFinite(time) && time <= now && now - time <= FRESHNESS_MS;
+};
+
+/**
+ * The classifier used to trust caller-supplied routing fields. That made a correct memory lesson
+ * advisory: a caller could omit the live search and AgentDB read and still receive ALLOW. This is
+ * the evidence boundary used by the executable preflight. Receipts are intentionally structural;
+ * the producers (search_ruvnet and ruflo memory retrieve) own their contents and identities.
+ */
+export function validateEvidence(input = {}, now = Date.now()) {
+  const failures = [];
+  const grounding = input.groundingReceipt;
+  const memory = input.memoryReceipt;
+  if (!grounding || grounding.status !== 'success' || !fresh(grounding.observedAt, now)) {
+    failures.push('fresh successful search_ruvnet receipt is required');
+  } else if (!(Array.isArray(grounding.sources) && grounding.sources.length > 0)
+    && !hex64(grounding.sourceIdentity)) {
+    failures.push('grounding receipt must bind a source list or source identity');
+  }
+  if (!memory || memory.status !== 'retrieved' || !fresh(memory.observedAt, now)) {
+    failures.push('fresh exact AgentDB checkpoint retrieval is required');
+  } else {
+    if (!String(memory.path || '').endsWith('/.swarm/memory.db')) failures.push('memory receipt must use the project .swarm/memory.db');
+    if (!/^project-state-current-\d+$/.test(String(memory.key || ''))) failures.push('memory receipt must retrieve an append-only project-state-current key');
+    if (!hex64(memory.valueDigest)) failures.push('memory receipt must bind the retrieved value digest');
+  }
+  return { valid: failures.length === 0, failures };
+}
 
 export function classifyExecutionPolicy(input = {}) {
   const action = String(input.action || 'read');
@@ -24,10 +58,21 @@ export function classifyExecutionPolicy(input = {}) {
         ? 'architecture-or-consequential-action'
         : 'single-sequential-surface';
 
+  const evidence = CONSEQUENTIAL_ACTIONS.has(action) && input.enforceEvidence === true
+    ? validateEvidence(input, input.now ?? Date.now())
+    : { valid: true, failures: [] };
+  if (!evidence.valid) {
+    return {
+      schema: 'ruvnet-brain.execution-policy.v1',
+      verdict: 'REFUSE', action, swarmRequired, swarmReason,
+      executor: 'unknown', reason: 'live-evidence-preflight-failed', evidence,
+    };
+  }
+
   if (action !== 'delegate') {
     return {
       schema: 'ruvnet-brain.execution-policy.v1',
-      verdict: 'ALLOW', action, swarmRequired, swarmReason,
+      verdict: 'ALLOW', action, swarmRequired, swarmReason, evidence,
       executor: 'current-agent', reason: 'delegation-not-requested',
     };
   }
@@ -37,7 +82,7 @@ export function classifyExecutionPolicy(input = {}) {
   if (API_EXECUTORS.has(requestedExecutor)) {
     return {
       schema: 'ruvnet-brain.execution-policy.v1',
-      verdict: nativeHost ? 'REFUSE' : 'DEGRADED', action, swarmRequired, swarmReason,
+      verdict: nativeHost ? 'REFUSE' : 'DEGRADED', action, swarmRequired, swarmReason, evidence,
       executor: nativeHost ? `native:${nativeHost}` : 'unknown',
       reason: nativeHost
         ? 'api-backed-executor-is-not-the-native-subscription-route'
@@ -47,13 +92,13 @@ export function classifyExecutionPolicy(input = {}) {
   if (!nativeHost) {
     return {
       schema: 'ruvnet-brain.execution-policy.v1',
-      verdict: 'DEGRADED', action, swarmRequired, swarmReason, executor: 'unknown',
+      verdict: 'DEGRADED', action, swarmRequired, swarmReason, executor: 'unknown', evidence,
       reason: 'no-authenticated-native-host-is-available',
     };
   }
   return {
     schema: 'ruvnet-brain.execution-policy.v1',
-    verdict: 'ALLOW', action, swarmRequired, swarmReason,
+    verdict: 'ALLOW', action, swarmRequired, swarmReason, evidence,
     executor: `native:${nativeHost}`, reason: 'native-subscription-route-selected',
   };
 }

--- a/scripts/execution-preflight.mjs
+++ b/scripts/execution-preflight.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Enforced knowledge-to-execution boundary. The caller must provide receipts produced by the
+// live Brain search and exact project AgentDB retrieval; prose, memory, and guessed host state do
+// not satisfy this command.
+import { classifyExecutionPolicy } from './execution-policy.mjs';
+
+export function runExecutionPreflight(input = {}) {
+  return classifyExecutionPolicy({ ...input, enforceEvidence: true });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let input;
+  try { input = JSON.parse(process.argv[2] || '{}'); }
+  catch { process.stderr.write('execution-preflight: input must be JSON\n'); process.exit(2); }
+  const result = runExecutionPreflight(input);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exit(result.verdict === 'ALLOW' ? 0 : 2);
+}

--- a/scripts/qa-runner.mjs
+++ b/scripts/qa-runner.mjs
@@ -33,6 +33,7 @@ const lanes = [
     'tests/unit/codex-claude-hook-parity.test.mjs',
     'tests/unit/brain-stamp-resolve-built-from-sha.test.mjs',
     'tests/unit/qa-runner-concurrency.test.mjs',
+    'tests/unit/execution-preflight.test.mjs',
     '--reporter=dot']],
   ['mesh', 'npm', ['run', 'test:mesh']],
   ['plugin', 'npm', ['test']],

--- a/scripts/wired-check.mjs
+++ b/scripts/wired-check.mjs
@@ -95,6 +95,7 @@ const STANDALONE = [
     + 'RVFs to RVF-GENERATIONS.json and optionally prunes legacy sidecars; build-bundle.mjs consumes '
     + 'and validates the resulting manifest, so scheduling this destructive migration would be wrong'],
   ['release', 'the ship path, run by a human'],
+  ['execution-preflight', 'external orchestration boundary — invoked by the host before consequential Ruflo/Codex execution; no in-repo caller exists because the host supplies the live Brain and AgentDB receipts'],
   ['fix-workstream', 'session-supervised coordination CLI run explicitly by the integration owner or an '
     + 'isolated writing agent to start and hand off a fix lane. Scheduling it would violate its safety '
     + 'boundary: it prepares evidence but never merges, pushes, publishes, deletes, or cleans worktrees'],

--- a/tests/unit/execution-preflight.test.mjs
+++ b/tests/unit/execution-preflight.test.mjs
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { runExecutionPreflight } from '../../scripts/execution-preflight.mjs';
+
+const now = Date.parse('2026-08-31T13:00:00.000Z');
+const valid = {
+  action: 'delegate', description: 'release rail audit', nativeHosts: ['codex'], activeHost: 'codex',
+  now,
+  groundingReceipt: { status: 'success', observedAt: '2026-08-31T12:45:00.000Z', sourceIdentity: 'a'.repeat(64) },
+  memoryReceipt: { status: 'retrieved', observedAt: '2026-08-31T12:45:00.000Z', path: '/repo/.swarm/memory.db', key: 'project-state-current-1756645200000', valueDigest: 'b'.repeat(64) },
+};
+
+describe('enforced execution preflight', () => {
+  it('allows only with fresh live grounding and exact AgentDB checkpoint evidence', () => {
+    expect(runExecutionPreflight(valid)).toMatchObject({ verdict: 'ALLOW', executor: 'native:codex', evidence: { valid: true } });
+  });
+
+  it('refuses a plausible route when the live evidence is missing', () => {
+    expect(runExecutionPreflight({ ...valid, groundingReceipt: undefined, memoryReceipt: undefined }))
+      .toMatchObject({ verdict: 'REFUSE', reason: 'live-evidence-preflight-failed', evidence: { valid: false } });
+  });
+
+  it('refuses stale receipts instead of treating AgentDB presence as a current read', () => {
+    expect(runExecutionPreflight({ ...valid, groundingReceipt: { ...valid.groundingReceipt, observedAt: '2026-08-30T13:00:00.000Z' } }))
+      .toMatchObject({ verdict: 'REFUSE', evidence: { valid: false } });
+  });
+
+  it('refuses an API executor before any provider can be selected', () => {
+    expect(runExecutionPreflight({ ...valid, requestedExecutor: 'agent_execute' }))
+      .toMatchObject({ verdict: 'REFUSE', executor: 'native:codex' });
+  });
+});


### PR DESCRIPTION
## What changed
- require fresh successful RuvNet Brain grounding and exact append-only project AgentDB checkpoint receipts for consequential delegation
- refuse stale/missing evidence and API-backed executor selection when a native host is available
- add focused contract tests and include them in canonical QA
- synchronize all release surfaces to 4.3.6-dev

## Evidence
- focused Vitest: 3 files, 11 tests passed
- version:check passed
- convergence-manifest check passed
- pre-push gate passed with 0 blocking currency violations

ADR-075 is updated in the same change.
