### PR TITLE
fix(release): isolate public verification host CLIs

### DIFF
--- a/.github/workflows/protected-release.yml
+++ b/.github/workflows/protected-release.yml
@@ -368,13 +368,14 @@ jobs:
         run: |
           set -euo pipefail
           npm ci --no-audit --no-fund
-          npm install --no-save --package-lock=false \
+          host_cli_prefix="$RUNNER_TEMP/ruvnet-host-clis"
+          npm install --prefix "$host_cli_prefix" --no-save --package-lock=false --no-audit --no-fund \
             @anthropic-ai/claude-code@latest \
             @openai/codex@latest
           if [[ "${{ matrix.os_name }}" == windows ]]; then
-            cygpath -w "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+            cygpath -w "$host_cli_prefix/node_modules/.bin" >> "$GITHUB_PATH"
           else
-            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+            echo "$host_cli_prefix/node_modules/.bin" >> "$GITHUB_PATH"
           fi
       - name: Restore published transaction and candidate evidence
         uses: actions/download-artifact@v4

--- a/.github/workflows/recover-public-verification.yml
+++ b/.github/workflows/recover-public-verification.yml
@@ -162,13 +162,14 @@ jobs:
         run: |
           set -euo pipefail
           npm ci --no-audit --no-fund
-          npm install --no-save --package-lock=false \
+          host_cli_prefix="$RUNNER_TEMP/ruvnet-host-clis"
+          npm install --prefix "$host_cli_prefix" --no-save --package-lock=false --no-audit --no-fund \
             @anthropic-ai/claude-code@latest \
             @openai/codex@latest
           if [[ "${{ matrix.os_name }}" == windows ]]; then
-            cygpath -w "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+            cygpath -w "$host_cli_prefix/node_modules/.bin" >> "$GITHUB_PATH"
           else
-            echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+            echo "$host_cli_prefix/node_modules/.bin" >> "$GITHUB_PATH"
           fi
       - uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.9 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.9-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.10 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.10-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.9",
+  "brainVersion": "4.3.10",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.9",
+    "softwareVersion": "4.3.10",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, proactive grounding, learning capture and session continuity.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.9</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.10</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.9",
-  "releaseTag": "v4.3.9",
+  "brainVersion": "4.3.10",
+  "releaseTag": "v4.3.10",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.9",
+      "version": "4.3.10",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.9 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.10 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/tests/unit/protected-release-workflow.test.mjs
+++ b/tests/unit/protected-release-workflow.test.mjs
@@ -95,7 +95,10 @@ describe('protected release rail', () => {
     expect(lane).toBeGreaterThan(-1);
     expect(source.indexOf('if: always()', lane)).toBeGreaterThan(lane);
     expect(source.indexOf('if-no-files-found: warn', lane)).toBeGreaterThan(lane);
-    expect(source).toContain('cygpath -w "$PWD/node_modules/.bin"');
+    expect(source).toContain('host_cli_prefix="$RUNNER_TEMP/ruvnet-host-clis"');
+    expect(source).toContain('npm install --prefix "$host_cli_prefix"');
+    expect(source).toContain('cygpath -w "$host_cli_prefix/node_modules/.bin"');
+    expect(source).not.toContain('cygpath -w "$PWD/node_modules/.bin"');
     expect(aggregate).toBeGreaterThan(lane);
     expect(finalize).toBeGreaterThan(aggregate);
     expect(terminal).toBeGreaterThan(finalize);

--- a/tests/unit/recover-public-verification-workflow.test.mjs
+++ b/tests/unit/recover-public-verification-workflow.test.mjs
@@ -42,7 +42,10 @@ describe('post-publication recovery rail', () => {
       .toBeLessThan(position('node scripts/public-verification-finalizer.mjs'));
     expect(source.match(/environment: Production – ruvnet-brain/g)).toHaveLength(1);
     expect(source.match(/RUVNET_SIGNING_KEY:/g)).toHaveLength(1);
-    expect(source).toContain('cygpath -w "$PWD/node_modules/.bin"');
+    expect(source).toContain('host_cli_prefix="$RUNNER_TEMP/ruvnet-host-clis"');
+    expect(source).toContain('npm install --prefix "$host_cli_prefix"');
+    expect(source).toContain('cygpath -w "$host_cli_prefix/node_modules/.bin"');
+    expect(source).not.toContain('cygpath -w "$PWD/node_modules/.bin"');
     expect(source).toContain('if-no-files-found: warn');
   });
 });


### PR DESCRIPTION
Repairs the 4.3.9 public-verification recovery rail by installing Claude and Codex CLIs into a disposable prefix instead of mutating the candidate dependency tree after npm ci. Includes protected/recovery workflow regression assertions and synchronized 4.3.10 source version metadata; this does not republish or replace the immutable 4.3.9 artifacts.