### PR TITLE
fix(forge-currency): read the canonical brain store root

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.7-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.7--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.8-dev — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.8--dev-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
-  "version": "4.3.7-dev",
-  "sourceIdentity": "088514ae2d95cc295838d9b6008831209fd5c71da1fbc5e708d1ad5d4e9af696",
+  "version": "4.3.8-dev",
+  "sourceIdentity": "1323353d19bdd05ac63540af3a8bf83aa60dea3ac9b614b40d4de10f2c34ebeb",
   "versionSurfaces": {
-    "package.json": "4.3.7-dev",
-    "plugin/.claude-plugin/plugin.json": "4.3.7-dev",
-    "plugin/.codex-plugin/plugin.json": "4.3.7-dev",
-    "data/manifest.json": "4.3.7-dev",
-    "kb/RVF-GENERATIONS.json": "4.3.7-dev",
-    "explainer/index.html": "4.3.7-dev",
-    "primer/ruvnet-primer.md": "4.3.7-dev"
+    "package.json": "4.3.8-dev",
+    "plugin/.claude-plugin/plugin.json": "4.3.8-dev",
+    "plugin/.codex-plugin/plugin.json": "4.3.8-dev",
+    "data/manifest.json": "4.3.8-dev",
+    "kb/RVF-GENERATIONS.json": "4.3.8-dev",
+    "explainer/index.html": "4.3.8-dev",
+    "primer/ruvnet-primer.md": "4.3.8-dev"
   },
   "adrInventory": [
     "0001-verified-bundle-not-single-file.md",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1172,
-  "trackedFilesSha256": "03455ffd8021b615881c3fb32d7497a186bd18ab7b1f005961ffdbe5804f87d9",
+  "trackedFilesSha256": "e44671fef3f0245468223da0862d3e7317775fa62ee628c6b1fdb355c2c54789",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.7-dev",
+  "brainVersion": "4.3.8-dev",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.7-dev",
+    "softwareVersion": "4.3.8-dev",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.7-dev</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.8-dev</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.7-dev",
-  "releaseTag": "v4.3.7-dev",
+  "brainVersion": "4.3.8-dev",
+  "releaseTag": "v4.3.8-dev",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/forge-currency.mjs
+++ b/kb/forge-currency.mjs
@@ -26,6 +26,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { storeRoot, storesAt } from './store-root.mjs';
 
 const KB_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SOURCE_PATH = path.join(KB_DIR, 'SOURCE.json');
@@ -53,12 +54,9 @@ function run(bin, args, { timeout = 25000, cwd } = {}) {
 const git = (dir, args, opts) => run('git', ['-C', dir, ...args], opts);
 
 // ---------- the brain's KNOWN set (authoritative: the .rvf files it actually loads) ----------
-function brainKnownSet() {
+export function brainKnownSet(root = storeRoot()) {
   const known = new Set();
-  for (const f of fs.readdirSync(KB_DIR)) {
-    if (!f.endsWith('.rvf')) continue;
-    known.add(f.replace(/\.big\.rvf$/, '').replace(/\.rvf$/, '').toLowerCase());
-  }
+  for (const s of storesAt(root)) known.add(s.toLowerCase());
   if (fs.existsSync(SOURCE_PATH)) {
     try {
       const src = JSON.parse(fs.readFileSync(SOURCE_PATH, 'utf8'));
@@ -244,4 +242,6 @@ async function main() {
   }
 }
 
-main().catch((e) => die(`unexpected: ${e.message}`));
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => die(`unexpected: ${e.message}`));
+}

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.7-dev",
+  "version": "4.3.8-dev",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.7-dev",
+  "version": "4.3.8-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.7-dev",
+      "version": "4.3.8-dev",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.7-dev",
+  "version": "4.3.8-dev",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.7-dev",
+  "version": "4.3.8-dev",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.7-dev",
+  "version": "4.3.8-dev",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.7-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.8-dev · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/tests/unit/forge-currency-helpers.test.mjs
+++ b/tests/unit/forge-currency-helpers.test.mjs
@@ -2,17 +2,34 @@
 // that the brain doesn't index yet" radar) has zero tests of any kind. isRuvnetOrigin/pad/sh are
 // pure string logic with no I/O — the cheapest possible tests in this file, once exported.
 //
-// PREREQUISITE: isRuvnetOrigin (line 139), pad (line 162), and sh (line 161, currently a `const sh =
-// (s) => ...` arrow, not a `function`) are all module-private. The file runs its report/subcommand
-// dispatch unconditionally at module top level (no IIFE guard), so importing it today would fire
-// real `gh`/`git`/`fetch` calls as an import side effect — same pattern as check-indexation.mjs and
-// self-update.mjs's own gap skeletons. Two additive, no-behavior-change edits unblock this file:
-//   1. `export function isRuvnetOrigin(url) {...}`, `export const sh = (s) => ...`,
-//      `export function pad(s, n) {...}` (currently unexported).
-//   2. Guard the dispatch with `if (import.meta.url === \`file://${process.argv[1]}\`) { ... }`
-//      (the same in-repo pattern verify-bundle.mjs already uses, line 39 there).
-// Flag both to Stuart before applying, per this repo's established pattern for these gap skeletons.
-import { describe, it, expect } from 'vitest';
+// The CLI dispatch is guarded and brainKnownSet is exported for the canonical-root regression.
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { brainKnownSet } from '../../kb/forge-currency.mjs';
+
+let dir;
+afterEach(() => { if (dir) { fs.rmSync(dir, { recursive: true, force: true }); dir = null; } });
+const sandbox = () => (dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-currency-')));
+
+describe('forge-currency.mjs — brainKnownSet() sources from the canonical store root', () => {
+  it('includes a store present at the given root', () => {
+    const root = sandbox();
+    fs.writeFileSync(path.join(root, 'totally-live-store.rvf'), '');
+    expect(brainKnownSet(root).has('totally-live-store')).toBe(true);
+  });
+
+  it('strips the .big.rvf suffix and lowercases', () => {
+    const root = sandbox();
+    fs.writeFileSync(path.join(root, 'Some-Repo.big.rvf'), '');
+    expect(brainKnownSet(root).has('some-repo')).toBe(true);
+  });
+
+  it('does not throw for a root that has not materialized', () => {
+    expect(() => brainKnownSet(path.join(os.tmpdir(), `never-${Date.now()}`))).not.toThrow();
+  });
+});
 
 describe.todo('forge-currency.mjs — isRuvnetOrigin() (requires export, see file header)', () => {
   it.todo('true for git@github.com:ruvnet/agentic-flow.git (SSH form)');


### PR DESCRIPTION
Fixes #212. Acceptance evidence: focused Vitest 3 files and 20 passed with 8 pre-existing todo; version check all surfaces agree on 4.3.8-dev; git diff check clean; pre-push passed with 0 blocking document-currency findings. brainKnownSet now reads storesAt(storeRoot), and CLI dispatch is import-safe. Candidate commit: 69b60d7.