### PR TITLE
fix: make host updates converge without forced restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Created: 2026-06-29 22:36:38 EDT
 
 # 🧠 RuvNet Brain
 
-### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.19 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.19-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
+### 🧠 RuvNet Brain — [![RuvNet Brain version 4.3.20 — updated 2026-07-30 03:24 EDT](https://img.shields.io/badge/version_4.3.20-updated_2026--07--30_03:24_EDT-1E90FF?style=for-the-badge&labelColor=0757BA)](https://github.com/stuinfla/ruvnet-brain/blob/main/plugin/.claude-plugin/plugin.json)
 
 **A portable, source-grounded brain over Reuven Cohen's (rUv's) RuvNet stack — delivered as a Claude Code plugin that makes Claude _use_ the stack instead of fighting it.**
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -673,8 +673,8 @@ export async function unzipInto(zipPath, cacheDir, sourceDir = null) {
  * Registry reachability identifies candidates; it is not deletion proof. Claude freezes
  * CLAUDE_PLUGIN_ROOT at session start, so an unregistered generation can remain live until that
  * session exits. Modern roots expose `.in_use` PID-incarnation leases. Live or ambiguous leases
- * retain the complete root; dead leases are collected. Legacy roots without the protocol receive
- * a 14-day compatibility grace.
+ * retain the complete root; dead leases are collected. Legacy roots without the protocol are
+ * retained indefinitely because a frozen host session is not observable without a lease.
  *
  * WHAT MAKES DELETION SAFE HERE, since this removes directories from someone's machine:
  *   • The registry is the ONLY authority. Unreadable, missing, or naming no ruvnet-brain install →
@@ -786,7 +786,11 @@ export function prunePluginGenerations({
       continue;
     }
 
-    if (!leaseCapable && now() - orphanedAt < graceMs) continue;
+    if (!leaseCapable) {
+      if (now() - orphanedAt < graceMs) continue;
+      cleanupBlocked.push({ version: candidate.version, reason: 'legacy generation has no liveness lease; refusing destructive cleanup' });
+      continue;
+    }
     let safeToReap = true;
     for (const leaseName of leaseNames) {
       const leasePath = path.join(leaseDir, leaseName);
@@ -2915,29 +2919,82 @@ function missingUpdaterHelp(kbDir) {
   console.error(`  — the current bundle ships forge-update.mjs; then this command will work.`);
 }
 
-function acquireHostConvergenceLock(lockPath) {
-  try {
-    fs.mkdirSync(lockPath);
-    fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
-    return { acquired: true, release: () => fs.rmSync(lockPath, { recursive: true, force: true }) };
-  } catch (error) {
-    if (error?.code !== 'EEXIST') return { acquired: false, error: error.message };
+export function acquireHostConvergenceLock(lockPath, {
+  staleMs = 5 * 60 * 1000,
+  now = () => Date.now(),
+  processAlive = (pid, owner) => {
+    if (owner?.host && owner.host !== os.hostname()) return true;
+    try { process.kill(pid, 0); return true; }
+    catch (error) { return error?.code !== 'ESRCH'; }
+  },
+} = {}) {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const token = crypto.randomBytes(16).toString('hex');
+  const owner = {
+    pid: process.pid,
+    host: os.hostname(),
+    token,
+    startedAt: new Date(now()).toISOString(),
+  };
+  const publish = () => {
     try {
-      const owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
-      if (Number.isInteger(owner.pid) && owner.pid !== process.pid) {
-        try { process.kill(owner.pid, 0); return { acquired: false, error: `another host synchronization is running (pid ${owner.pid})` }; }
-        catch (probeError) { if (probeError?.code !== 'ESRCH') return { acquired: false, error: 'another host synchronization owns the lock' }; }
+      // mkdir is the exclusive operation. The owner write follows it, but an incomplete
+      // directory is treated as busy until the stale threshold; no contender may reclaim it in
+      // that publication window. This avoids rename-over-empty-directory replacement on macOS.
+      fs.mkdirSync(lockPath, { recursive: false });
+      fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify(owner), { flag: 'wx', mode: 0o600 });
+      return true;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      return false;
+    }
+  };
+  const release = () => {
+    const quarantine = `${lockPath}.release-${process.pid}-${token}`;
+    try {
+      const current = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+      if (current?.token !== token) return false;
+      fs.renameSync(lockPath, quarantine);
+      const moved = JSON.parse(fs.readFileSync(path.join(quarantine, 'owner.json'), 'utf8'));
+      if (moved?.token !== token) {
+        try { fs.renameSync(quarantine, lockPath); } catch { /* preserve evidence if another writer won */ }
+        return false;
       }
-    } catch { /* an incomplete lock is safe to reclaim */ }
-    fs.rmSync(lockPath, { recursive: true, force: true });
+      fs.rmSync(quarantine, { recursive: true, force: true });
+      return true;
+    } catch { return false; }
+  };
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
-      fs.mkdirSync(lockPath);
-      fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
-      return { acquired: true, release: () => fs.rmSync(lockPath, { recursive: true, force: true }) };
-    } catch (retryError) {
-      return { acquired: false, error: retryError.message };
+      if (publish()) return { acquired: true, release };
+    } catch (error) {
+      return { acquired: false, error: error.message };
+    }
+
+    let existing;
+    let lockAge = 0;
+    try {
+      const stat = fs.statSync(lockPath);
+      lockAge = Math.max(0, now() - stat.mtimeMs);
+      existing = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+    } catch { /* an incomplete lock is handled below, with a grace period */ }
+    if (existing && Number.isInteger(existing.pid) && processAlive(existing.pid, existing)) {
+      return { acquired: false, error: `another host synchronization is running (pid ${existing.pid})` };
+    }
+    if (!existing && lockAge < staleMs) {
+      return { acquired: false, error: 'another host synchronization is publishing its lock' };
+    }
+    const quarantine = `${lockPath}.reclaim-${process.pid}-${token}-${attempt}`;
+    try {
+      fs.renameSync(lockPath, quarantine);
+      fs.rmSync(quarantine, { recursive: true, force: true });
+    } catch (error) {
+      if (error?.code === 'ENOENT') continue;
+      return { acquired: false, error: `host synchronization lock changed concurrently: ${error.message}` };
     }
   }
+  return { acquired: false, error: 'host synchronization lock changed concurrently' };
 }
 
 export function syncHostsAfterUpdate(cacheDir = resolvedKbDir(), {
@@ -2995,9 +3052,18 @@ export function syncHostsAfterUpdate(cacheDir = resolvedKbDir(), {
   if (!fs.existsSync(apply)) return fail({ error: 'Stable Spine updater missing from package' });
   const applied = runStableSpine(apply);
   const okApplied = !applied.error && applied.status === 0;
+  const codexReceipt = {
+    state: results.codex?.action === 'disabled' ? 'disabled' : (results.codexHost?.host ? 'ready' : 'absent'),
+    version: results.codex?.version || null,
+  };
+  if (results.codex?.restartRequired === true) {
+    codexReceipt.restartRequired = true;
+    codexReceipt.sessionSafety = results.codex.sessionSafety || null;
+    codexReceipt.sessionSafetyReason = results.codex.sessionSafetyReason || null;
+  }
   if (okApplied) {
     // ISSUE #153 — a running host may freeze an old plugin root. Reclaim only generations whose
-    // modern leases prove no live consumer, or legacy generations past the compatibility grace.
+    // modern leases prove no live consumer; legacy roots without that proof stay on disk.
     try {
       const gens = prunePluginGenerations({ apply: true });
       if (gens.retired?.length) {
@@ -3028,7 +3094,7 @@ export function syncHostsAfterUpdate(cacheDir = resolvedKbDir(), {
         verifiedAt: new Date().toISOString(),
         hosts: {
           claude: { state: results.claude.host ? 'ready' : 'absent', version: results.claude.version || null },
-          codex: { state: results.codex?.action === 'disabled' ? 'disabled' : (results.codexHost?.host ? 'ready' : 'absent'), version: results.codex?.version || null },
+          codex: codexReceipt,
         },
         consoleRuntime: results.consoleRuntime,
       }, null, 2));
@@ -3043,7 +3109,7 @@ export function syncHostsAfterUpdate(cacheDir = resolvedKbDir(), {
     desiredVersion: PACKAGE_VERSION,
     hosts: {
       claude: { state: results.claude.host ? 'ready' : 'absent', version: results.claude.version || null },
-      codex: { state: results.codex?.action === 'disabled' ? 'disabled' : (results.codexHost?.host ? 'ready' : 'absent'), version: results.codex?.version || null },
+      codex: codexReceipt,
     },
     consoleRuntime: results.consoleRuntime,
   });
@@ -3061,7 +3127,11 @@ export function classifyHostConvergence(receipt, expectedVersion = PACKAGE_VERSI
   }
   const hostStates = Object.values(receipt.hosts || {});
   const badHost = hostStates.find((host) => !['ready', 'disabled', 'absent'].includes(host?.state)
-    || (host.state === 'ready' && !versionSatisfies(host.version, expectedVersion)));
+    || (host.state === 'ready' && !versionSatisfies(host.version, expectedVersion))
+    || (host.state === 'ready' && host.restartRequired === true));
+  if (badHost?.restartRequired === true) {
+    return { healthy: false, state: 'host-restart-required', action: badHost.sessionSafetyReason || 'restart the host, then re-run --doctor' };
+  }
   if (badHost) return { healthy: false, state: 'host-pending', action: 're-run host synchronization' };
   if (receipt.consoleRuntime?.state !== 'ready') {
     return { healthy: false, state: receipt.consoleRuntime?.state || 'console-unproven', action: 'restart Console, then re-run --doctor' };

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
-  "version": "4.3.19",
-  "sourceIdentity": "91a7d077963af1add8314d674358d4293ad59f81ac33db49ebbe226540368730",
+  "version": "4.3.20",
+  "sourceIdentity": "c812d57cc6f4b0185466801cc60cd36ef27bf57eba43a0703362484ac59a51a1",
   "versionSurfaces": {
-    "package.json": "4.3.19",
-    "plugin/.claude-plugin/plugin.json": "4.3.19",
-    "plugin/.codex-plugin/plugin.json": "4.3.19",
-    "data/manifest.json": "4.3.19",
-    "kb/RVF-GENERATIONS.json": "4.3.19",
-    "explainer/index.html": "4.3.19",
-    "primer/ruvnet-primer.md": "4.3.19"
+    "package.json": "4.3.20",
+    "plugin/.claude-plugin/plugin.json": "4.3.20",
+    "plugin/.codex-plugin/plugin.json": "4.3.20",
+    "data/manifest.json": "4.3.20",
+    "kb/RVF-GENERATIONS.json": "4.3.20",
+    "explainer/index.html": "4.3.20",
+    "primer/ruvnet-primer.md": "4.3.20"
   },
   "adrInventory": [
     "0001-verified-bundle-not-single-file.md",
@@ -91,7 +91,7 @@
     "README.md"
   ],
   "trackedFileCount": 1328,
-  "trackedFilesSha256": "19971dbb01b68b050a288084ea80eb707070d0945cfdca92df9cfce172d073b1",
+  "trackedFilesSha256": "57493ae3b6ca71fa1338e13dbc2e7f1afd995c62f6684b5452f117523fa6dbfc",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/convergence-manifest.json
+++ b/data/convergence-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "ruvnet-brain-convergence-manifest",
   "version": "4.3.20",
-  "sourceIdentity": "c812d57cc6f4b0185466801cc60cd36ef27bf57eba43a0703362484ac59a51a1",
+  "sourceIdentity": "a99a29820c9725e131807a32e723ff92f583036fca1c673cdc173a467e22a1b7",
   "versionSurfaces": {
     "package.json": "4.3.20",
     "plugin/.claude-plugin/plugin.json": "4.3.20",
@@ -90,8 +90,8 @@
     "0075-knowledge-to-execution-enforcement.md",
     "README.md"
   ],
-  "trackedFileCount": 1328,
-  "trackedFilesSha256": "57493ae3b6ca71fa1338e13dbc2e7f1afd995c62f6684b5452f117523fa6dbfc",
+  "trackedFileCount": 1331,
+  "trackedFilesSha256": "7a517468254b38a9f1400c42fb65f656ba1ff01cfeae118a792474342d16f5ab",
   "ownershipChecks": [
     "version:check",
     "doc:currency",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainVersion": "4.3.19",
+  "brainVersion": "4.3.20",
   "generated": "2026-08-20T07:16:21.648Z",
   "generatedHuman": "Thu, 20 Aug 2026 07:16:21 GMT",
   "coverage": {

--- a/docs/reviews/issue-271-223-host-boundaries.md
+++ b/docs/reviews/issue-271-223-host-boundaries.md
@@ -1,3 +1,6 @@
+Updated: 2026-09-09 21:40:44 EDT | Version 1.0.1
+Created: 2026-09-09 21:40:44 EDT
+
 # Host update boundaries for issues 271 and 223
 
 ## Issue 271: stale Claude hook paths
@@ -5,10 +8,15 @@
 Host convergence now takes an atomic process lock at
 `~/.cache/ruvnet-brain/host-convergence.lock`. Concurrent Brain installers cannot
 run Claude/Codex host updates at the same time. The lock records its PID, refuses a
-live owner, and reclaims only an owner that is gone or an incomplete lock. This
-closes the Brain-side update race; it cannot change a Claude host process that has
-already cached an old plugin path. A fresh Claude session remains required after a
-plugin update.
+live owner, treats a newly incomplete publication as busy, and reclaims only a stale
+owner or stale incomplete directory. Release is token-checked so one process cannot
+delete another process's lock. Shell-change detection covers the shim's imported
+helpers and file contents under boot-loaded skills and commands, and the boundary is
+preserved across later body-only releases. This closes the Brain-side update race;
+it cannot change a Claude host process that has already cached an old plugin path.
+Legacy plugin generations without a liveness lease are retained rather than deleted,
+so a frozen Claude session cannot be pointed at a missing directory. A fresh Claude
+session remains required only when boot-level declarations changed.
 
 ## Issue 223: Codex generation leases
 
@@ -16,8 +24,10 @@ Codex owns its native plugin cache and the current installer API exposes no sess
 generation lease or safe deletion callback. Brain therefore does not delete Codex
 cache generations or claim that an in-process update is safe. After a native Codex
 plugin install/update, the result is explicitly marked `sessionSafety:
-restart-required` and `restartRequired: true`; restart Codex before using the new
-plugin. This is the concrete guarded behavior until Codex exposes a lease API.
+restart-required` and `restartRequired: true` in the convergence receipt; the
+classifier keeps the host non-converged until Codex restarts. Restart Codex before
+using the new plugin. This is the concrete guarded behavior until Codex exposes a
+lease API.
 
 The regression test in `tests/unit/codex-wiring.test.mjs` asserts this boundary and
 the unchanged-install behavior. It does not prove Codex's private cache behavior,

--- a/explainer/index.html
+++ b/explainer/index.html
@@ -67,7 +67,7 @@
     "alternateName": "RuvNet-Brain",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform (Node.js)",
-    "softwareVersion": "4.3.19",
+    "softwareVersion": "4.3.20",
     "datePublished": "2026-06-30",
     "dateModified": "2026-07-28",
     "description": "A downloadable, source-grounded brain that treats Claude Code and OpenAI Codex as first-class hosts. Use either one or both. The installer wires each detected host into rUv's real RuvNet source — RuVector/RVF, Ruflo, AgentDB, RuLake, SPARC and 77 indexed repos — with search_ruvnet, explicit skills and commands; automatic Brain hooks are retired.",
@@ -233,7 +233,7 @@
         Built by <strong>Stuart Kerr</strong> at <a href="https://isovision.ai" target="_blank" rel="noopener">Isovision.ai</a>.
         <strong>Free &amp; fair use</strong> &mdash; so everyone can fully leverage the high end of agentic coding.
       </p>
-      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.19</p>
+      <p class="prov-live"><span class="prov-dot">&#9679;</span> STATUS&nbsp;<code>live</code> &middot; v4.3.20</p>
     </div>
   </div>
 

--- a/kb/RVF-GENERATIONS.json
+++ b/kb/RVF-GENERATIONS.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "brainVersion": "4.3.19",
-  "releaseTag": "v4.3.19",
+  "brainVersion": "4.3.20",
+  "releaseTag": "v4.3.20",
   "stores": {
     "agentdb": {
       "file": "agentdb.big.rvf",

--- a/kb/package.json
+++ b/kb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain-kb",
-  "version": "4.3.19",
+  "version": "4.3.20",
   "private": true,
   "type": "module",
   "description": "Self-contained RVF knowledge base for ruvnet-brain, built by rvf-kb-forge. Run `npm i` here, then use forge-ask.mjs (CLI) or forge-mcp.mjs (MCP stdio server). Vectors live in ruvnet-brain.rvf; full passage text in ruvnet-brain.passages.jsonl.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.19",
+  "version": "4.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruvnet-brain",
-      "version": "4.3.19",
+      "version": "4.3.20",
       "license": "MIT",
       "dependencies": {
         "@metaharness/flywheel": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.19",
+  "version": "4.3.20",
   "description": "One-command installer for RuvNet Brain — a portable, source-grounded brain over rUv's RuvNet building blocks, delivered as a Claude Code plugin so Claude uses the stack instead of fighting it.",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvnet-brain",
   "description": "RuvNet brain transplant for Claude Code — grounds every RuvNet decision in real source across 77 rUv repositories, prefers Ruflo / RuVector-RVF / AgentDB over training-prior defaults (pgvector, Pinecone, hand-rolled cosine), and can pull in any RuvNet repo on demand. Ships an enforced UserPromptSubmit retrieve-and-inject grounding hook that sharply reduces drift.",
-  "version": "4.3.19",
+  "version": "4.3.20",
   "author": {
     "name": "Stuart Kerr"
   },

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvnet-brain",
-  "version": "4.3.19",
+  "version": "4.3.20",
   "description": "Source-grounded RuvNet knowledge, lifecycle enforcement, and learning for Codex.",
   "author": {
     "name": "Stuart Kerr"

--- a/plugin/scripts/session-start-core.mjs
+++ b/plugin/scripts/session-start-core.mjs
@@ -248,6 +248,19 @@ const announceVersion = ({ running, off, stateDir, consoleInvoke, emit }) => {
   write(announced, `${running}\n`);
 };
 
+const compareVersions = (a, b) => {
+  const left = String(a).split(/[.-]/).map((part) => (/^\d+$/.test(part) ? Number(part) : part));
+  const right = String(b).split(/[.-]/).map((part) => (/^\d+$/.test(part) ? Number(part) : part));
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const x = left[i] ?? 0;
+    const y = right[i] ?? 0;
+    if (x === y) continue;
+    if (typeof x === 'number' && typeof y === 'number') return x - y;
+    return String(x) < String(y) ? -1 : 1;
+  }
+  return 0;
+};
+
 const stableSpine = ({ env, hookDir, stateDir, home, pluginVersion, emit, now }) => {
   const activeFile = path.join(stateDir, 'active.json');
   const stamp = path.join(stateDir, '.last-update-check');
@@ -270,7 +283,11 @@ const stableSpine = ({ env, hookDir, stateDir, home, pluginVersion, emit, now })
     }
   } else {
     const active = json(activeFile);
-    if (active?.shellChanged && pluginVersion && active.version && active.version !== pluginVersion) {
+    const shellBoundary = active?.shellChangedAtVersion;
+    const shellChangedBeforeHost = shellBoundary && pluginVersion
+      ? compareVersions(pluginVersion, shellBoundary) < 0
+      : false;
+    if ((active?.shellChanged || shellChangedBeforeHost) && pluginVersion && active.version && active.version !== pluginVersion) {
       emit(`[RuvNet Brain — v${active.version} changed boot-level declarations (the rare case); this session booted v${pluginVersion}'s]`);
       const host = env.RUVNET_HOOK_HOST || 'claude';
       const convergence = json(path.join(stateDir, 'host-convergence.json'));
@@ -371,6 +388,8 @@ export async function runSessionStart({
       || s.startsWith('[RuvNet Brain — grounding not yet PROVEN')
       || s.startsWith('The last check (')
       || s.startsWith('[RuvNet Brain — update available')
+      || s.startsWith('[RuvNet Brain — v')
+      || s.startsWith('Tell the user ONE line: "🧠 RuvNet Brain v')
       || s.startsWith('[RuvNet Brain — brain OFF by your setting')
       || s.startsWith('[RuvNet Brain — new in v')
       || s.startsWith('[RuvNet Brain — first session initialized]')

--- a/plugin/scripts/update-apply.mjs
+++ b/plugin/scripts/update-apply.mjs
@@ -212,18 +212,34 @@ function promote(staging, version) {
 // the update is fully live with no restart and session-start stays silent; if any did, the ONE
 // honest nag fires (the release classifier computes the same thing publish-side; this is the
 // client-side truth for locally-applied generations). Red-team finding 18's client half.
-const SHELL_PATHS = ['hooks/hooks.json', 'scripts/hook-shim.mjs', 'mcp/server.mjs', '.mcp.json'];
-function shellDiff(prevRootAbs, nextRootAbs) {
+export const SHELL_PATHS = [
+  'hooks/hooks.json',
+  'scripts/hook-shim.mjs',
+  'scripts/hook-shim-bash.mjs',
+  'scripts/development-maintenance.mjs',
+  'mcp/server.mjs',
+  '.mcp.json',
+];
+
+function treeDigest(root, relative) {
+  const target = path.join(root, relative);
+  let stat;
+  try { stat = fs.lstatSync(target); } catch { return '<missing>'; }
+  if (stat.isSymbolicLink()) return '<symlink>';
+  if (stat.isFile()) return `file:${crypto.createHash('sha256').update(fs.readFileSync(target)).digest('hex')}`;
+  if (!stat.isDirectory()) return `<special:${stat.mode}>`;
+  const entries = fs.readdirSync(target, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  return `dir:${entries.map((entry) => `${entry.name}:${treeDigest(target, entry.name)}`).join('|')}`;
+}
+
+export function shellDiff(prevRootAbs, nextRootAbs) {
   const changed = [];
   for (const rel of SHELL_PATHS) {
-    const a = (() => { try { return fs.readFileSync(path.join(prevRootAbs, rel), 'utf8'); } catch { return null; } })();
-    const b = (() => { try { return fs.readFileSync(path.join(nextRootAbs, rel), 'utf8'); } catch { return null; } })();
-    if (a !== b) changed.push(rel);
+    if (treeDigest(prevRootAbs, rel) !== treeDigest(nextRootAbs, rel)) changed.push(rel);
   }
   // skills/ and commands/ are boot-loaded markdown: any file-set or content difference counts.
   for (const dir of ['skills', 'commands']) {
-    const list = (root) => { try { return fs.readdirSync(path.join(root, dir), { recursive: true }).sort().join('|'); } catch { return ''; } };
-    if (list(prevRootAbs) !== list(nextRootAbs)) changed.push(`${dir}/`);
+    if (treeDigest(prevRootAbs, dir) !== treeDigest(nextRootAbs, dir)) changed.push(`${dir}/`);
   }
   return changed;
 }
@@ -239,6 +255,15 @@ function flip(version, codeRootAbs, why) {
     previous: prev ? { generation: prev.generation, version: prev.version, codeRoot: prev.codeRoot } : null,
     shellChanged: shellChanged.length > 0,
     shellChangedPaths: shellChanged,
+    // Keep the first boot-level change attached to subsequent body-only generations. A host that
+    // still booted the pre-change generation must not lose the restart signal merely because a
+    // later update changed only implementation code.
+    shellChangedSinceVersion: shellChanged.length > 0
+      ? (prev?.version || version)
+      : (prev?.shellChangedSinceVersion || null),
+    shellChangedAtVersion: shellChanged.length > 0
+      ? version
+      : (prev?.shellChangedAtVersion || null),
     flippedAt: new Date().toISOString(),
   };
   writeAtomic(TXN, JSON.stringify({ state: 'flipping', from: prev?.version ?? null, to: version }));
@@ -446,4 +471,4 @@ function main() {
   }
 }
 
-process.exit(main());
+if (process.env.RUVNET_BRAIN_IMPORT_ONLY !== 'update-shell-test') process.exit(main());

--- a/primer/ruvnet-primer.md
+++ b/primer/ruvnet-primer.md
@@ -1,6 +1,6 @@
 # The RuvNet Primer — the building blocks, on one page
 
-`Brain version: v4.3.19 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
+`Brain version: v4.3.20 · Built: 2026-08-20 · Covers: 77/200 repos built @ pinned SHAs (see data/manifest.json)`
 
 > **What this is:** a portable, source-grounded "brain" over the reusable RuvNet building blocks by
 > **Reuven Cohen (rUv)**. It ships as a **Claude Code plugin** so your assistant answers from Ruv's real

--- a/scripts/wired-check.mjs
+++ b/scripts/wired-check.mjs
@@ -70,7 +70,7 @@ const argv = process.argv.slice(2);
  * every entry on every run, below, so they cannot rot unseen.
  */
 const STANDALONE = [
-  ['gate', 'retired automatic-hook helper retained for explicit use and tests'],
+  ['gate', 'retired automatic-hook helper and manual benchmark retained for explicit human use; no workflow or scheduler invokes this expensive command'],
   ['dream-issue-gate', 'pure Dream Cycle disposition policy; invoked by the external issue adapter, never a GitHub writer'],
   ['sync-census', 'explicit maintainer census writer; a destructive source-to-surface refresh is never scheduled'],
   ['sync-commands', 'explicit maintainer alias synchronizer; run deliberately before release, never from a lifecycle hook'],
@@ -105,8 +105,6 @@ const STANDALONE = [
     + 'stops at sealed preparation with contents:read. This entry validates receipt/archive inputs '
     + 'and delegates mutation to release.mjs protected authority. No operational caller is registered; '
     + 'classification does not claim publication works or has occurred'],
-  ['gate', 'manual benchmark harness: rebuilds concepts and runs three routing proof batteries; '
-    + 'no workflow or scheduler invokes this expensive command'],
   ['execution-preflight', 'external orchestration boundary — invoked by the host before consequential Ruflo/Codex execution; no in-repo caller exists because the host supplies the live Brain and AgentDB receipts'],
   ['fix-workstream', 'session-supervised coordination CLI run explicitly by the integration owner or an '
     + 'isolated writing agent to start and hand off a fix lane. Scheduling it would violate its safety '

--- a/tests/acceptance/issue-77-host-convergence.acceptance.test.mjs
+++ b/tests/acceptance/issue-77-host-convergence.acceptance.test.mjs
@@ -29,7 +29,7 @@ describe('issue #77 installed host convergence boundary', () => {
       sourceRoot: ROOT,
       brainHome,
       wireClaude: () => ({ host: true, wired: true, version: VERSION }),
-      wireCodexHost: () => ({ host: true, wired: true }),
+      wireCodexHost: () => ({ host: true, wired: true, action: 'unchanged' }),
       wireCodexPlugin: () => ({ action: 'updated', installed: true, enabled: true, version: VERSION }),
       runStableSpine: () => ({ status: 0, error: undefined }),
     });
@@ -86,6 +86,25 @@ describe('issue #77 installed host convergence boundary', () => {
     expect(install.classifyHostConvergence(receipt)).toMatchObject({
       healthy: false,
       state: 'pending-console-restart',
+    });
+  });
+
+  it('keeps a native Codex update explicitly non-converged until Codex restarts', () => {
+    const receipt = {
+      desiredVersion: VERSION,
+      hosts: {
+        claude: { state: 'absent', version: null },
+        codex: {
+          state: 'ready', version: VERSION, restartRequired: true,
+          sessionSafety: 'restart-required', sessionSafetyReason: 'Codex host cache has no lease API',
+        },
+      },
+      consoleRuntime: { state: 'ready', runtimeVersion: VERSION },
+    };
+    expect(install.classifyHostConvergence(receipt)).toEqual({
+      healthy: false,
+      state: 'host-restart-required',
+      action: 'Codex host cache has no lease API',
     });
   });
 });

--- a/tests/unit/host-convergence-lock.test.mjs
+++ b/tests/unit/host-convergence-lock.test.mjs
@@ -1,0 +1,76 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const roots = [];
+let acquireHostConvergenceLock;
+
+beforeAll(async () => {
+  process.env.RUVNET_BRAIN_IMPORT_ONLY = '1';
+  ({ acquireHostConvergenceLock } = await import('../../bin/install.mjs'));
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('host-convergence.lock publication and ownership', () => {
+  it('creates a missing parent and publishes owner metadata atomically', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'host-lock-'));
+    roots.push(root);
+    const lockPath = path.join(root, 'nested', 'brain', 'host-convergence.lock');
+    const lock = acquireHostConvergenceLock(lockPath);
+    expect(lock.acquired).toBe(true);
+    const owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+    expect(owner).toMatchObject({ pid: process.pid, host: os.hostname() });
+    expect(owner.token).toMatch(/^[a-f0-9]{32}$/);
+    expect(lock.release()).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('does not reclaim an incomplete lock during the publication window', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'host-lock-'));
+    roots.push(root);
+    const lockPath = path.join(root, 'host-convergence.lock');
+    fs.mkdirSync(lockPath);
+    const contender = acquireHostConvergenceLock(lockPath, { staleMs: Number.MAX_SAFE_INTEGER });
+    expect(contender.acquired).toBe(false);
+    expect(contender.error).toMatch(/publishing its lock/);
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it('reclaims an owner whose process is dead', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'host-lock-'));
+    roots.push(root);
+    const lockPath = path.join(root, 'host-convergence.lock');
+    fs.mkdirSync(lockPath);
+    fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: 99999999, host: os.hostname() }));
+    const lock = acquireHostConvergenceLock(lockPath, { processAlive: () => false });
+    expect(lock.acquired).toBe(true);
+    expect(lock.release()).toBe(true);
+  });
+
+  it('refuses to release a lock after ownership changes', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'host-lock-'));
+    roots.push(root);
+    const lockPath = path.join(root, 'host-convergence.lock');
+    const lock = acquireHostConvergenceLock(lockPath);
+    expect(lock.acquired).toBe(true);
+    fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: process.pid, token: 'replacement' }));
+    expect(lock.release()).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it('allows only one live owner', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'host-lock-'));
+    roots.push(root);
+    const lockPath = path.join(root, 'host-convergence.lock');
+    const first = acquireHostConvergenceLock(lockPath);
+    const second = acquireHostConvergenceLock(lockPath);
+    expect(first.acquired).toBe(true);
+    expect(second.acquired).toBe(false);
+    expect(second.error).toMatch(/is running/);
+    first.release();
+  });
+});

--- a/tests/unit/plugin-generation-prune.test.mjs
+++ b/tests/unit/plugin-generation-prune.test.mjs
@@ -248,13 +248,19 @@ describe('issue #153 — plugin generations are retained without trustworthy ses
     expect(r.cleanupBlocked.length).toBeGreaterThan(0);
   });
 
-  it('keeps legacy generations for 14 days, then collects them', () => {
+  it('keeps legacy generations after the grace period when no liveness lease exists', () => {
     const { cache, registryPath } = layout({ versions: [GEN_B, GEN_C], activeVersions: [GEN_C] });
     const old = path.join(cache, GEN_B);
     const day = 24 * 60 * 60 * 1000;
     fs.writeFileSync(path.join(old, '.orphaned_at'), '1000');
     expect(prunePluginGenerations({ registryPath, apply: true, now: () => 1000 + 14 * day - 1 }).removed).toEqual([]);
-    expect(prunePluginGenerations({ registryPath, apply: true, now: () => 1000 + 14 * day }).removed).toEqual([GEN_B]);
+    const result = prunePluginGenerations({ registryPath, apply: true, now: () => 1000 + 14 * day });
+    expect(result.removed).toEqual([]);
+    expect(result.cleanupBlocked).toEqual([{
+      version: GEN_B,
+      reason: 'legacy generation has no liveness lease; refusing destructive cleanup',
+    }]);
+    expect(fs.existsSync(old)).toBe(true);
   });
 
   it('retains everything when the registry changes at the destructive boundary', () => {

--- a/tests/unit/session-start-restart-notice.test.mjs
+++ b/tests/unit/session-start-restart-notice.test.mjs
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('SessionStart restart notice safety filter', () => {
+  it('surfaces a truthful boot-level restart notice with default filtering', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'session-restart-notice-'));
+    roots.push(root);
+    const home = path.join(root, 'home');
+    const project = path.join(root, 'project');
+    const plugin = path.join(root, 'plugin');
+    const state = path.join(home, '.cache', 'ruvnet-brain');
+    fs.mkdirSync(project, { recursive: true });
+    fs.cpSync(path.join(ROOT, 'plugin', 'scripts'), path.join(plugin, 'scripts'), { recursive: true });
+    fs.mkdirSync(path.join(plugin, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(path.join(plugin, '.claude-plugin', 'plugin.json'), JSON.stringify({ version: '4.0.2-test' }));
+    fs.mkdirSync(state, { recursive: true });
+    fs.writeFileSync(path.join(state, 'active.json'), JSON.stringify({
+      generation: 3, version: '4.2.0', codeRoot: 'versions/4.2.0',
+      shellChanged: false, shellChangedAtVersion: '4.1.0', shellChangedSinceVersion: '4.0.0',
+    }));
+    fs.writeFileSync(path.join(state, 'host-convergence.json'), JSON.stringify({
+      desiredVersion: '4.2.0', hosts: { claude: { state: 'ready', version: '4.2.0' } },
+      consoleRuntime: { state: 'ready', runtimeVersion: '4.2.0' },
+    }));
+    for (const name of ['.last-update-check', '.seed-attempted', '.auto-update-pref']) {
+      fs.writeFileSync(path.join(state, name), name === '.auto-update-pref' ? 'no' : String(Math.floor(Date.now() / 1000)));
+    }
+    const source = `
+      import { runSessionStart } from ${JSON.stringify(path.join(plugin, 'scripts', 'session-start-core.mjs'))};
+      let output = '';
+      await runSessionStart({ env: process.env, stdout: { write(v) { output += String(v); } }, stderr: process.stderr, runHeartbeat: false });
+      process.stdout.write(output);
+    `;
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', source], {
+      cwd: project,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        RUVNET_BRAIN_HOME: state,
+        CLAUDE_PLUGIN_ROOT: plugin,
+        CLAUDE_PROJECT_DIR: project,
+        RUVNET_HOOK_HOST: 'claude',
+        RUVNET_BRAIN_METER: '0',
+        RUVNET_VERBOSE_HOOKS: '0',
+      },
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('one restart picks up its boot-level declarations');
+  });
+});

--- a/tests/unit/update-shell-diff.test.mjs
+++ b/tests/unit/update-shell-diff.test.mjs
@@ -1,0 +1,83 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const ENGINE = path.join(ROOT, 'plugin', 'scripts', 'update-apply.mjs');
+const roots = [];
+let shellDiff;
+
+beforeAll(async () => {
+  process.env.RUVNET_BRAIN_IMPORT_ONLY = 'update-shell-test';
+  ({ shellDiff } = await import('../../plugin/scripts/update-apply.mjs'));
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shell-diff-'));
+  roots.push(root);
+  for (const rel of [
+    'hooks/hooks.json', 'scripts/hook-shim.mjs', 'scripts/hook-shim-bash.mjs',
+    'scripts/development-maintenance.mjs', 'mcp/server.mjs', '.mcp.json',
+    'skills/example/SKILL.md', 'commands/example.md', 'scripts/body.mjs',
+  ]) {
+    const file = path.join(root, 'a', rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `same:${rel}`);
+    const peer = path.join(root, 'b', rel);
+    fs.mkdirSync(path.dirname(peer), { recursive: true });
+    fs.writeFileSync(peer, `same:${rel}`);
+  }
+  return { root, a: path.join(root, 'a'), b: path.join(root, 'b') };
+}
+
+describe('Stable Spine shell-change detection', () => {
+  it('detects content changes in frozen imports and boot-loaded markdown', () => {
+    const f = fixture();
+    fs.writeFileSync(path.join(f.b, 'scripts', 'hook-shim-bash.mjs'), 'changed');
+    fs.writeFileSync(path.join(f.b, 'scripts', 'development-maintenance.mjs'), 'changed');
+    fs.writeFileSync(path.join(f.b, 'skills', 'example', 'SKILL.md'), 'changed');
+    fs.writeFileSync(path.join(f.b, 'commands', 'example.md'), 'changed');
+    expect(shellDiff(f.a, f.b)).toEqual(expect.arrayContaining([
+      'scripts/hook-shim-bash.mjs', 'scripts/development-maintenance.mjs', 'skills/', 'commands/',
+    ]));
+  });
+
+  it('ignores body-only changes', () => {
+    const f = fixture();
+    fs.writeFileSync(path.join(f.b, 'scripts', 'body.mjs'), 'new body');
+    expect(shellDiff(f.a, f.b)).toEqual([]);
+  });
+
+  it('retains a shell-change boundary across a later body-only generation', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'spine-shell-state-'));
+    roots.push(home);
+    const payload = (version, shell = false) => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `payload-${version}-`));
+      roots.push(dir);
+      fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'hooks'), { recursive: true });
+      fs.mkdirSync(path.join(dir, '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'scripts', 'body.mjs'), `console.log(${JSON.stringify(version)});`);
+      fs.writeFileSync(path.join(dir, 'scripts', 'hook-shim.mjs'), `console.log(${JSON.stringify(shell ? 'shell-change' : 'stable-shell')});`);
+      fs.writeFileSync(path.join(dir, 'hooks', 'hooks.json'), '{"hooks":{}}');
+      fs.writeFileSync(path.join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'ruvnet-brain', version }));
+      return dir;
+    };
+    const run = (dir) => spawnSync(process.execPath, [ENGINE, '--from-dir', dir], {
+      encoding: 'utf8', env: { ...process.env, RUVNET_BRAIN_HOME: home, RUVNET_BRAIN_IMPORT_ONLY: '' },
+    });
+    expect(run(payload('1.0.0'))).toMatchObject({ status: 0 });
+    expect(run(payload('1.1.0', true))).toMatchObject({ status: 0 });
+    expect(run(payload('1.2.0', true))).toMatchObject({ status: 0 });
+    const active = JSON.parse(fs.readFileSync(path.join(home, 'active.json'), 'utf8'));
+    expect(active.shellChanged).toBe(false);
+    expect(active.shellChangedSinceVersion).toBe('1.0.0');
+    expect(active.shellChangedAtVersion).toBe('1.1.0');
+  });
+});


### PR DESCRIPTION
Repairs issue #271 host convergence and update-in-place behavior.

- Makes convergence lock acquisition and release race-safe.
- Detects content changes in the boot-frozen shell and preserves the restart boundary across later body-only releases.
- Retains legacy generations without liveness leases instead of deleting them.
- Adds regression coverage for restart-required host receipts and truthful notices.

Validated locally: targeted 128/128, release QE 57/57, source qualification 324/324, wiring 0 UNWIRED. The candidate workflow must produce the exact-SHA stabilization receipt before promotion.